### PR TITLE
#20 Support alternative session crypto algorithms.

### DIFF
--- a/src/main/java/com/netflix/msl/MslConstants.java
+++ b/src/main/java/com/netflix/msl/MslConstants.java
@@ -67,6 +67,35 @@ public abstract class MslConstants {
         }
     }
     
+    /** Encryption algorithms. */
+    public static enum EncryptionAlgo {
+        /** AES */
+        AES,
+        ;
+        
+        /**
+         * @param value the string value of the encryption algorithm.
+         * @return the encryption algorithm associated with the string value.
+         * @throws IllegalArgumentException if the value is unknown.
+         */
+        public static EncryptionAlgo fromString(final String value) {
+            return EncryptionAlgo.valueOf(EncryptionAlgo.class, value);
+        }
+        
+        /**
+         * Returns the string value of this encryption algorithm. This will be
+         * equal to the Java standard algorithm name and is suitable for use
+         * with the JCE interfaces.
+         * 
+         * @return the Java standard algorithm name for this encryption
+         *         algorithm.
+         */
+        @Override
+        public String toString() {
+            return name();
+        }
+    }
+    
     /** Cipher specifications. */
     public static enum CipherSpec {
         /** AES/CBC/PKCS5Padding */
@@ -122,6 +151,8 @@ public abstract class MslConstants {
         HmacSHA256,
         /** SHA256withRSA */
         SHA256withRSA,
+        /** AESCmac. */
+        AESCmac,
         ;
         
         /**

--- a/src/main/java/com/netflix/msl/crypto/JcaAlgorithm.java
+++ b/src/main/java/com/netflix/msl/crypto/JcaAlgorithm.java
@@ -27,4 +27,6 @@ public class JcaAlgorithm {
     public static final String HMAC_SHA256 = "HmacSHA256";
     /** AES key wrap. */
     public static final String AESKW = "AES";
+    /** CMAC. */
+    public static final String AES_CMAC = "AESCmac";
 }

--- a/src/main/java/com/netflix/msl/crypto/MslSignatureEnvelope.java
+++ b/src/main/java/com/netflix/msl/crypto/MslSignatureEnvelope.java
@@ -71,6 +71,7 @@ public class MslSignatureEnvelope {
          * <tr><th>Algorithm</th><th>Description</th>
          * <tr><td>HmacSHA256</td><td>HMAC w/SHA-256</td></tr>
          * <tr><td>SHA256withRSA</td><td>RSA signature w/SHA-256</td></tr>
+         * <tr><td>AESCmac</td><td>AES CMAC</td></tr>
          * </table></p>
          */
         V2;

--- a/src/main/java/com/netflix/msl/crypto/SessionCryptoContext.java
+++ b/src/main/java/com/netflix/msl/crypto/SessionCryptoContext.java
@@ -37,7 +37,7 @@ public class SessionCryptoContext extends SymmetricCryptoContext {
      * @throws MslMasterTokenException if the master token is not trusted.
      */
     public SessionCryptoContext(final MslContext ctx, final MasterToken masterToken) throws MslMasterTokenException {
-        this(ctx, masterToken, masterToken.getIdentity(), masterToken.getEncryptionKey(), masterToken.getHmacKey());
+        this(ctx, masterToken, masterToken.getIdentity(), masterToken.getEncryptionKey(), masterToken.getSignatureKey());
         if (!masterToken.isDecrypted())
             throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
     }

--- a/src/main/javascript/crypto/CipherKey.js
+++ b/src/main/javascript/crypto/CipherKey.js
@@ -69,6 +69,7 @@ var CipherKey$import;
 
                     // The properties.
                     var props = {
+                        algorithm: { value: rawKey.algorithm, writable: false, configurable: false },
                         rawKey: { value: rawKey, writable: false, configurable: false },
                         keyData: { value: keyData, writable: false, configurable: false },
                         keyDataB64: { value: keyDataB64, writable: false, configurable: false }

--- a/src/main/javascript/crypto/MslSignatureEnvelope.js
+++ b/src/main/javascript/crypto/MslSignatureEnvelope.js
@@ -75,6 +75,7 @@ var MslSignatureEnvelope$Version;
          * <tr><th>Algorithm</th><th>Description</th>
          * <tr><td>HmacSHA256</td><td>HMAC w/SHA-256</td></tr>
          * <tr><td>SHA256withRSA</td><td>RSA signature w/SHA-256</td></tr>
+         * <tr><td>AESCmac</td><td>AES CMAC</td></tr>
          * </table></p>
          */
         V2 : 2,

--- a/src/main/javascript/crypto/SessionCryptoContext.js
+++ b/src/main/javascript/crypto/SessionCryptoContext.js
@@ -33,17 +33,17 @@ var SessionCryptoContext = SymmetricCryptoContext.extend({
      *        the identity, encryption key, and HMAC key are provided.
      * @param {string=} identity entity identity.
      * @param {CipherKey=} encryptionKey encryption key.
-     * @param {CipherKey=} hmacKey HMAC key.
+     * @param {CipherKey=} signatureKey signature key.
      * @throws MslMasterTokenException if the master token is not trusted.
      * @throws MslCryptoException if the encryption key length is unsupported.
      */
-    init: function init(ctx, masterToken, identity, encryptionKey, hmacKey) {
-        if (identity || encryptionKey || hmacKey) {
-            init.base.call(this, ctx, identity + '_' + masterToken.sequenceNumber, encryptionKey, hmacKey, null);
+    init: function init(ctx, masterToken, identity, encryptionKey, signatureKey) {
+        if (identity || encryptionKey || signatureKey) {
+            init.base.call(this, ctx, identity + '_' + masterToken.sequenceNumber, encryptionKey, signatureKey, null);
         } else {
             if (!masterToken.isDecrypted())
                 throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
-            init.base.call(this, ctx, masterToken.identity + '_' + masterToken.sequenceNumber, masterToken.encryptionKey, masterToken.hmacKey, null);
+            init.base.call(this, ctx, masterToken.identity + '_' + masterToken.sequenceNumber, masterToken.encryptionKey, masterToken.signatureKey, null);
         }
     },
 });

--- a/src/main/javascript/crypto/WebCryptoAlgorithm.js
+++ b/src/main/javascript/crypto/WebCryptoAlgorithm.js
@@ -35,6 +35,7 @@ var WebCryptoAlgorithm = {
     /** generate */
     RSASSA: { 'name': 'RSASSA-PKCS1-v1_5', 'hash': { 'name': 'SHA-1' } },
     /** sign/verify */
+    AES_CMAC: { 'name': 'AES-CMAC' },
     RSASSA_SHA256: { 'name': 'RSASSA-PKCS1-v1_5', 'hash': { 'name': 'SHA-256' } },
     RSASSA_SHA1: { 'name': 'RSASSA-PKCS1-v1_5', 'hash': { 'name': 'SHA-1' } },
     /** deriveKey */

--- a/src/test/java/com/netflix/msl/keyx/AsymmetricWrappedExchangeSuite.java
+++ b/src/test/java/com/netflix/msl/keyx/AsymmetricWrappedExchangeSuite.java
@@ -147,7 +147,7 @@ public class AsymmetricWrappedExchangeSuite {
             ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
             MASTER_TOKEN = MslTestUtils.getMasterToken(ctx, 1, 1);
             ENCRYPTION_KEY = MASTER_TOKEN.getEncryptionKey().getEncoded();
-            HMAC_KEY = MASTER_TOKEN.getHmacKey().getEncoded();
+            HMAC_KEY = MASTER_TOKEN.getSignatureKey().getEncoded();
         }
     }
     

--- a/src/test/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchangeSuite.java
+++ b/src/test/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchangeSuite.java
@@ -150,7 +150,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final SecretKey pskEncryptionKey = PSK_MASTER_TOKEN.getEncryptionKey();
             final JsonWebKey pskEncryptionJwk = new JsonWebKey(Usage.enc, Algorithm.A128CBC, false, null, pskEncryptionKey);
             PSK_ENCRYPTION_JWK = WRAP_CRYPTO_CONTEXT.wrap(pskEncryptionJwk.toJSONString().getBytes(UTF_8));
-            final SecretKey pskHmacKey = PSK_MASTER_TOKEN.getHmacKey();
+            final SecretKey pskHmacKey = PSK_MASTER_TOKEN.getSignatureKey();
             final JsonWebKey pskHmacJwk = new JsonWebKey(Usage.sig, Algorithm.HS256, false, null, pskHmacKey);
             PSK_HMAC_JWK = WRAP_CRYPTO_CONTEXT.wrap(pskHmacJwk.toJSONString().getBytes(UTF_8));
         }
@@ -699,7 +699,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test
@@ -727,7 +727,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test(expected = MslInternalException.class)
@@ -763,7 +763,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test
@@ -793,7 +793,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test(expected = MslInternalException.class)

--- a/src/test/java/com/netflix/msl/keyx/JsonWebKeyLadderExchangeSuite.java
+++ b/src/test/java/com/netflix/msl/keyx/JsonWebKeyLadderExchangeSuite.java
@@ -145,7 +145,7 @@ public class JsonWebKeyLadderExchangeSuite {
             final SecretKey pskEncryptionKey = PSK_MASTER_TOKEN.getEncryptionKey();
             final JsonWebKey pskEncryptionJwk = new JsonWebKey(Usage.enc, Algorithm.A128CBC, false, null, pskEncryptionKey);
             PSK_ENCRYPTION_JWK = WRAP_CRYPTO_CONTEXT.wrap(pskEncryptionJwk.toJSONString().getBytes(UTF_8));
-            final SecretKey pskHmacKey = PSK_MASTER_TOKEN.getHmacKey();
+            final SecretKey pskHmacKey = PSK_MASTER_TOKEN.getSignatureKey();
             final JsonWebKey pskHmacJwk = new JsonWebKey(Usage.sig, Algorithm.HS256, false, null, pskHmacKey);
             PSK_HMAC_JWK = WRAP_CRYPTO_CONTEXT.wrap(pskHmacJwk.toJSONString().getBytes(UTF_8));
         }
@@ -693,7 +693,7 @@ public class JsonWebKeyLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test
@@ -720,7 +720,7 @@ public class JsonWebKeyLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test(expected = MslInternalException.class)
@@ -755,7 +755,7 @@ public class JsonWebKeyLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test
@@ -784,7 +784,7 @@ public class JsonWebKeyLadderExchangeSuite {
             final SecretKey encryptionKey = extractJwkSecretKey(wrapCryptoContext, respdata.getEncryptionKey());
             assertArrayEquals(masterToken.getEncryptionKey().getEncoded(), encryptionKey.getEncoded());
             final SecretKey hmacKey = extractJwkSecretKey(wrapCryptoContext, respdata.getHmacKey());
-            assertArrayEquals(masterToken.getHmacKey().getEncoded(), hmacKey.getEncoded());
+            assertArrayEquals(masterToken.getSignatureKey().getEncoded(), hmacKey.getEncoded());
         }
         
         @Test(expected = MslInternalException.class)

--- a/src/test/java/com/netflix/msl/util/SimpleMslStoreTest.java
+++ b/src/test/java/com/netflix/msl/util/SimpleMslStoreTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -110,7 +109,7 @@ public class SimpleMslStoreTest {
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
         assertNull(store.getCryptoContext(masterToken));
         
-        final ICryptoContext cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.getEncryptionKey(), masterToken.getHmacKey(), null);
+        final ICryptoContext cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.getEncryptionKey(), masterToken.getSignatureKey(), null);
         store.setCryptoContext(masterToken, cc1);
         final ICryptoContext cc2 = store.getCryptoContext(masterToken);
         assertNotNull(cc2);
@@ -121,7 +120,7 @@ public class SimpleMslStoreTest {
     @Test
     public void replaceCryptoContext() throws MslEncodingException, MslCryptoException {
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
-        final ICryptoContext cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.getEncryptionKey(), masterToken.getHmacKey(), null);
+        final ICryptoContext cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.getEncryptionKey(), masterToken.getSignatureKey(), null);
         final ICryptoContext cc2 = new NullCryptoContext();
         
         store.setCryptoContext(masterToken, cc1);
@@ -150,7 +149,7 @@ public class SimpleMslStoreTest {
     @Test
     public void clearCryptoContext() throws MslEncodingException, MslCryptoException {
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
-        final ICryptoContext cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.getEncryptionKey(), masterToken.getHmacKey(), null);
+        final ICryptoContext cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.getEncryptionKey(), masterToken.getSignatureKey(), null);
         store.setCryptoContext(masterToken, cc1);
         store.clearCryptoContexts();
         assertNull(store.getCryptoContext(masterToken));

--- a/src/test/javascript/crypto/SymmetricCryptoContextTest.js
+++ b/src/test/javascript/crypto/SymmetricCryptoContextTest.js
@@ -29,6 +29,8 @@ describe("SymmetricCryptoContext", function() {
     var KEY_ID = "keyId";
     /** AES-128 CBC key. */
     var AES_128_KEY;
+    /** AES-128 CMAC key. */
+    var AES_CMAC_KEY;
     /** AES-128 symmetric crypto context. */
     var SYMMETRIC_CRYPTO_CONTEXT;
     
@@ -36,8 +38,6 @@ describe("SymmetricCryptoContext", function() {
     var random = new Random();
     /** MSL Context. */
     var ctx;
-    /** Crypto context. */
-    var cryptoContext;
     /** Plaintext data. */
     var data = new Uint8Array(128);
     random.nextBytes(data);
@@ -52,631 +52,672 @@ describe("SymmetricCryptoContext", function() {
                     result: function(k) { AES_128_KEY = k; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
+                /* TODO AES-CMAC is not supported by any browsers yet. We need to check
+                 * based on the MslCrypto$WebCryptoVersion, once it is supported.
+                CipherKey$import(aes128Bytes, WebCryptoAlgorithm.AES_CMAC, WebCryptoUsage.SIGN_VERIFY, {
+                    result: function(k) { AES_CMAC_KEY = k; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                */
+                AES_CMAC_KEY = true;
                 
                 MockMslContext$create(EntityAuthenticationScheme.PSK, false, {
                     result: function(c) { ctx = c; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
             });
-            waitsFor(function() { return AES_128_KEY && ctx; }, "static initialization", 100);
+            waitsFor(function() { return AES_128_KEY && AES_CMAC_KEY && ctx; }, "static initialization", 100);
             runs(function() {
                 SYMMETRIC_CRYPTO_CONTEXT = new SymmetricCryptoContext(ctx, KEY_ID, AES_128_KEY, null, null);
-                cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
                 initialized = true;
             });
         }
     });
     
-    it("encrypt/decrypt", function() {
-        var messageA = new Uint8Array(32);
-        random.nextBytes(messageA);
-        
-        var messageB = new Uint8Array(32);
-        random.nextBytes(messageB);
-        
-        var ciphertextA = undefined, ciphertextB;
-        runs(function() {
-        	cryptoContext.encrypt(messageA, {
-        		result: function(c) { ciphertextA = c; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        	cryptoContext.encrypt(messageB, {
-        		result: function(c) { ciphertextB = c; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        });
-        waitsFor(function() { return ciphertextA && ciphertextB; }, "ciphertext not received", 100);
-        runs(function() {
-	        expect(ciphertextA).not.toBeNull();
-	        expect(ciphertextA).not.toEqual(messageA);
-	        expect(ciphertextB).not.toBeNull();
-	        expect(ciphertextB).not.toEqual(messageB);
-	        expect(ciphertextA).not.toEqual(ciphertextB);
-        });
-        
-        var plaintextA = undefined, plaintextB;
-        runs(function() {
-        	cryptoContext.decrypt(ciphertextA, {
-        		result: function(p) { plaintextA = p; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        	cryptoContext.decrypt(ciphertextB, {
-        		result: function(p) { plaintextB = p; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        });
-        waitsFor(function() { return plaintextA && plaintextB; }, "plaintext not received", 100);
-        runs(function() {
-	        expect(plaintextA).not.toBeNull();
-	        expect(plaintextA).toEqual(messageA);
-	        expect(plaintextB).not.toBeNull();
-	        expect(plaintextB).toEqual(messageB);
-        });
-    });
+    function cryptoKeys() {
+        var params = [];
+        params.push([ 1 ]);
+        /* TODO AES-CMAC is not supported by any browsers yet. We need to check
+         * based on the MslCrypto$WebCryptoVersion, once it is supported.
+        params.push([ 2 ]);
+        */
+        return params;
+    }
 
-	it("invalid ciphertext", function() {
-    	var message = new Uint8Array(32);
-    	random.nextBytes(message);
+    parameterize("Parameterized", cryptoKeys, function(keyset) {
+        var cryptoContext;
+        beforeEach(function() {
+            if (!cryptoContext) {
+                var encryptionKey, signatureKey, wrappingKey;
+                switch (keyset) {
+                    case 1:
+                        encryptionKey = MockPresharedAuthenticationFactory.KPE;
+                        signatureKey = MockPresharedAuthenticationFactory.KPH;
+                        wrappingKey = MockPresharedAuthenticationFactory.KPW;
+                        break;
+                    case 2:
+                        encryptionKey = MockPresharedAuthenticationFactory.KPE;
+                        signatureKey = AES_CMAC_KEY;
+                        wrappingKey = MockPresharedAuthenticationFactory.KPW;
+                        break;
+                    default:
+                        throw new Error("Key set " + keyset + " is not configured.");
+                }
+                cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, encryptionKey, signatureKey, wrappingKey);
+            }
+        });
 
-    	var ciphertext;
-    	runs(function() {
-    		cryptoContext.encrypt(message, {
-    			result: function(c) { ciphertext = c; },
-    			error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-    		});
-    	});
-    	waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+        it("encrypt/decrypt", function() {
+            var messageA = new Uint8Array(32);
+            random.nextBytes(messageA);
 
-    	var envelope;
-    	runs(function() {
-            var envelopeJson = textEncoding$getString(ciphertext, MslConstants$DEFAULT_CHARSET);
-            var envelopeJo = JSON.parse(envelopeJson);
-            MslCiphertextEnvelope$parse(envelopeJo, null, {
-                result: function(e) { envelope = e; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            var messageB = new Uint8Array(32);
+            random.nextBytes(messageB);
+
+            var ciphertextA = undefined, ciphertextB;
+            runs(function() {
+                cryptoContext.encrypt(messageA, {
+                    result: function(c) { ciphertextA = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.encrypt(messageB, {
+                    result: function(c) { ciphertextB = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
             });
-    	});
-    	waitsFor(function() { return envelope; }, "envelope", 100);
-    	
-    	var shortEnvelope;
-    	runs(function() {
-    	    var ciphertext = envelope.ciphertext;
-            ++ciphertext[ciphertext.length / 2];
-            ++ciphertext[ciphertext.length - 1];
-            MslCiphertextEnvelope$create(envelope.keyId, envelope.iv, ciphertext, {
-                result: function(e) { shortEnvelope = e; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            waitsFor(function() { return ciphertextA && ciphertextB; }, "ciphertext not received", 100);
+            runs(function() {
+                expect(ciphertextA).not.toBeNull();
+                expect(ciphertextA).not.toEqual(messageA);
+                expect(ciphertextB).not.toBeNull();
+                expect(ciphertextB).not.toEqual(messageB);
+                expect(ciphertextA).not.toEqual(ciphertextB);
             });
-    	});
-    	waitsFor(function() { return shortEnvelope; }, "short envelope", 100);
-    	
-    	var exception;
-    	runs(function() {
-	    	var shortEnvelopeJson = JSON.stringify(shortEnvelope);
-	    	var shortEnvelopeData = textEncoding$getBytes(shortEnvelopeJson, MslConstants$DEFAULT_CHARSET);
-	    	cryptoContext.decrypt(shortEnvelopeData, {
-	    		result: function() {},
-	    		error: function(err) { exception = err; },
-	    	});
-    	});
-    	waitsFor(function() { return exception; }, "exception not received", 100);
 
-    	runs(function() {
-	    	var f = function() { throw exception; };
-	    	expect(f).toThrow(new MslCryptoException(MslError.DECRYPT_ERROR));
-    	});
-    });
-
-	it("insufficient ciphertext", function() {
-    	var message = new Uint8Array(32);
-    	random.nextBytes(message);
-
-    	var ciphertext;
-    	runs(function() {
-    		cryptoContext.encrypt(message, {
-    			result: function(c) { ciphertext = c; },
-    			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-    		});
-    	});
-    	waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
-    	
-    	var envelope;
-    	runs(function() {
-            var envelopeJson = textEncoding$getString(ciphertext, MslConstants$DEFAULT_CHARSET);
-            var envelopeJo = JSON.parse(envelopeJson);
-            MslCiphertextEnvelope$parse(envelopeJo, null, {
-                result: function(x) { envelope = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            var plaintextA = undefined, plaintextB;
+            runs(function() {
+                cryptoContext.decrypt(ciphertextA, {
+                    result: function(p) { plaintextA = p; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.decrypt(ciphertextB, {
+                    result: function(p) { plaintextB = p; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
             });
-    	});
-    	waitsFor(function() { return envelope; }, "envelope", 100);
-    	
-    	var shortEnvelope;
-    	runs(function() {
-            var ciphertext = envelope.ciphertext;
-            ciphertext = new Uint8Array(ciphertext.buffer, 0, ciphertext.length / 2);
-            MslCiphertextEnvelope$create(envelope.keyId, envelope.iv, ciphertext, {
-                result: function(x) { shortEnvelope = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-    	});
-    	waitsFor(function() { return shortEnvelope; }, "short envelope", 100);
-    	
-    	var exception;
-    	runs(function() {
-	    	var shortEnvelopeJson = JSON.stringify(shortEnvelope);
-	    	var shortEnvelopeData = textEncoding$getBytes(shortEnvelopeJson, MslConstants$DEFAULT_CHARSET);
-	    	cryptoContext.decrypt(shortEnvelopeData, {
-	    		result: function() {},
-	    		error: function(err) { exception = err; }
-	    	});
-    	});
-    	waitsFor(function() { return exception; }, "exception not received", 100);
-    	
-    	runs(function() {
-	    	var f = function() { throw exception; };
-	    	expect(f).toThrow(new MslCryptoException(MslError.DECRYPT_ERROR));
-    	});
-    });
-
-    it("not envelope", function() {
-    	var message = new Uint8Array(32);
-    	random.nextBytes(message);
-
-    	var ciphertext;
-    	runs(function() {
-    		cryptoContext.encrypt(message, {
-    			result: function(c) { ciphertext = c; },
-    			error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-    		});
-    	});
-    	waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
-    	
-    	var exception;
-    	runs(function() {
-	    	var envelopeJson = textEncoding$getString(ciphertext, MslConstants$DEFAULT_CHARSET);
-	    	var envelopeJo = JSON.parse(envelopeJson);
-	    	delete envelopeJo[KEY_CIPHERTEXT];
-	    	var badJson = JSON.stringify(envelopeJo);
-	    	var badData = textEncoding$getBytes(badJson, MslConstants$DEFAULT_CHARSET);
-	    	cryptoContext.decrypt(badData, {
-	    		result: function() {},
-	    		error: function(err) { exception = err; },
-	    	});
-    	});
-
-    	runs(function() {
-	    	var f = function() { throw exception; };
-	    	expect(f).toThrow(new MslCryptoException(MslError.CIPHERTEXT_ENVELOPE_ENCODE_ERROR));
-    	});
-    });
-
-    it("corrupt envelope", function() {
-    	var message = new Uint8Array(32);
-    	random.nextBytes(message);
-
-    	var ciphertext;
-    	runs(function() {
-    		cryptoContext.encrypt(message, {
-    			result: function(c) { ciphertext = c; },
-    			error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-    		});
-    	});
-    	waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
-    	
-    	var exception;
-    	runs(function() {
-	    	ciphertext[0] = 0;
-	    	cryptoContext.decrypt(ciphertext, {
-	    		result: function() {},
-	    		error: function(err) { exception = err; }
-	    	});
-    	});
-
-    	runs(function() {
-	    	var f = function() { throw exception; };
-	    	expect(f).toThrow(new MslCryptoException(MslError.CIPHERTEXT_ENVELOPE_PARSE_ERROR));
-    	});
-    });
-
-    it("encrypt/decrypt with null encryption key", function() {
-    	var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, null, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPE_WRAP);
-	        
-    	var message = new Uint8Array(32);
-    	random.nextBytes(message);
-
-    	var exception;
-    	runs(function() {
-    		cryptoContext.encrypt(message, {
-    			result: function() {},
-    			error: function(err) { exception = err; },
-    		});
-    	});
-
-    	runs(function() {
-	    	var f = function() { throw exception; };
-	    	expect(f).toThrow(new MslCryptoException(MslError.ENCRYPT_NOT_SUPPORTED));
-    	});
-    });
-    
-    it("encrypt/decrypt with null keys", function() {
-        var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, null, null);
-        
-        var messageA = new Uint8Array(32);
-        random.nextBytes(messageA);
-        
-        var messageB = new Uint8Array(32);
-        random.nextBytes(messageB);
-        
-        var ciphertextA = undefined, ciphertextB;
-        runs(function() {
-        	cryptoContext.encrypt(messageA, {
-        		result: function(c) { ciphertextA = c; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        	cryptoContext.encrypt(messageB, {
-        		result: function(c) { ciphertextB = c; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        });
-        waitsFor(function() { return ciphertextA && ciphertextB; }, "ciphertext not received", 100);
-        runs(function() {
-	        expect(ciphertextA).not.toBeNull();
-	        expect(ciphertextA).not.toEqual(messageA);
-	        expect(ciphertextB).not.toBeNull();
-	        expect(ciphertextB).not.toEqual(messageB);
-	        expect(ciphertextA).not.toEqual(ciphertextB);
-        });
-        
-        var plaintextA = undefined, plaintextB;
-        runs(function() {
-        	cryptoContext.decrypt(ciphertextA, {
-        		result: function(p) { plaintextA = p; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        	cryptoContext.decrypt(ciphertextB, {
-        		result: function(p) { plaintextB = p; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        });
-        waitsFor(function() { return plaintextA && plaintextB; }, "plaintext not received", 100);
-        runs(function() {
-	        expect(plaintextA).not.toBeNull();
-	        expect(plaintextA).toEqual(messageA);
-	        expect(plaintextB).not.toBeNull();
-	        expect(plaintextB).toEqual(messageB);
-        });
-    });
-    
-    it("encrypt/decrypt with mismatched ID", function() {
-    	var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID + "A", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
-        var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID + "B", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
-
-        var message = new Uint8Array(32);
-        random.nextBytes(message);
-        
-        var ciphertext;
-        runs(function() {
-        	cryptoContextA.encrypt(message, {
-        		result: function(c) { ciphertext = c; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        });
-        waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
-        
-        var exception;
-        runs(function() {
-        	cryptoContextB.decrypt(ciphertext, {
-        		result: function() {},
-        		error: function(err) { exception = err; },
-        	});
-        });
-        waitsFor(function() { return exception; }, "exception not received", 100);
-        
-        runs(function() {
-        	var f = function() { throw exception; };
-        	expect(f).toThrow(new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH));
-        });
-    });
-
-    it("encrypt/decrypt keys mismatched", function() {
-        var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
-        var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE2, MockPresharedAuthenticationFactory.KPH2, MockPresharedAuthenticationFactory.KPW2);
-        
-        var message = new Uint8Array(32);
-        random.nextBytes(message);
-        
-        var ciphertext;
-        runs(function() {
-        	cryptoContextA.encrypt(message, {
-        		result: function(c) { ciphertext = c; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        });
-        waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
-        
-        var exception;
-        runs(function() {
-        	cryptoContextB.decrypt(ciphertext, {
-        		result: function() {},
-        		error: function(err) { exception = err; },
-        	});
-        });
-        waitsFor(function() { return exception; }, "exception not received", 200);
-        
-        runs(function() {
-	        var f = function() { throw exception; };
-	        expect(f).toThrow(new MslCryptoException(MslError.DECRYPT_ERROR));
-        });
-    });
-    
-    it("wrap/unwrap", function() {
-        var wrapped;
-        runs(function() {
-            cryptoContext.wrap(AES_128_KEY, {
-                result: function(data) { wrapped = data; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            waitsFor(function() { return plaintextA && plaintextB; }, "plaintext not received", 100);
+            runs(function() {
+                expect(plaintextA).not.toBeNull();
+                expect(plaintextA).toEqual(messageA);
+                expect(plaintextB).not.toBeNull();
+                expect(plaintextB).toEqual(messageB);
             });
         });
-        waitsFor(function() { return wrapped; }, "wrapped not received", 100);
-        
-        var unwrapped;
-        runs(function() {
-            expect(wrapped).not.toBeNull();
-            expect(wrapped).not.toEqual(AES_128_KEY.toByteArray());
-            cryptoContext.unwrap(wrapped, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
-                result: function(key) { unwrapped = key; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return unwrapped; }, "unwrapped not received", 100);
-        
-        // We must verify the unwrapped key by performing a crypto
-        // operation as the wrapped key is not exportable.
-        var wrapCryptoContext, refCiphertext, wrapCiphertext;
-        runs(function() {
-            wrapCryptoContext = new SymmetricCryptoContext(ctx, KEY_ID, unwrapped, null, null);
-            SYMMETRIC_CRYPTO_CONTEXT.encrypt(data, {
-                result: function(x) { refCiphertext = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-            wrapCryptoContext.encrypt(data, {
-                result: function(x) { wrapCiphertext = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return refCiphertext && wrapCiphertext; }, "ciphertexts", 100);
-        var refPlaintext, wrapPlaintext;
-        runs(function() {
-            SYMMETRIC_CRYPTO_CONTEXT.decrypt(wrapCiphertext, {
-                result: function(x) { refPlaintext = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-            wrapCryptoContext.decrypt(refCiphertext, {
-                result: function(x) { wrapPlaintext = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return refPlaintext && wrapPlaintext; }, "plaintexts", 100);
-        runs(function() {
-            expect(wrapPlaintext).toEqual(refPlaintext);
-        });
-    });
-    
-    it("wrap/unwrap with mismatched contexts", function() {
-        var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
-        var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE2, MockPresharedAuthenticationFactory.KPH2, MockPresharedAuthenticationFactory.KPW2);
-        
-        var wrapped;
-        runs(function() {
-            cryptoContextA.wrap(AES_128_KEY, {
-                result: function(data) { wrapped = data; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return wrapped; }, "wrapped not received", 100);
-        
-        var exception;
-        runs(function() {
-            expect(wrapped).not.toBeNull();
-            expect(wrapped).not.toEqual(AES_128_KEY.toByteArray());
-            cryptoContextB.unwrap(wrapped, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
-                result: function() {},
-                error: function(e) { exception = e; }
-            });
-        });
-        waitsFor(function() { return exception; }, "exception", 100);
-        runs(function() {
-            var f = function() { throw exception; };
-            expect(f).toThrow(new MslCryptoException(MslError.UNWRAP_ERROR));
-        });
-    });
-    
-    it("wrap with null wrap key", function() {
-        var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, null);
-        
-        var exception;
-        runs(function() {
-            cryptoContext.wrap(AES_128_KEY, {
-                result: function() {},
-                error: function(e) { exception = e; }
-            });
-        });
-        waitsFor(function() { return exception; }, "exception", 100);
-        runs(function() {
-            var f = function() { throw exception; };
-            expect(f).toThrow(new MslCryptoException(MslError.WRAP_NOT_SUPPORTED));
-        });
-    });
-    
-    it("unwrap with null wrap key", function() {
-        var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, null);
-        
-        var exception;
-        runs(function() {
-            cryptoContext.unwrap(AES_128_KEY, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
-                result: function() {},
-                error: function(e) { exception = e; }
-            });
-        });
-        waitsFor(function() { return exception; }, "exception", 100);
-        runs(function() {
-            var f = function() { throw exception; };
-            expect(f).toThrow(new MslCryptoException(MslError.UNWRAP_NOT_SUPPORTED));
-        });
-    });
 
-    it("sign/verify", function() {
-        var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
-        
-        var messageA = new Uint8Array(32);
-        random.nextBytes(messageA);
-        
-        var messageB = new Uint8Array(32);
-        random.nextBytes(messageB);
-        
-        var signatureA = undefined, signatureB;
-        runs(function() {
-        	cryptoContext.sign(messageA, {
-        		result: function(s) { signatureA = s; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-            cryptoContext.sign(messageB, {
-            	result: function(s) { signatureB = s; },
-            	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+        it("invalid ciphertext", function() {
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var ciphertext;
+            runs(function() {
+                cryptoContext.encrypt(message, {
+                    result: function(c) { ciphertext = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
             });
-        });
-        waitsFor(function() { return signatureA && signatureB; }, "signature not received", 100);
-        runs(function() {
-	        expect(signatureA).not.toBeNull();
-	        expect(signatureA.length).toBeGreaterThan(0);
-	        expect(signatureA).not.toEqual(messageA);
-	        expect(signatureB.length).toBeGreaterThan(0);
-	        expect(signatureB).not.toEqual(signatureA);
-        });
-        
-        var verifiedAA = undefined, verifiedBB = undefined, verifiedBA;
-        runs(function() {
-        	cryptoContext.verify(messageA, signatureA, {
-        		result: function(v) { verifiedAA = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        	cryptoContext.verify(messageB, signatureB, {
-        		result: function(v) { verifiedBB = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        	cryptoContext.verify(messageB, signatureA, {
-        		result: function(v) { verifiedBA = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        });
-        waitsFor(function() { return verifiedAA !== undefined && verifiedBB !== undefined && verifiedBA !== undefined; }, "verified not received", 100);
-        runs(function() {
-	        expect(verifiedAA).toBeTruthy();
-	        expect(verifiedBB).toBeTruthy();
-	        expect(verifiedBA).toBeFalsy();
-        });
-    });
-    
-    it("sign/verify with mismatched contexts", function() {
-        var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
-        var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE2, MockPresharedAuthenticationFactory.KPH2, MockPresharedAuthenticationFactory.KPW2);
-        
-        var message = new Uint8Array(32);
-        random.nextBytes(message);
-        
-        var signature;
-        runs(function() {
-        	cryptoContextA.sign(message, {
-        		result: function(s) { signature = s; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        });
-        waitsFor(function() { return signature; }, "signature not received", 100);
-        
-        var verified;
-        runs(function() {
-        	cryptoContextB.verify(message, signature, {
-        		result: function(v) { verified = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        });
-        waitsFor(function() { return verified !== undefined; }, "verified not received", 100);
-        runs(function() {
-        	expect(verified).toBeFalsy();
-        });
-    });
-    
-    it("sign/verify with null keys", function() {
-        var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, null, MockPresharedAuthenticationFactory.KPH, null);
-        
-        var messageA = new Uint8Array(32);
-        random.nextBytes(messageA);
-        
-        var messageB = new Uint8Array(32);
-        random.nextBytes(messageB);
-        
-        var signatureA = undefined, signatureB;
-        runs(function() {
-        	cryptoContext.sign(messageA, {
-        		result: function(s) { signatureA = s; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        	cryptoContext.sign(messageB, {
-        		result: function(s) { signatureB = s; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        });
-        waitsFor(function() { return signatureA && signatureB; }, "signature not received", 100);
-        runs(function() {
-	        expect(signatureA).not.toBeNull();
-	        expect(signatureA.length).toBeGreaterThan(0);
-	        expect(signatureA).not.toEqual(messageA);
-	        expect(signatureB.length).toBeGreaterThan(0);
-	        expect(signatureB).not.toEqual(signatureA);
+            waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+
+            var envelope;
+            runs(function() {
+                var envelopeJson = textEncoding$getString(ciphertext, MslConstants$DEFAULT_CHARSET);
+                var envelopeJo = JSON.parse(envelopeJson);
+                MslCiphertextEnvelope$parse(envelopeJo, null, {
+                    result: function(e) { envelope = e; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return envelope; }, "envelope", 100);
+
+            var shortEnvelope;
+            runs(function() {
+                var ciphertext = envelope.ciphertext;
+                ++ciphertext[ciphertext.length / 2];
+                ++ciphertext[ciphertext.length - 1];
+                MslCiphertextEnvelope$create(envelope.keyId, envelope.iv, ciphertext, {
+                    result: function(e) { shortEnvelope = e; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return shortEnvelope; }, "short envelope", 100);
+
+            var exception;
+            runs(function() {
+                var shortEnvelopeJson = JSON.stringify(shortEnvelope);
+                var shortEnvelopeData = textEncoding$getBytes(shortEnvelopeJson, MslConstants$DEFAULT_CHARSET);
+                cryptoContext.decrypt(shortEnvelopeData, {
+                    result: function() {},
+                    error: function(err) { exception = err; },
+                });
+            });
+            waitsFor(function() { return exception; }, "exception not received", 100);
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.DECRYPT_ERROR));
+            });
         });
 
-        var verifiedAA = undefined, verifiedBB = undefined, verifiedBA;
-        runs(function() {
-        	cryptoContext.verify(messageA, signatureA, {
-        		result: function(v) { verifiedAA = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-        	});
-        	cryptoContext.verify(messageB, signatureB, {
-        		result: function(v) { verifiedBB = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        	cryptoContext.verify(messageB, signatureA, {
-        		result: function(v) { verifiedBA = v; },
-        		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-        	});
-        });
-        waitsFor(function() { return verifiedAA !== undefined && verifiedBB !== undefined && verifiedBA !== undefined; }, "verified not received", 100);
-        runs(function() {
-	        expect(verifiedAA).toBeTruthy();
-	        expect(verifiedBB).toBeTruthy();
-	        expect(verifiedBA).toBeFalsy();
-        });
-    });
-    
-    it("sign with null HMAC key", function() {
-    	var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, null, MockPresharedAuthenticationFactory.KPW);
+        it("insufficient ciphertext", function() {
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
 
-    	var messageA = new Uint8Array(32);
-    	random.nextBytes(messageA);
-    	
-    	var exception;
-    	runs(function() {
-    		cryptoContext.sign(messageA, {
-    			result: function() {},
-    			error: function(err) { exception = err; },
-    		});
-    	});
-    	waitsFor(function() { return exception; }, "exception not received", 100);
-    	
-    	runs(function() {
-    		var f = function() { throw exception; };
-    		expect(f).toThrow(new MslCryptoException(MslError.SIGN_NOT_SUPPORTED));
-    	});
+            var ciphertext;
+            runs(function() {
+                cryptoContext.encrypt(message, {
+                    result: function(c) { ciphertext = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+
+            var envelope;
+            runs(function() {
+                var envelopeJson = textEncoding$getString(ciphertext, MslConstants$DEFAULT_CHARSET);
+                var envelopeJo = JSON.parse(envelopeJson);
+                MslCiphertextEnvelope$parse(envelopeJo, null, {
+                    result: function(x) { envelope = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return envelope; }, "envelope", 100);
+
+            var shortEnvelope;
+            runs(function() {
+                var ciphertext = envelope.ciphertext;
+                ciphertext = new Uint8Array(ciphertext.buffer, 0, ciphertext.length / 2);
+                MslCiphertextEnvelope$create(envelope.keyId, envelope.iv, ciphertext, {
+                    result: function(x) { shortEnvelope = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return shortEnvelope; }, "short envelope", 100);
+
+            var exception;
+            runs(function() {
+                var shortEnvelopeJson = JSON.stringify(shortEnvelope);
+                var shortEnvelopeData = textEncoding$getBytes(shortEnvelopeJson, MslConstants$DEFAULT_CHARSET);
+                cryptoContext.decrypt(shortEnvelopeData, {
+                    result: function() {},
+                    error: function(err) { exception = err; }
+                });
+            });
+            waitsFor(function() { return exception; }, "exception not received", 100);
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.DECRYPT_ERROR));
+            });
+        });
+
+        it("not envelope", function() {
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var ciphertext;
+            runs(function() {
+                cryptoContext.encrypt(message, {
+                    result: function(c) { ciphertext = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+
+            var exception;
+            runs(function() {
+                var envelopeJson = textEncoding$getString(ciphertext, MslConstants$DEFAULT_CHARSET);
+                var envelopeJo = JSON.parse(envelopeJson);
+                delete envelopeJo[KEY_CIPHERTEXT];
+                var badJson = JSON.stringify(envelopeJo);
+                var badData = textEncoding$getBytes(badJson, MslConstants$DEFAULT_CHARSET);
+                cryptoContext.decrypt(badData, {
+                    result: function() {},
+                    error: function(err) { exception = err; },
+                });
+            });
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.CIPHERTEXT_ENVELOPE_ENCODE_ERROR));
+            });
+        });
+
+        it("corrupt envelope", function() {
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var ciphertext;
+            runs(function() {
+                cryptoContext.encrypt(message, {
+                    result: function(c) { ciphertext = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+
+            var exception;
+            runs(function() {
+                ciphertext[0] = 0;
+                cryptoContext.decrypt(ciphertext, {
+                    result: function() {},
+                    error: function(err) { exception = err; }
+                });
+            });
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.CIPHERTEXT_ENVELOPE_PARSE_ERROR));
+            });
+        });
+
+        it("encrypt/decrypt with null encryption key", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, null, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPE_WRAP);
+
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var exception;
+            runs(function() {
+                cryptoContext.encrypt(message, {
+                    result: function() {},
+                    error: function(err) { exception = err; },
+                });
+            });
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.ENCRYPT_NOT_SUPPORTED));
+            });
+        });
+
+        it("encrypt/decrypt with null keys", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, null, null);
+
+            var messageA = new Uint8Array(32);
+            random.nextBytes(messageA);
+
+            var messageB = new Uint8Array(32);
+            random.nextBytes(messageB);
+
+            var ciphertextA = undefined, ciphertextB;
+            runs(function() {
+                cryptoContext.encrypt(messageA, {
+                    result: function(c) { ciphertextA = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.encrypt(messageB, {
+                    result: function(c) { ciphertextB = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return ciphertextA && ciphertextB; }, "ciphertext not received", 100);
+            runs(function() {
+                expect(ciphertextA).not.toBeNull();
+                expect(ciphertextA).not.toEqual(messageA);
+                expect(ciphertextB).not.toBeNull();
+                expect(ciphertextB).not.toEqual(messageB);
+                expect(ciphertextA).not.toEqual(ciphertextB);
+            });
+
+            var plaintextA = undefined, plaintextB;
+            runs(function() {
+                cryptoContext.decrypt(ciphertextA, {
+                    result: function(p) { plaintextA = p; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                cryptoContext.decrypt(ciphertextB, {
+                    result: function(p) { plaintextB = p; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return plaintextA && plaintextB; }, "plaintext not received", 100);
+            runs(function() {
+                expect(plaintextA).not.toBeNull();
+                expect(plaintextA).toEqual(messageA);
+                expect(plaintextB).not.toBeNull();
+                expect(plaintextB).toEqual(messageB);
+            });
+        });
+
+        it("encrypt/decrypt with mismatched ID", function() {
+            var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID + "A", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+            var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID + "B", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var ciphertext;
+            runs(function() {
+                cryptoContextA.encrypt(message, {
+                    result: function(c) { ciphertext = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+
+            var exception;
+            runs(function() {
+                cryptoContextB.decrypt(ciphertext, {
+                    result: function() {},
+                    error: function(err) { exception = err; },
+                });
+            });
+            waitsFor(function() { return exception; }, "exception not received", 100);
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH));
+            });
+        });
+
+        it("encrypt/decrypt keys mismatched", function() {
+            var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+            var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE2, MockPresharedAuthenticationFactory.KPH2, MockPresharedAuthenticationFactory.KPW2);
+
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var ciphertext;
+            runs(function() {
+                cryptoContextA.encrypt(message, {
+                    result: function(c) { ciphertext = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
+
+            var exception;
+            runs(function() {
+                cryptoContextB.decrypt(ciphertext, {
+                    result: function() {},
+                    error: function(err) { exception = err; },
+                });
+            });
+            waitsFor(function() { return exception; }, "exception not received", 200);
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.DECRYPT_ERROR));
+            });
+        });
+
+        it("wrap/unwrap", function() {
+            var wrapped;
+            runs(function() {
+                cryptoContext.wrap(AES_128_KEY, {
+                    result: function(data) { wrapped = data; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return wrapped; }, "wrapped not received", 100);
+
+            var unwrapped;
+            runs(function() {
+                expect(wrapped).not.toBeNull();
+                expect(wrapped).not.toEqual(AES_128_KEY.toByteArray());
+                cryptoContext.unwrap(wrapped, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
+                    result: function(key) { unwrapped = key; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return unwrapped; }, "unwrapped not received", 100);
+
+            // We must verify the unwrapped key by performing a crypto
+            // operation as the wrapped key is not exportable.
+            var wrapCryptoContext, refCiphertext, wrapCiphertext;
+            runs(function() {
+                wrapCryptoContext = new SymmetricCryptoContext(ctx, KEY_ID, unwrapped, null, null);
+                SYMMETRIC_CRYPTO_CONTEXT.encrypt(data, {
+                    result: function(x) { refCiphertext = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                wrapCryptoContext.encrypt(data, {
+                    result: function(x) { wrapCiphertext = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return refCiphertext && wrapCiphertext; }, "ciphertexts", 100);
+            var refPlaintext, wrapPlaintext;
+            runs(function() {
+                SYMMETRIC_CRYPTO_CONTEXT.decrypt(wrapCiphertext, {
+                    result: function(x) { refPlaintext = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                wrapCryptoContext.decrypt(refCiphertext, {
+                    result: function(x) { wrapPlaintext = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return refPlaintext && wrapPlaintext; }, "plaintexts", 100);
+            runs(function() {
+                expect(wrapPlaintext).toEqual(refPlaintext);
+            });
+        });
+
+        it("wrap/unwrap with mismatched contexts", function() {
+            var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+            var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE2, MockPresharedAuthenticationFactory.KPH2, MockPresharedAuthenticationFactory.KPW2);
+
+            var wrapped;
+            runs(function() {
+                cryptoContextA.wrap(AES_128_KEY, {
+                    result: function(data) { wrapped = data; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return wrapped; }, "wrapped not received", 100);
+
+            var exception;
+            runs(function() {
+                expect(wrapped).not.toBeNull();
+                expect(wrapped).not.toEqual(AES_128_KEY.toByteArray());
+                cryptoContextB.unwrap(wrapped, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
+                    result: function() {},
+                    error: function(e) { exception = e; }
+                });
+            });
+            waitsFor(function() { return exception; }, "exception", 100);
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.UNWRAP_ERROR));
+            });
+        });
+
+        it("wrap with null wrap key", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, null);
+
+            var exception;
+            runs(function() {
+                cryptoContext.wrap(AES_128_KEY, {
+                    result: function() {},
+                    error: function(e) { exception = e; }
+                });
+            });
+            waitsFor(function() { return exception; }, "exception", 100);
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.WRAP_NOT_SUPPORTED));
+            });
+        });
+
+        it("unwrap with null wrap key", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, null);
+
+            var exception;
+            runs(function() {
+                cryptoContext.unwrap(AES_128_KEY, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
+                    result: function() {},
+                    error: function(e) { exception = e; }
+                });
+            });
+            waitsFor(function() { return exception; }, "exception", 100);
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.UNWRAP_NOT_SUPPORTED));
+            });
+        });
+
+        it("sign/verify", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+
+            var messageA = new Uint8Array(32);
+            random.nextBytes(messageA);
+
+            var messageB = new Uint8Array(32);
+            random.nextBytes(messageB);
+
+            var signatureA = undefined, signatureB;
+            runs(function() {
+                cryptoContext.sign(messageA, {
+                    result: function(s) { signatureA = s; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.sign(messageB, {
+                    result: function(s) { signatureB = s; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return signatureA && signatureB; }, "signature not received", 100);
+            runs(function() {
+                expect(signatureA).not.toBeNull();
+                expect(signatureA.length).toBeGreaterThan(0);
+                expect(signatureA).not.toEqual(messageA);
+                expect(signatureB.length).toBeGreaterThan(0);
+                expect(signatureB).not.toEqual(signatureA);
+            });
+
+            var verifiedAA = undefined, verifiedBB = undefined, verifiedBA;
+            runs(function() {
+                cryptoContext.verify(messageA, signatureA, {
+                    result: function(v) { verifiedAA = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.verify(messageB, signatureB, {
+                    result: function(v) { verifiedBB = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                cryptoContext.verify(messageB, signatureA, {
+                    result: function(v) { verifiedBA = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return verifiedAA !== undefined && verifiedBB !== undefined && verifiedBA !== undefined; }, "verified not received", 100);
+            runs(function() {
+                expect(verifiedAA).toBeTruthy();
+                expect(verifiedBB).toBeTruthy();
+                expect(verifiedBA).toBeFalsy();
+            });
+        });
+
+        it("sign/verify with mismatched contexts", function() {
+            var cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+            var cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE2, MockPresharedAuthenticationFactory.KPH2, MockPresharedAuthenticationFactory.KPW2);
+
+            var message = new Uint8Array(32);
+            random.nextBytes(message);
+
+            var signature;
+            runs(function() {
+                cryptoContextA.sign(message, {
+                    result: function(s) { signature = s; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return signature; }, "signature not received", 100);
+
+            var verified;
+            runs(function() {
+                cryptoContextB.verify(message, signature, {
+                    result: function(v) { verified = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return verified !== undefined; }, "verified not received", 100);
+            runs(function() {
+                expect(verified).toBeFalsy();
+            });
+        });
+
+        it("sign/verify with null keys", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, null, MockPresharedAuthenticationFactory.KPH, null);
+
+            var messageA = new Uint8Array(32);
+            random.nextBytes(messageA);
+
+            var messageB = new Uint8Array(32);
+            random.nextBytes(messageB);
+
+            var signatureA = undefined, signatureB;
+            runs(function() {
+                cryptoContext.sign(messageA, {
+                    result: function(s) { signatureA = s; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.sign(messageB, {
+                    result: function(s) { signatureB = s; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return signatureA && signatureB; }, "signature not received", 100);
+            runs(function() {
+                expect(signatureA).not.toBeNull();
+                expect(signatureA.length).toBeGreaterThan(0);
+                expect(signatureA).not.toEqual(messageA);
+                expect(signatureB.length).toBeGreaterThan(0);
+                expect(signatureB).not.toEqual(signatureA);
+            });
+
+            var verifiedAA = undefined, verifiedBB = undefined, verifiedBA;
+            runs(function() {
+                cryptoContext.verify(messageA, signatureA, {
+                    result: function(v) { verifiedAA = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+                cryptoContext.verify(messageB, signatureB, {
+                    result: function(v) { verifiedBB = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                cryptoContext.verify(messageB, signatureA, {
+                    result: function(v) { verifiedBA = v; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return verifiedAA !== undefined && verifiedBB !== undefined && verifiedBA !== undefined; }, "verified not received", 100);
+            runs(function() {
+                expect(verifiedAA).toBeTruthy();
+                expect(verifiedBB).toBeTruthy();
+                expect(verifiedBA).toBeFalsy();
+            });
+        });
+
+        it("sign with null HMAC key", function() {
+            var cryptoContext = new SymmetricCryptoContext(ctx, KEYSET_ID, MockPresharedAuthenticationFactory.KPE, null, MockPresharedAuthenticationFactory.KPW);
+
+            var messageA = new Uint8Array(32);
+            random.nextBytes(messageA);
+
+            var exception;
+            runs(function() {
+                cryptoContext.sign(messageA, {
+                    result: function() {},
+                    error: function(err) { exception = err; },
+                });
+            });
+            waitsFor(function() { return exception; }, "exception not received", 100);
+
+            runs(function() {
+                var f = function() { throw exception; };
+                expect(f).toThrow(new MslCryptoException(MslError.SIGN_NOT_SUPPORTED));
+            });
+        });
     });
 });

--- a/src/test/javascript/keyx/AsymmetricWrappedExchangeSuite.js
+++ b/src/test/javascript/keyx/AsymmetricWrappedExchangeSuite.js
@@ -131,7 +131,7 @@ describe("AsymmetricWrappedExchangeSuite", function() {
     				result: function(masterToken) {
     					MASTER_TOKEN = masterToken;
     					ENCRYPTION_KEY = MASTER_TOKEN.encryptionKey.toByteArray();
-    					HMAC_KEY = MASTER_TOKEN.hmacKey.toByteArray();
+    					HMAC_KEY = MASTER_TOKEN.signatureKey.toByteArray();
     				},
     				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     			});

--- a/src/test/javascript/keyx/JsonWebEncryptionLadderExchangeSuite.js
+++ b/src/test/javascript/keyx/JsonWebEncryptionLadderExchangeSuite.js
@@ -117,7 +117,7 @@ if (MslCrypto$getWebCryptoVersion() == MslCrypto$WebCryptoVersion.LEGACY) {
                     result: function(x) { PSK_ENCRYPTION_JWK = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
-                var pskHmacKey = PSK_MASTER_TOKEN.hmacKey;
+                var pskHmacKey = PSK_MASTER_TOKEN.signatureKey;
                 WRAP_CRYPTO_CONTEXT.wrap(pskHmacKey, {
                     result: function(x) { PSK_HMAC_JWK = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
@@ -767,7 +767,7 @@ if (MslCrypto$getWebCryptoVersion() == MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },
@@ -868,7 +868,7 @@ if (MslCrypto$getWebCryptoVersion() == MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },
@@ -986,7 +986,7 @@ if (MslCrypto$getWebCryptoVersion() == MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },
@@ -1089,7 +1089,7 @@ if (MslCrypto$getWebCryptoVersion() == MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },

--- a/src/test/javascript/keyx/JsonWebKeyLadderExchangeSuite.js
+++ b/src/test/javascript/keyx/JsonWebKeyLadderExchangeSuite.js
@@ -123,7 +123,7 @@ if (mslCrypto$version != MslCrypto$WebCryptoVersion.LEGACY) {
                     result: function(x) { PSK_ENCRYPTION_JWK = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
-                var pskHmacKey = PSK_MASTER_TOKEN.hmacKey;
+                var pskHmacKey = PSK_MASTER_Token.signatureKey;
                 WRAP_CRYPTO_CONTEXT.wrap(pskHmacKey, {
                     result: function(x) { PSK_HMAC_JWK = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
@@ -773,7 +773,7 @@ if (mslCrypto$version != MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },
@@ -874,7 +874,7 @@ if (mslCrypto$version != MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },
@@ -992,7 +992,7 @@ if (mslCrypto$version != MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },
@@ -1095,7 +1095,7 @@ if (mslCrypto$version != MslCrypto$WebCryptoVersion.LEGACY) {
             // operation as the wrapped key is not exportable.
             var refCryptoContext, wrapCryptoContext, refCiphertext, wrapCiphertext, refHmac, wrapHmac;
             runs(function() {
-                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+                refCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
                 wrapCryptoContext = new SymmetricCryptoContext(pskCtx, KEY_ID, encryptionKey, hmacKey, null);
                 refCryptoContext.encrypt(data, {
                     result: function(x) { refCiphertext = x; },

--- a/src/test/javascript/tokens/MasterTokenTest.js
+++ b/src/test/javascript/tokens/MasterTokenTest.js
@@ -47,8 +47,14 @@ describe("MasterToken", function() {
     var KEY_IDENTITY = "identity";
     /** JSON key symmetric encryption key. */
     var KEY_ENCRYPTION_KEY = "encryptionkey";
+    /** JSON key encryption algorithm. */
+    var KEY_ENCRYPTION_ALGORITHM = "encryptionalgorithm";
     /** JSON key symmetric HMAC key. */
     var KEY_HMAC_KEY = "hmackey";
+    /** JSON key signature key. */
+    var KEY_SIGNATURE_KEY = "signaturekey";
+    /** JSON key signature algorithm. */
+    var KEY_SIGNATURE_ALGORITHM = "signaturealgorithm";
     
     var RENEWAL_WINDOW = new Date(Date.now() + 120000);
     var EXPIRATION = new Date(Date.now() + 180000);
@@ -56,7 +62,7 @@ describe("MasterToken", function() {
     var SERIAL_NUMBER = 42;
     var IDENTITY = MockPresharedAuthenticationFactory.PSK_ESN;
     var ENCRYPTION_KEY;
-    var HMAC_KEY;
+    var SIGNATURE_KEY;
     
     var ISSUER_DATA = { "issuerid": 17 };
     
@@ -76,9 +82,9 @@ describe("MasterToken", function() {
             runs(function() {
                 // These keys won't exist until after the factory is instantiated.
                 ENCRYPTION_KEY = MockPresharedAuthenticationFactory.KPE;
-                HMAC_KEY = MockPresharedAuthenticationFactory.KPH;
+                SIGNATURE_KEY = MockPresharedAuthenticationFactory.KPH;
             });
-            waitsFor(function() { return ENCRYPTION_KEY && HMAC_KEY; }, "keys", 500);
+            waitsFor(function() { return ENCRYPTION_KEY && SIGNATURE_KEY; }, "keys", 500);
             runs(function() { initialized = true; });
         }
     });
@@ -98,7 +104,7 @@ describe("MasterToken", function() {
     it("ctors", function() {
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -114,7 +120,7 @@ describe("MasterToken", function() {
 	        expect(masterToken.isNewerThan(masterToken)).toBeFalsy();
 	        expect(masterToken.encryptionKey.toByteArray()).toEqual(ENCRYPTION_KEY.toByteArray());
 	        expect(masterToken.expiration.getTime() / MILLISECONDS_PER_SECOND).toEqual(Math.floor(EXPIRATION.getTime() / MILLISECONDS_PER_SECOND));
-	        expect(masterToken.hmacKey.toByteArray()).toEqual(HMAC_KEY.toByteArray());
+	        expect(masterToken.signatureKey.toByteArray()).toEqual(SIGNATURE_KEY.toByteArray());
 	        expect(masterToken.identity).toEqual(IDENTITY);
 	        expect(masterToken.issuerData).toEqual(ISSUER_DATA);
 	        expect(masterToken.renewalWindow.getTime() / MILLISECONDS_PER_SECOND).toEqual(Math.floor(RENEWAL_WINDOW.getTime() / MILLISECONDS_PER_SECOND));
@@ -142,7 +148,7 @@ describe("MasterToken", function() {
 	        expect(masterToken.isNewerThan(joMasterToken)).toBeFalsy();
 	        expect(joMasterToken.encryptionKey.toByteArray()).toEqual(masterToken.encryptionKey.toByteArray());
 	        expect(joMasterToken.expiration.getTime() / MILLISECONDS_PER_SECOND).toEqual(masterToken.expiration.getTime() / MILLISECONDS_PER_SECOND);
-	        expect(joMasterToken.hmacKey.toByteArray()).toEqual(masterToken.hmacKey.toByteArray());
+	        expect(joMasterToken.signatureKey.toByteArray()).toEqual(masterToken.signatureKey.toByteArray());
 	        expect(joMasterToken.identity).toEqual(masterToken.identity);
 	        expect(joMasterToken.issuerData).toEqual(masterToken.issuerData);
 	        expect(joMasterToken.renewalWindow.getTime() / MILLISECONDS_PER_SECOND).toEqual(masterToken.renewalWindow.getTime() / MILLISECONDS_PER_SECOND);
@@ -158,7 +164,7 @@ describe("MasterToken", function() {
     	var exception;
     	runs(function() {
 	        var sequenceNumber = -1;
-	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumber, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumber, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
 	        	result: function() {},
 	        	error: function(err) { exception = err; },
 	        });
@@ -174,7 +180,7 @@ describe("MasterToken", function() {
     	var exception;
     	runs(function() {
 	        var sequenceNumber = MslConstants$MAX_LONG_VALUE + 2;
-	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumber, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumber, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
 	            result: function() {},
 	            error: function(err) { exception = err; },
 	        });
@@ -190,7 +196,7 @@ describe("MasterToken", function() {
     	var exception;
     	runs(function() {
 	        var serialNumber = -1;
-	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumber, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumber, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
 	            result: function() {},
 	            error: function(err) { exception = err; },
 	        });
@@ -206,7 +212,7 @@ describe("MasterToken", function() {
     	var exception;
     	runs(function() {
     		var serialNumber = MslConstants$MAX_LONG_VALUE + 2;
-	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumber, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+	        MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumber, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
 	            result: function() {},
 	            error: function(err) { exception = err; },
 	        });
@@ -224,7 +230,7 @@ describe("MasterToken", function() {
 	        var expiration = new Date(Date.now() - 1000);
 	        var renewalWindow = new Date();
 	        expect(expiration.getTime()).toBeLessThan(renewalWindow.getTime());
-	        MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+	        MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
 	            result: function() {},
 	            error: function(err) { exception = err; },
 	        });
@@ -239,7 +245,7 @@ describe("MasterToken", function() {
     it("inconsistent expiration JSON", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -273,7 +279,7 @@ describe("MasterToken", function() {
     it("null issuer data", function() {
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, null, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, null, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -302,7 +308,7 @@ describe("MasterToken", function() {
     it("missing tokendata", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -332,7 +338,7 @@ describe("MasterToken", function() {
     it("invalid tokendata", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -363,7 +369,7 @@ describe("MasterToken", function() {
     it("missing signature", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -393,7 +399,7 @@ describe("MasterToken", function() {
     it("missing renewal window", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -426,7 +432,7 @@ describe("MasterToken", function() {
     it("invalid renewal window", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -458,7 +464,7 @@ describe("MasterToken", function() {
     it("missing expiration", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -491,7 +497,7 @@ describe("MasterToken", function() {
     it("invalid expiration", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -523,7 +529,7 @@ describe("MasterToken", function() {
     it("missing sequence number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -556,7 +562,7 @@ describe("MasterToken", function() {
     it("invalid sequence number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -588,7 +594,7 @@ describe("MasterToken", function() {
     it("negative sequence number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -620,7 +626,7 @@ describe("MasterToken", function() {
     it("too large sequence number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -652,7 +658,7 @@ describe("MasterToken", function() {
     it("missing serial number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -686,7 +692,7 @@ describe("MasterToken", function() {
     it("invalid serial number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -718,7 +724,7 @@ describe("MasterToken", function() {
     it("negative serial number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -750,7 +756,7 @@ describe("MasterToken", function() {
     it("too large serial number", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -782,7 +788,7 @@ describe("MasterToken", function() {
     it("missing session data", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -815,7 +821,7 @@ describe("MasterToken", function() {
     it("invalid session data", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -856,7 +862,7 @@ describe("MasterToken", function() {
     it("empty session data", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -898,7 +904,7 @@ describe("MasterToken", function() {
     it("corrupt session data", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -942,7 +948,7 @@ describe("MasterToken", function() {
     it("not verified", function() {
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -975,7 +981,7 @@ describe("MasterToken", function() {
 	        expect(masterToken.isNewerThan(joMasterToken)).toBeFalsy();
 	        expect(joMasterToken.encryptionKey).toBeNull();
 	        expect(joMasterToken.expiration.getTime() / MILLISECONDS_PER_SECOND).toEqual(masterToken.expiration.getTime() / MILLISECONDS_PER_SECOND);
-	        expect(joMasterToken.hmacKey).toBeNull();
+	        expect(joMasterToken.signatureKey).toBeNull();
 	        expect(joMasterToken.identity).toBeNull();
 	        expect(joMasterToken.issuerData).toBeNull();
 	        expect(joMasterToken.renewalWindow.getTime() / MILLISECONDS_PER_SECOND).toEqual(masterToken.renewalWindow.getTime() / MILLISECONDS_PER_SECOND);
@@ -990,7 +996,7 @@ describe("MasterToken", function() {
     it("invalid issuer data", function() {
     	var masterToken;
     	runs(function() {
-    		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+    		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
     			result: function(token) { masterToken = token; },
     			error: function(e) { expect(function() { throw e; }).not.toThrow(); },
     		});
@@ -1052,7 +1058,7 @@ describe("MasterToken", function() {
     it("missing identity", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1115,7 +1121,7 @@ describe("MasterToken", function() {
     it("missing encryption key", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1178,7 +1184,7 @@ describe("MasterToken", function() {
     it("invalid encryption key", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1237,10 +1243,396 @@ describe("MasterToken", function() {
     	});
     });
     
+    it("missing encryption algorithm", function() {
+        var masterToken;
+        runs(function() {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
+                result: function(token) { masterToken = token; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return masterToken; }, "masterToken not received", 500);
+        
+        var joMasterToken;
+        runs(function() {
+            var jsonString = JSON.stringify(masterToken);
+            var jo = JSON.parse(jsonString);
+            
+            var cryptoContext = ctx.getMslCryptoContext();
+            
+            // Before modifying the session data we need to decrypt it.
+            var tokendata = base64$decode(jo[KEY_TOKENDATA]);
+            var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
+            var ciphertext = base64$decode(tokendataJo[KEY_SESSIONDATA]);
+            cryptoContext.decrypt(ciphertext, {
+                result: function(plaintext) {
+                    var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
+                    
+                    // After modifying the session data we need to encrypt it.
+                    expect(sessiondataJo[KEY_ENCRYPTION_ALGORITHM]).not.toBeNull();
+                    delete sessiondataJo[KEY_ENCRYPTION_ALGORITHM];
+                    var json = JSON.stringify(sessiondataJo);
+                    plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
+                    cryptoContext.encrypt(plaintext, {
+                        result: function(sessiondata) {
+                            tokendataJo[KEY_SESSIONDATA] = base64$encode(sessiondata);
+                            
+                            // The tokendata must be signed otherwise the session data will not be
+                            // processed.
+                            var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
+                            cryptoContext.sign(modifiedTokendata, {
+                                result: function(signature) {
+                                    jo[KEY_TOKENDATA] = base64$encode(modifiedTokendata);
+                                    jo[KEY_SIGNATURE] = base64$encode(signature);
+                                    
+                                    MasterToken$parse(ctx, jo, {
+                                        result: function(x) { joMasterToken = x; },
+                                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                                    }); 
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                            });
+                        },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                    });
+                },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return joMasterToken; }, "joMasterToken not received", 500);
+        
+        runs(function() {
+            // Confirm default algorithm.
+            var joEncryptionKey = joMasterToken.encryptionKey;
+            expect(WebCryptoAlgorithm.AES_CBC['name']).toEqual(joEncryptionKey.algorithm['name']);
+        });
+    });
+    
+    it("invalid encryption algorithm", function() {
+        var masterToken;
+        runs(function() {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
+                result: function(token) { masterToken = token; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return masterToken; }, "masterToken not received", 500);
+        
+        var exception;
+        runs(function() {
+            var jsonString = JSON.stringify(masterToken);
+            var jo = JSON.parse(jsonString);
+            
+            var cryptoContext = ctx.getMslCryptoContext();
+            
+            // Before modifying the session data we need to decrypt it.
+            var tokendata = base64$decode(jo[KEY_TOKENDATA]);
+            var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
+            var ciphertext = base64$decode(tokendataJo[KEY_SESSIONDATA]);
+            cryptoContext.decrypt(ciphertext, {
+                result: function(plaintext) {
+                    var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
+                    
+                    // After modifying the session data we need to encrypt it.
+                    sessiondataJo[KEY_ENCRYPTION_ALGORITHM] = "x";
+                    var json = JSON.stringify(sessiondataJo);
+                    plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
+                    cryptoContext.encrypt(plaintext, {
+                        result: function(sessiondata) {
+                            tokendataJo[KEY_SESSIONDATA] = base64$encode(sessiondata);
+                            
+                            // The tokendata must be signed otherwise the session data will not be
+                            // processed.
+                            var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
+                            cryptoContext.sign(modifiedTokendata, {
+                                result: function(signature) {
+                                    jo[KEY_TOKENDATA] = base64$encode(modifiedTokendata);
+                                    jo[KEY_SIGNATURE] = base64$encode(signature);
+                                    
+                                    MasterToken$parse(ctx, jo, {
+                                        result: function() {},
+                                        error: function(e) { exception = e; }
+                                    }); 
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                            });
+                        },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                    });
+                },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return exception; }, "exception not received", 500);
+        runs(function() {
+            var f = function() { throw exception; };
+            expect(f).toThrow(new MslCryptoException(MslError.UNIDENTIFIED_ALGORITHM));
+        });
+    });
+    
     it("missing HMAC key", function() {
+        var masterToken;
+        runs(function() {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
+                result: function(token) { masterToken = token; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return masterToken; }, "masterToken not received", 500);
+        
+        var joMasterToken;
+        runs(function() {
+            var jsonString = JSON.stringify(masterToken);
+            var jo = JSON.parse(jsonString);
+            
+            var cryptoContext = ctx.getMslCryptoContext();
+            
+            // Before modifying the session data we need to decrypt it.
+            var tokendata = base64$decode(jo[KEY_TOKENDATA]);
+            var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
+            var ciphertext = base64$decode(tokendataJo[KEY_SESSIONDATA]);
+            cryptoContext.decrypt(ciphertext, {
+                result: function(plaintext) {
+                    var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
+                    
+                    // After modifying the session data we need to encrypt it.
+                    expect(sessiondataJo[KEY_HMAC_KEY]).not.toBeNull();
+                    delete sessiondataJo[KEY_HMAC_KEY];
+                    var json = JSON.stringify(sessiondataJo);
+                    plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
+                    cryptoContext.encrypt(plaintext, {
+                        result: function(sessiondata) {
+                            tokendataJo[KEY_SESSIONDATA] = base64$encode(sessiondata);
+                            
+                            // The tokendata must be signed otherwise the session data will not be
+                            // processed.
+                            var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
+                            cryptoContext.sign(modifiedTokendata, {
+                                result: function(signature) {
+                                    jo[KEY_TOKENDATA] = base64$encode(modifiedTokendata);
+                                    jo[KEY_SIGNATURE] = base64$encode(signature);
+                                    
+                                    MasterToken$parse(ctx, jo, {
+                                        result: function(x) { joMasterToken = x; },
+                                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                                    }); 
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                            });
+                        },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                    });
+                },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return joMasterToken; }, "joMasterToken not received", 500);
+        
+        runs(function() {
+            // Confirm signature key.
+            var joSignatureKey = joMasterToken.signatureKey;
+            expect(joSignatureKey.toByteArray()).toEqual(masterToken.signatureKey.toByteArray());
+        });
+    });
+    
+    it("missing signature key", function() {
+        var masterToken;
+        runs(function() {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
+                result: function(token) { masterToken = token; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return masterToken; }, "masterToken not received", 500);
+        
+        var joMasterToken;
+        runs(function() {
+            var jsonString = JSON.stringify(masterToken);
+            var jo = JSON.parse(jsonString);
+            
+            var cryptoContext = ctx.getMslCryptoContext();
+            
+            // Before modifying the session data we need to decrypt it.
+            var tokendata = base64$decode(jo[KEY_TOKENDATA]);
+            var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
+            var ciphertext = base64$decode(tokendataJo[KEY_SESSIONDATA]);
+            cryptoContext.decrypt(ciphertext, {
+                result: function(plaintext) {
+                    var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
+                    
+                    // After modifying the session data we need to encrypt it.
+                    expect(sessiondataJo[KEY_SIGNATURE_KEY]).not.toBeNull();
+                    delete sessiondataJo[KEY_SIGNATURE_KEY];
+                    var json = JSON.stringify(sessiondataJo);
+                    plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
+                    cryptoContext.encrypt(plaintext, {
+                        result: function(sessiondata) {
+                            tokendataJo[KEY_SESSIONDATA] = base64$encode(sessiondata);
+                            
+                            // The tokendata must be signed otherwise the session data will not be
+                            // processed.
+                            var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
+                            cryptoContext.sign(modifiedTokendata, {
+                                result: function(signature) {
+                                    jo[KEY_TOKENDATA] = base64$encode(modifiedTokendata);
+                                    jo[KEY_SIGNATURE] = base64$encode(signature);
+                                    
+                                    MasterToken$parse(ctx, jo, {
+                                        result: function(x) { joMasterToken = x; },
+                                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                                    }); 
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                            });
+                        },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                    });
+                },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return joMasterToken; }, "joMasterToken not received", 500);
+        
+        runs(function() {
+            // Confirm signature key.
+            var joSignatureKey = joMasterToken.signatureKey;
+            expect(joSignatureKey.toByteArray()).toEqual(masterToken.signatureKey.toByteArray());
+        });
+    });
+    
+    it("missing signature algorithm", function() {
+        var masterToken;
+        runs(function() {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
+                result: function(token) { masterToken = token; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return masterToken; }, "masterToken not received", 500);
+        
+        var joMasterToken;
+        runs(function() {
+            var jsonString = JSON.stringify(masterToken);
+            var jo = JSON.parse(jsonString);
+            
+            var cryptoContext = ctx.getMslCryptoContext();
+            
+            // Before modifying the session data we need to decrypt it.
+            var tokendata = base64$decode(jo[KEY_TOKENDATA]);
+            var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
+            var ciphertext = base64$decode(tokendataJo[KEY_SESSIONDATA]);
+            cryptoContext.decrypt(ciphertext, {
+                result: function(plaintext) {
+                    var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
+                    
+                    // After modifying the session data we need to encrypt it.
+                    expect(sessiondataJo[KEY_SIGNATURE_ALGORITHM]).not.toBeNull();
+                    delete sessiondataJo[KEY_SIGNATURE_ALGORITHM];
+                    var json = JSON.stringify(sessiondataJo);
+                    plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
+                    cryptoContext.encrypt(plaintext, {
+                        result: function(sessiondata) {
+                            tokendataJo[KEY_SESSIONDATA] = base64$encode(sessiondata);
+                            
+                            // The tokendata must be signed otherwise the session data will not be
+                            // processed.
+                            var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
+                            cryptoContext.sign(modifiedTokendata, {
+                                result: function(signature) {
+                                    jo[KEY_TOKENDATA] = base64$encode(modifiedTokendata);
+                                    jo[KEY_SIGNATURE] = base64$encode(signature);
+                                    
+                                    MasterToken$parse(ctx, jo, {
+                                        result: function(x) { joMasterToken = x; },
+                                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                                    }); 
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                            });
+                        },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                    });
+                },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return joMasterToken; }, "joMasterToken not received", 500);
+        
+        runs(function() {
+            // Confirm default algorithm.
+            var joSignatureKey = joMasterToken.signatureKey;
+            expect(WebCryptoAlgorithm.HMAC_SHA256['name']).toEqual(joSignatureKey.algorithm['name']);
+            expect(joSignatureKey.algorithm['hash']).toBeTruthy();
+            expect(WebCryptoAlgorithm.HMAC_SHA256['hash']['name']).toEqual(joSignatureKey.algorithm['hash']['name']);
+        });
+    });
+    
+    it("invalid signature algorithm", function() {
+        var masterToken;
+        runs(function() {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
+                result: function(token) { masterToken = token; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return masterToken; }, "masterToken not received", 500);
+        
+        var exception;
+        runs(function() {
+            var jsonString = JSON.stringify(masterToken);
+            var jo = JSON.parse(jsonString);
+            
+            var cryptoContext = ctx.getMslCryptoContext();
+            
+            // Before modifying the session data we need to decrypt it.
+            var tokendata = base64$decode(jo[KEY_TOKENDATA]);
+            var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
+            var ciphertext = base64$decode(tokendataJo[KEY_SESSIONDATA]);
+            cryptoContext.decrypt(ciphertext, {
+                result: function(plaintext) {
+                    var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
+                    
+                    // After modifying the session data we need to encrypt it.
+                    sessiondataJo[KEY_SIGNATURE_ALGORITHM] = "x";
+                    var json = JSON.stringify(sessiondataJo);
+                    plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
+                    cryptoContext.encrypt(plaintext, {
+                        result: function(sessiondata) {
+                            tokendataJo[KEY_SESSIONDATA] = base64$encode(sessiondata);
+                            
+                            // The tokendata must be signed otherwise the session data will not be
+                            // processed.
+                            var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
+                            cryptoContext.sign(modifiedTokendata, {
+                                result: function(signature) {
+                                    jo[KEY_TOKENDATA] = base64$encode(modifiedTokendata);
+                                    jo[KEY_SIGNATURE] = base64$encode(signature);
+                                    
+                                    MasterToken$parse(ctx, jo, {
+                                        result: function() {},
+                                        error: function(e) { exception = e; }
+                                    }); 
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                            });
+                        },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                    });
+                },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return exception; }, "exception not received", 500);
+        runs(function() {
+            var f = function() { throw exception; };
+            expect(f).toThrow(new MslCryptoException(MslError.UNIDENTIFIED_ALGORITHM));
+        });
+    });
+    
+    it("missing HMAC and signature key", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1263,8 +1655,10 @@ describe("MasterToken", function() {
 	        		var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
 	    	        
 	    	        // After modifying the session data we need to encrypt it.
-	    	        expect(sessiondataJo[KEY_HMAC_KEY]).not.toBeNull();
-	    	        delete sessiondataJo[KEY_HMAC_KEY];
+                    expect(sessiondataJo[KEY_HMAC_KEY]).not.toBeNull();
+                    delete sessiondataJo[KEY_HMAC_KEY];
+	    	        expect(sessiondataJo[KEY_SIGNATURE_KEY]).not.toBeNull();
+	    	        delete sessiondataJo[KEY_SIGNATURE_KEY];
 	    	        var json = JSON.stringify(sessiondataJo);
 	    	        var plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
 	    	        cryptoContext.encrypt(plaintext, {
@@ -1300,10 +1694,10 @@ describe("MasterToken", function() {
     	});
     });
     
-    it("invalid HMAC key", function() {
+    it("invalid HMAC and signature key", function() {
     	var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1326,7 +1720,8 @@ describe("MasterToken", function() {
 	        		var sessiondataJo = JSON.parse(textEncoding$getString(plaintext, MslConstants$DEFAULT_CHARSET));
 	    	        
 	    	        // After modifying the session data we need to encrypt it.
-	    	        sessiondataJo[KEY_HMAC_KEY] = "";
+                    sessiondataJo[KEY_HMAC_KEY] = "";
+	    	        sessiondataJo[KEY_SIGNATURE_KEY] = "";
 	    	        var json = JSON.stringify(sessiondataJo);
 	    	        plaintext = textEncoding$getBytes(json, MslConstants$DEFAULT_CHARSET);
 	    	        cryptoContext.encrypt(plaintext, {
@@ -1367,7 +1762,7 @@ describe("MasterToken", function() {
         var expiration = new Date(Date.now() + 10000);
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1395,7 +1790,7 @@ describe("MasterToken", function() {
         var expiration = new Date();
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1423,7 +1818,7 @@ describe("MasterToken", function() {
         var expiration = new Date(Date.now() + 2000);
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, renewalWindow, expiration, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1451,11 +1846,11 @@ describe("MasterToken", function() {
         var sequenceNumberB = 2;
         var masterTokenA = undefined, masterTokenB;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberA, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberA, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenA = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberB, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberB, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenB = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1483,23 +1878,23 @@ describe("MasterToken", function() {
         	var minus1MasterToken = undefined, plus1MasterToken;
         	var plus127MasterToken = undefined, plus128MasterToken;
         	runs(function() {
-        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, zero, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, zero, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
         			result: function(x) { masterToken = x; },
         			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         		});
-        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, minus1, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, minus1, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
         			result: function(x) { minus1MasterToken = x; },
         			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         		});
-        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, plus1, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, plus1, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
         			result: function(x) { plus1MasterToken = x; },
         			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         		});
-        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, plus127, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, plus127, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
         			result: function(x) { plus127MasterToken = x; },
         			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         		});
-        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, plus128, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+        		MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, plus128, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
         			result: function(x) { plus128MasterToken = x; },
         			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         		});
@@ -1524,11 +1919,11 @@ describe("MasterToken", function() {
     	var expirationB = new Date(EXPIRATION.getTime() + 10000);
         var masterTokenA = undefined, masterTokenB;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, expirationA, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, expirationA, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenA = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
-            MasterToken$create(ctx, RENEWAL_WINDOW, expirationB, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, expirationB, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenB = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1548,11 +1943,11 @@ describe("MasterToken", function() {
         var sequenceNumberB = 2;
         var masterTokenA = undefined, masterTokenB;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberA, serialNumberA, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberA, serialNumberA, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenA = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberB, serialNumberB, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberB, serialNumberB, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenB = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1602,11 +1997,11 @@ describe("MasterToken", function() {
         var serialNumberB = 2;
         var masterTokenA = undefined, masterTokenB;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumberA, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumberA, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenA = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumberB, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, serialNumberB, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenB = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1639,11 +2034,11 @@ describe("MasterToken", function() {
         var sequenceNumberB = 2;
         var masterTokenA = undefined, masterTokenB;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberA, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberA, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenA = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberB, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, sequenceNumberB, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenB = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1676,11 +2071,11 @@ describe("MasterToken", function() {
         var expirationB = new Date(EXPIRATION.getTime() + 10000);
         var masterTokenA = undefined, masterTokenB;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, expirationA, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, expirationA, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenA = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
-            MasterToken$create(ctx, RENEWAL_WINDOW, expirationB, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, expirationB, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterTokenB = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -1711,7 +2106,7 @@ describe("MasterToken", function() {
     it("equals object", function() {
         var masterToken;
         runs(function() {
-            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, HMAC_KEY, {
+            MasterToken$create(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY, {
                 result: function(token) { masterToken = token; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });

--- a/src/test/javascript/util/SimpleMslStoreTest.js
+++ b/src/test/javascript/util/SimpleMslStoreTest.js
@@ -117,7 +117,7 @@ describe("SimpleMslStore", function() {
         runs(function() {
             expect(store.getCryptoContext(masterToken)).toBeUndefined();
 
-	        var cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+	        var cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
 	        store.setCryptoContext(masterToken, cc1);
 	        var cc2 = store.getCryptoContext(masterToken);
 	        expect(cc2).not.toBeNull();
@@ -137,7 +137,7 @@ describe("SimpleMslStore", function() {
         waitsFor(function() { return masterToken; }, "master token not received", 100);
         
         runs(function() {
-	        var cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+	        var cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
 	        var cc2 = new NullCryptoContext();
 	        
 	        store.setCryptoContext(masterToken, cc1);
@@ -184,7 +184,7 @@ describe("SimpleMslStore", function() {
         waitsFor(function() { return masterToken; }, "master token not received", 100);
         
         runs(function() {
-	        var cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.encryptionKey, masterToken.hmacKey, null);
+	        var cc1 = new SymmetricCryptoContext(ctx, KEYSET_ID, masterToken.encryptionKey, masterToken.signatureKey, null);
 	        store.setCryptoContext(masterToken, cc1);
 	        store.clearCryptoContexts();
 	        expect(store.getCryptoContext(masterToken)).toBeUndefined();


### PR DESCRIPTION
* Change master tokens so they can carry an encryption key and signature key of arbitrary crypto algorithms. Crypto algorithm names are encoded as the JCE standard algorithm names.
* Change master token so it uses a signature key instead of an HMAC key. The code is backwards compatible and will accept either "hmackey" or "signaturekey" with the latter taking precedence, and the default algorithms are AES-CBC for encryption and HMAC-SHA256 for signing.
* Since the master token identifies the crypto algorithms (necessary for proper reconstruction of keys, particularly with Web Crypto) there is no need to use version 2 MSL ciphertext or signature envelopes.