### PR TITLE
Fixing bug in MslControl.js, SynchronizedClock#getTime.

### DIFF
--- a/src/main/javascript/msg/MslControl.js
+++ b/src/main/javascript/msg/MslControl.js
@@ -183,7 +183,7 @@ var MslControl$MslChannel;
          */
         getTime: function getTime(ctx) {
             var localSeconds = ctx.getTime() / MILLISECONDS_PER_SECOND;
-            var remoteSeconds = localSeconds + offset;
+            var remoteSeconds = localSeconds + this._offset;
             return new Date(remoteSeconds * MILLISECONDS_PER_SECOND);
         },
     });


### PR DESCRIPTION
Just a small bug fix.

Now using `this._offset` property instead of undefined `offset` variable.

I noticed this problem while running the example JavaScript client.
