### PR TITLE
Implement unauthenticated suffixed entity authentication scheme.

### DIFF
--- a/src/main/java/com/netflix/msl/entityauth/EntityAuthenticationScheme.java
+++ b/src/main/java/com/netflix/msl/entityauth/EntityAuthenticationScheme.java
@@ -41,6 +41,8 @@ public class EntityAuthenticationScheme {
     public static final EntityAuthenticationScheme RSA = new EntityAuthenticationScheme("RSA", false, true);
     /** Unauthenticated. */
     public static final EntityAuthenticationScheme NONE = new EntityAuthenticationScheme("NONE", false, false);
+    /** Unauthenticated suffixed. */
+    public static final EntityAuthenticationScheme NONE_SUFFIXED = new EntityAuthenticationScheme("NONE_SUFFIXED", false, false);
     
     /**
      * Define an entity authentication scheme with the specified name and

--- a/src/main/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationData.java
+++ b/src/main/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationData.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.entityauth;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslError;
+
+/**
+ * <p>Unauthenticated suffixed entity authentication data. This form of
+ * authentication is used by entities that cannot provide any form of entity
+ * authentication, and wish to share a root identity across themselves. This
+ * scheme may also be useful in cases where multiple MSL stacks need to execute
+ * independently on a single entity.</p>
+ * 
+ * <p>A suffixed scheme can expose an entity to cloning attacks of the root
+ * identity as the master token sequence number will now be tied to the
+ * root and suffix pair. This is probably acceptable for unauthenticated
+ * entities anyway as they have no credentials to provide as proof of their
+ * claimed identity.</p>
+ * 
+ * <p>Unauthenticated suffixed entity authentication data is represented as
+ * {@code
+ * unauthenticatedauthdata = {
+ *   "#mandatory" : [ "root", "suffix" ],
+ *   "root" : "string",
+ *   "suffix" : "string"
+ * }} where:
+ * <ul>
+ * <li>{@code root} is the entity identity root</li>
+ * <li>{@code suffix} is the entity identity suffix</li>
+ * </ul></p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class UnauthenticatedSuffixedAuthenticationData extends EntityAuthenticationData {
+    /** JSON key entity root. */
+    private static final String KEY_ROOT = "root";
+    /** JSON key entity suffix. */
+    private static final String KEY_SUFFIX = "suffix";
+    
+    /** Identity concatenation character. */
+    private static final String CONCAT_CHAR = ".";
+    
+    /**
+     * Construct a new unauthenticated suffixed entity authentication data
+     * instance from the specified entity identity root and suffix.
+     * 
+     * @param root the entity identity root.
+     * @param suffix the entity identity suffix.
+     */
+    public UnauthenticatedSuffixedAuthenticationData(final String root, final String suffix) {
+        super(EntityAuthenticationScheme.NONE_SUFFIXED);
+        this.root = root;
+        this.suffix = suffix;
+    }
+    
+    /**
+     * Construct a new unauthenticated suffixed entity authentication data
+     * instance from the provided JSON object.
+     * 
+     * @param unauthSuffixedAuthJO the authentication data JSON object.
+     * @throws MslEncodingException if there is an error parsing the JSON
+     *         representation.
+     */
+    UnauthenticatedSuffixedAuthenticationData(final JSONObject unauthSuffixedAuthJO) throws MslEncodingException {
+        super(EntityAuthenticationScheme.NONE_SUFFIXED);
+        try {
+            root = unauthSuffixedAuthJO.getString(KEY_ROOT);
+            suffix = unauthSuffixedAuthJO.getString(KEY_SUFFIX);
+        } catch (final JSONException e) {
+            throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "unauthenticated suffixed authdata " + unauthSuffixedAuthJO.toString(), e);
+        }
+    }
+    
+    /**
+     * <p>Returns the entity identity. This is equal to the root and suffix
+     * strings joined with a period, e.g. {@code root.suffix}.</p>
+     * 
+     * @return the entity identity.
+     */
+    @Override
+    public String getIdentity() {
+        return root + CONCAT_CHAR + suffix;
+    }
+
+    /**
+     * @return the entity identity root.
+     */
+    public String getRoot() {
+       return root; 
+    }
+    
+    /**
+     * @return the entity identity suffix.
+     */
+    public String getSuffix() {
+        return suffix;
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#getAuthData()
+     */
+    @Override
+    public JSONObject getAuthData() throws MslEncodingException {
+        try {
+            final JSONObject jsonObj = new JSONObject();
+            jsonObj.put(KEY_ROOT, root);
+            jsonObj.put(KEY_SUFFIX, suffix);
+            return jsonObj;
+        } catch (final JSONException e) {
+            throw new MslEncodingException(MslError.JSON_ENCODE_ERROR, "unauthenticated suffixed authdata", e);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) return true;
+        if (!(obj instanceof UnauthenticatedSuffixedAuthenticationData)) return false;
+        final UnauthenticatedSuffixedAuthenticationData that = (UnauthenticatedSuffixedAuthenticationData)obj;
+        return super.equals(obj) && this.root.equals(that.root) && this.suffix.equals(that.suffix);
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ root.hashCode() ^ suffix.hashCode();
+    }
+
+    /** Entity identity root. */
+    private final String root;
+    /** Entity identity suffix. */
+    private final String suffix;
+}

--- a/src/main/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationFactory.java
+++ b/src/main/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationFactory.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.entityauth;
+
+import org.json.JSONObject;
+
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslEntityAuthException;
+import com.netflix.msl.MslError;
+import com.netflix.msl.MslInternalException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.crypto.NullCryptoContext;
+import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.MslContext;
+
+/**
+ * <p>Unauthenticated suffixed entity authentication factory.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class UnauthenticatedSuffixedAuthenticationFactory extends EntityAuthenticationFactory {
+    /**
+     * Construct a new unauthenticated suffixed authentication factory instance.
+     * 
+     * @param authutils authentication utilities.
+     */
+    public UnauthenticatedSuffixedAuthenticationFactory(final AuthenticationUtils authutils) {
+        super(EntityAuthenticationScheme.NONE_SUFFIXED);
+        this.authutils = authutils;
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationFactory#createData(com.netflix.msl.util.MslContext, org.json.JSONObject)
+     */
+    @Override
+    public EntityAuthenticationData createData(final MslContext ctx, final JSONObject entityAuthJO) throws MslEncodingException {
+        return new UnauthenticatedSuffixedAuthenticationData(entityAuthJO);
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationFactory#getCryptoContext(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData)
+     */
+    @Override
+    public ICryptoContext getCryptoContext(final MslContext ctx, final EntityAuthenticationData authdata) throws MslEntityAuthException {
+        // Make sure we have the right kind of entity authentication data.
+        if (!(authdata instanceof UnauthenticatedSuffixedAuthenticationData))
+            throw new MslInternalException("Incorrect authentication data type " + authdata.getClass().getName() + ".");
+        final UnauthenticatedSuffixedAuthenticationData usad = (UnauthenticatedSuffixedAuthenticationData)authdata;
+        
+        // Check for revocation.
+        final String root = usad.getRoot();
+        if (authutils.isEntityRevoked(root))
+            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "none suffixed " + root).setEntity(usad);
+        
+        // Verify the scheme is permitted.
+        if (!authutils.isSchemePermitted(root, getScheme()))
+            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication Scheme for Device Type Not Supported " + root + ":" + getScheme()).setEntity(usad);
+        
+        // Return the crypto context.
+        return new NullCryptoContext();
+    }
+    
+    /** Authentication utilities. */
+    final AuthenticationUtils authutils;
+}

--- a/src/main/javascript/entityauth/EntityAuthenticationScheme.js
+++ b/src/main/javascript/entityauth/EntityAuthenticationScheme.js
@@ -65,6 +65,8 @@ var EntityAuthenticationScheme$getScheme;
         RSA : new EntityAuthenticationScheme("RSA", false, true),
         /** Unauthenticated. */
         NONE : new EntityAuthenticationScheme("NONE", false, false),
+        /** Unauthenticated suffixed. */
+        NONE_SUFFIXED : new EntityAuthenticationScheme("NONE_SUFFIXED", false, false),
     }));
     Object.freeze(EntityAuthenticationScheme);
 

--- a/src/main/javascript/entityauth/UnauthenticatedAuthenticationData.js
+++ b/src/main/javascript/entityauth/UnauthenticatedAuthenticationData.js
@@ -35,6 +35,8 @@ var UnauthenticatedAuthenticationData;
 var UnauthenticatedAuthenticationData$parse;
 
 (function() {
+    "use strict";
+    
     /**
      * JSON key entity identity.
      * @const
@@ -53,7 +55,7 @@ var UnauthenticatedAuthenticationData$parse;
             init.base.call(this, EntityAuthenticationScheme.NONE);
             // The properties.
             var props = {
-                identity: { value: identity, writable: false }
+                identity: { value: identity, writable: false, configurable: false }
             };
             Object.defineProperties(this, props);
         },
@@ -82,7 +84,7 @@ var UnauthenticatedAuthenticationData$parse;
      * Construct a new Unauthenticated asymmetric keys authentication data instance from the
      * provided JSON object.
      *
-     * @param unauthenticatedAuthJO the authentication data JSON object.
+     * @param {object} unauthenticatedAuthJO the authentication data JSON object.
      * @throws MslEncodingException if there is an error parsing the entity
      *         authentication data.
      */

--- a/src/main/javascript/entityauth/UnauthenticatedAuthenticationFactory.js
+++ b/src/main/javascript/entityauth/UnauthenticatedAuthenticationFactory.js
@@ -22,8 +22,6 @@
 var UnauthenticatedAuthenticationFactory = EntityAuthenticationFactory.extend({
     /**
      * Construct a new unauthenticated authentication factory instance.
-     *
-     * @param {string} identity my local identity.
      */
     init: function init() {
         init.base.call(this, EntityAuthenticationScheme.NONE);

--- a/src/main/javascript/entityauth/UnauthenticatedSuffixedAuthenticationData.js
+++ b/src/main/javascript/entityauth/UnauthenticatedSuffixedAuthenticationData.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>Unauthenticated suffixed entity authentication data. This form of
+ * authentication is used by entities that cannot provide any form of entity
+ * authentication, and wish to share a root identity across themselves. This
+ * scheme may also be useful in cases where multiple MSL stacks need to execute
+ * independently on a single entity.</p>
+ * 
+ * <p>A suffixed scheme can expose an entity to cloning attacks of the root
+ * identity as the master token sequence number will now be tied to the
+ * root and suffix pair. This is probably acceptable for unauthenticated
+ * entities anyway as they have no credentials to provide as proof of their
+ * claimed identity.</p>
+ * 
+ * <p>Unauthenticated suffixed entity authentication data is represented as
+ * {@code
+ * unauthenticatedauthdata = {
+ *   "#mandatory" : [ "root", "suffix" ],
+ *   "root" : "string",
+ *   "suffix" : "string"
+ * }} where:
+ * <ul>
+ * <li>{@code root} is the entity identity root</li>
+ * <li>{@code suffix} is the entity identity suffix</li>
+ * </ul></p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+var UnauthenticatedSuffixedAuthenticationData;
+var UnauthenticatedSuffixedAuthenticationData$parse;
+
+(function() {
+    "use strict";
+    
+    /**
+     * JSON key entity root.
+     * @const
+     * @type {string}
+     */
+    var KEY_ROOT = "root";
+    /**
+     * JSON key entity suffix.
+     * @const
+     * @type {string}
+     */
+    var KEY_SUFFIX = "suffix";
+    
+    /**
+     * Identity concatenation character.
+     * @const
+     * @type {string}
+     */
+    var CONCAT_CHAR = ".";
+    
+    UnauthenticatedSuffixedAuthenticationData = EntityAuthenticationData.extend({
+        /**
+         * Construct a new unauthenticated suffixed entity authentication data
+         * instance from the specified entity identity root and suffix.
+         * 
+         * @param {string} root the entity identity root.
+         * @param {string} suffix the entity identity suffix.
+         */
+        init: function init(root, suffix) {
+            init.base.call(this, EntityAuthenticationScheme.NONE_SUFFIXED);
+            
+            // The properties.
+            var props = {
+                root: { value: root, writable: false, configurable: false },
+                suffix: { value: suffix, writable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+        
+        /**
+         * <p>Returns the entity identity. This is equal to the root and suffix
+         * strings joined with a period, e.g. {@code root.suffix}.</p>
+         * 
+         * @return the entity identity.
+         */
+        getIdentity: function getIdentity() {
+            return this.root + CONCAT_CHAR + this.suffix;
+        },
+
+        /** @inheritDoc */
+        getAuthData: function getAuthData() {
+            var result = {};
+            result[KEY_ROOT] = this.root;
+            result[KEY_SUFFIX] = this.suffix;
+            return result;
+        },
+
+        /** @inheritDoc */
+        equals: function equals(that) {
+            if (this === that) return true;
+            if (!(that instanceof UnauthenticatedSuffixedAuthenticationData)) return false;
+            return (equals.base.call(this, that) && this.root == that.root && this.suffix == that.suffix);
+        },
+    });
+    
+    /**
+     * Construct a new unauthenticated suffixed entity authentication data
+     * instance from the provided JSON object.
+     * 
+     * @param {object} unauthSuffixedAuthJO the authentication data JSON object.
+     * @throws MslEncodingException if there is an error parsing the JSON
+     *         representation.
+     */
+    UnauthenticatedSuffixedAuthenticationData$parse = function UnauthenticatedSuffixedAuthenticationData$parse(unauthSuffixedAuthJO) {
+        var root = unauthSuffixedAuthJO[KEY_ROOT];
+        var suffix = unauthSuffixedAuthJO[KEY_SUFFIX];
+        if (typeof root !== 'string' || typeof suffix !== 'string')
+            throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "Unauthenticated suffixed authdata" + JSON.stringify(unauthSuffixedAuthJO));
+        return new UnauthenticatedSuffixedAuthenticationData(root, suffix);
+    };
+})();

--- a/src/main/javascript/entityauth/UnauthenticatedSuffixedAuthenticationFactory.js
+++ b/src/main/javascript/entityauth/UnauthenticatedSuffixedAuthenticationFactory.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>Unauthenticated suffixed entity authentication factory.</p>
+ *
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+var UnauthenticatedSuffixedAuthenticationFactory = EntityAuthenticationFactory.extend({
+    /**
+     * Construct a new unauthenticated suffixed authentication factory instance.
+     */
+    init: function init() {
+        init.base.call(this, EntityAuthenticationScheme.NONE_SUFFIXED);
+    },
+
+    /** @inheritDoc */
+    createData: function createData(ctx, entityAuthJO) {
+        return UnauthenticatedSuffixedAuthenticationData$parse(entityAuthJO);
+    },
+
+    /** @inheritDoc */
+    getCryptoContext: function getCryptoContext(ctx, authdata) {
+        // Make sure we have the right kind of entity authentication data.
+        if (!(authdata instanceof UnauthenticatedSuffixedAuthenticationData))
+            throw new MslInternalException("Incorrect authentication data type " + JSON.stringify(authdata) + ".");
+
+        // Return the crypto context.
+        return new NullCryptoContext();
+    },
+});

--- a/src/test/java/com/netflix/msl/entityauth/UnauthenticatedAuthenticationDataTest.java
+++ b/src/test/java/com/netflix/msl/entityauth/UnauthenticatedAuthenticationDataTest.java
@@ -123,7 +123,7 @@ public class UnauthenticatedAuthenticationDataTest {
 
         final UnauthenticatedAuthenticationData data = new UnauthenticatedAuthenticationData(IDENTITY);
         final JSONObject authdata = data.getAuthData();
-        authdata.remove("identity");
+        authdata.remove(KEY_IDENTITY);
         new UnauthenticatedAuthenticationData(authdata);
     }
     

--- a/src/test/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationDataTest.java
+++ b/src/test/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationDataTest.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.entityauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslEntityAuthException;
+import com.netflix.msl.MslError;
+import com.netflix.msl.test.ExpectedMslException;
+import com.netflix.msl.util.JsonUtils;
+import com.netflix.msl.util.MockMslContext;
+import com.netflix.msl.util.MslContext;
+
+/**
+ * Unauthenticated suffixed entity authentication data unit tests.
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class UnauthenticatedSuffixedAuthenticationDataTest {
+    /** JSON key entity authentication scheme. */
+    private static final String KEY_SCHEME = "scheme";
+    /** JSON key entity authentication data. */
+    private static final String KEY_AUTHDATA = "authdata";
+    
+    /** JSON key entity root. */
+    private static final String KEY_ROOT = "root";
+    /** JSON key entity suffix. */
+    private static final String KEY_SUFFIX = "suffix";
+    
+    /** Identity concatenation character. */
+    private static final String CONCAT_CHAR = ".";
+
+    @Rule
+    public ExpectedMslException thrown = ExpectedMslException.none();
+    
+    private static final String ROOT = "root";
+    private static final String SUFFIX = "suffix";
+    
+    @BeforeClass
+    public static void setup() throws IOException, MslEncodingException, MslCryptoException {
+        ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
+    }
+    
+    @AfterClass
+    public static void teardown() {
+        ctx = null;
+    }
+    
+    @Test
+    public void ctors() throws MslEncodingException, JSONException {
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        assertEquals(ROOT + CONCAT_CHAR + SUFFIX, data.getIdentity());
+        assertEquals(ROOT, data.getRoot());
+        assertEquals(SUFFIX, data.getSuffix());
+        assertEquals(EntityAuthenticationScheme.NONE_SUFFIXED, data.getScheme());
+        final JSONObject authdata = data.getAuthData();
+        assertNotNull(authdata);
+        final String jsonString = data.toJSONString();
+        assertNotNull(jsonString);
+        
+        final UnauthenticatedSuffixedAuthenticationData joData = new UnauthenticatedSuffixedAuthenticationData(authdata);
+        assertEquals(data.getIdentity(), joData.getIdentity());
+        assertEquals(data.getRoot(), joData.getRoot());
+        assertEquals(data.getSuffix(), joData.getSuffix());
+        assertEquals(data.getScheme(), joData.getScheme());
+        final JSONObject joAuthdata = joData.getAuthData();
+        assertNotNull(joAuthdata);
+        assertTrue(JsonUtils.equals(authdata, joAuthdata));
+        final String joJsonString = joData.toJSONString();
+        assertNotNull(joJsonString);
+        assertEquals(jsonString, joJsonString);
+    }
+    
+    @Test
+    public void jsonString() throws JSONException {
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        final JSONObject jo = new JSONObject(data.toJSONString());
+        assertEquals(EntityAuthenticationScheme.NONE_SUFFIXED.toString(), jo.getString(KEY_SCHEME));
+        final JSONObject authdata = jo.getJSONObject(KEY_AUTHDATA);
+        assertEquals(ROOT, authdata.getString(KEY_ROOT));
+        assertEquals(SUFFIX, authdata.getString(KEY_SUFFIX));
+    }
+    
+    @Test
+    public void create() throws JSONException, MslEntityAuthException, MslEncodingException, MslCryptoException {
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        final String jsonString = data.toJSONString();
+        final JSONObject jo = new JSONObject(jsonString);
+        final EntityAuthenticationData entitydata = EntityAuthenticationData.create(ctx, jo);
+        assertNotNull(entitydata);
+        assertTrue(entitydata instanceof UnauthenticatedSuffixedAuthenticationData);
+        
+        final UnauthenticatedSuffixedAuthenticationData joData = (UnauthenticatedSuffixedAuthenticationData)entitydata;
+        assertEquals(data.getIdentity(), joData.getIdentity());
+        assertEquals(data.getRoot(), joData.getRoot());
+        assertEquals(data.getSuffix(), joData.getSuffix());
+        assertEquals(data.getScheme(), joData.getScheme());
+        final JSONObject joAuthdata = joData.getAuthData();
+        assertNotNull(joAuthdata);
+        assertTrue(JsonUtils.equals(data.getAuthData(), joAuthdata));
+        final String joJsonString = joData.toJSONString();
+        assertNotNull(joJsonString);
+        assertEquals(jsonString, joJsonString);
+    }
+    
+    @Test
+    public void missingRoot() throws MslEncodingException {
+        thrown.expect(MslEncodingException.class);
+        thrown.expectMslError(MslError.JSON_PARSE_ERROR);
+
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        final JSONObject authdata = data.getAuthData();
+        authdata.remove(KEY_ROOT);
+        new UnauthenticatedSuffixedAuthenticationData(authdata);
+    }
+    
+    @Test
+    public void missingSuffix() throws MslEncodingException {
+        thrown.expect(MslEncodingException.class);
+        thrown.expectMslError(MslError.JSON_PARSE_ERROR);
+
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        final JSONObject authdata = data.getAuthData();
+        authdata.remove(KEY_SUFFIX);
+        new UnauthenticatedSuffixedAuthenticationData(authdata);
+    }
+    
+    @Test
+    public void equalsRoot() throws MslEncodingException, JSONException, MslEntityAuthException, MslCryptoException {
+        final UnauthenticatedSuffixedAuthenticationData dataA = new UnauthenticatedSuffixedAuthenticationData(ROOT + "A", SUFFIX);
+        final UnauthenticatedSuffixedAuthenticationData dataB = new UnauthenticatedSuffixedAuthenticationData(ROOT + "B", SUFFIX);
+        final EntityAuthenticationData dataA2 = EntityAuthenticationData.create(ctx, new JSONObject(dataA.toJSONString()));
+        
+        assertTrue(dataA.equals(dataA));
+        assertEquals(dataA.hashCode(), dataA.hashCode());
+        
+        assertFalse(dataA.equals(dataB));
+        assertFalse(dataB.equals(dataA));
+        assertTrue(dataA.hashCode() != dataB.hashCode());
+        
+        assertTrue(dataA.equals(dataA2));
+        assertTrue(dataA2.equals(dataA));
+        assertEquals(dataA.hashCode(), dataA2.hashCode());
+    }
+    
+    @Test
+    public void equalsSuffix() throws MslEncodingException, JSONException, MslEntityAuthException, MslCryptoException {
+        final UnauthenticatedSuffixedAuthenticationData dataA = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX + "A");
+        final UnauthenticatedSuffixedAuthenticationData dataB = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX + "B");
+        final EntityAuthenticationData dataA2 = EntityAuthenticationData.create(ctx, new JSONObject(dataA.toJSONString()));
+        
+        assertTrue(dataA.equals(dataA));
+        assertEquals(dataA.hashCode(), dataA.hashCode());
+        
+        assertFalse(dataA.equals(dataB));
+        assertFalse(dataB.equals(dataA));
+        assertTrue(dataA.hashCode() != dataB.hashCode());
+        
+        assertTrue(dataA.equals(dataA2));
+        assertTrue(dataA2.equals(dataA));
+        assertEquals(dataA.hashCode(), dataA2.hashCode());
+    }
+    
+    @Test
+    public void equalsObject() {
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        assertFalse(data.equals(null));
+        assertFalse(data.equals(ROOT));
+        assertTrue(data.hashCode() != ROOT.hashCode());
+    }
+
+    /** MSL context. */
+    private static MslContext ctx;
+}

--- a/src/test/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationFactoryTest.java
+++ b/src/test/java/com/netflix/msl/entityauth/UnauthenticatedSuffixedAuthenticationFactoryTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.entityauth;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslEntityAuthException;
+import com.netflix.msl.MslError;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.test.ExpectedMslException;
+import com.netflix.msl.util.JsonUtils;
+import com.netflix.msl.util.MockAuthenticationUtils;
+import com.netflix.msl.util.MockMslContext;
+
+/**
+ * Unauthenticated suffixed authentication factory unit tests.
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class UnauthenticatedSuffixedAuthenticationFactoryTest {
+    /** JSON key entity root. */
+    private static final String KEY_ROOT = "root";
+    
+    @Rule
+    public ExpectedMslException thrown = ExpectedMslException.none();
+    
+    private static final String UNAUTHENTICATED_ROOT = "MOCKUNAUTH-ROOT";
+    private static final String UNAUTHENTICATED_SUFFIX = "MOCKUNAUTH-SUFFIX";
+
+    /** Authentication utilities. */
+    private static MockAuthenticationUtils authutils;
+    
+    @BeforeClass
+    public static void setup() throws MslEncodingException, MslCryptoException {
+        ctx = new MockMslContext(EntityAuthenticationScheme.NONE, false);
+        authutils = new MockAuthenticationUtils();
+        factory = new UnauthenticatedSuffixedAuthenticationFactory(authutils);
+        ctx.addEntityAuthenticationFactory(factory);
+    }
+    
+    @AfterClass
+    public static void teardown() {
+        factory = null;
+        ctx = null;
+    }
+    
+    @After
+    public void reset() {
+        authutils.reset();
+    }
+    
+    @Test
+    public void createData() throws MslCryptoException, MslEncodingException, MslEntityAuthException, JSONException {
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        final JSONObject entityAuthJO = data.getAuthData();
+        
+        final EntityAuthenticationData authdata = factory.createData(ctx, entityAuthJO);
+        assertNotNull(authdata);
+        assertTrue(authdata instanceof UnauthenticatedSuffixedAuthenticationData);
+        
+        final JSONObject dataJo = new JSONObject(data.toJSONString());
+        final JSONObject authdataJo = new JSONObject(authdata.toJSONString());
+        assertTrue(JsonUtils.equals(dataJo, authdataJo));
+    }
+    
+    @Test
+    public void encodeException() throws MslCryptoException, MslEncodingException, MslEntityAuthException {
+        thrown.expect(MslEncodingException.class);
+        thrown.expectMslError(MslError.JSON_PARSE_ERROR);
+
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        final JSONObject entityAuthJO = data.getAuthData();
+        entityAuthJO.remove(KEY_ROOT);
+        factory.createData(ctx, entityAuthJO);
+    }
+    
+    @Test
+    public void cryptoContext() throws MslCryptoException, MslEntityAuthException {
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        final ICryptoContext cryptoContext = factory.getCryptoContext(ctx, data);
+        assertNotNull(cryptoContext);
+    }
+    
+    @Test
+    public void revoked() throws MslCryptoException, MslEntityAuthException {
+        thrown.expect(MslEntityAuthException.class);
+        thrown.expectMslError(MslError.ENTITY_REVOKED);
+
+        authutils.revokeEntity(UNAUTHENTICATED_ROOT);
+        final UnauthenticatedSuffixedAuthenticationData data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        factory.getCryptoContext(ctx, data);
+    }
+    
+    /** MSL context. */
+    private static MockMslContext ctx;
+    /** Entity authentication factory. */
+    private static EntityAuthenticationFactory factory;
+}

--- a/src/test/java/com/netflix/msl/util/MockMslContext.java
+++ b/src/test/java/com/netflix/msl/util/MockMslContext.java
@@ -49,6 +49,8 @@ import com.netflix.msl.entityauth.PresharedProfileAuthenticationData;
 import com.netflix.msl.entityauth.RsaAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationFactory;
+import com.netflix.msl.entityauth.UnauthenticatedSuffixedAuthenticationData;
+import com.netflix.msl.entityauth.UnauthenticatedSuffixedAuthenticationFactory;
 import com.netflix.msl.entityauth.X509AuthenticationData;
 import com.netflix.msl.keyx.AsymmetricWrappedExchange;
 import com.netflix.msl.keyx.DiffieHellmanExchange;
@@ -143,6 +145,8 @@ public class MockMslContext implements MslContext {
             entityAuthData = new RsaAuthenticationData(MockRsaAuthenticationFactory.RSA_ESN, MockRsaAuthenticationFactory.RSA_PUBKEY_ID);
         else if (EntityAuthenticationScheme.NONE.equals(scheme))
             entityAuthData = new UnauthenticatedAuthenticationData("MOCKUNAUTH-ESN");
+        else if (EntityAuthenticationScheme.NONE_SUFFIXED.equals(scheme))
+            entityAuthData = new UnauthenticatedSuffixedAuthenticationData("MOCKUNAUTH-ROOT", "MOCKUNAUTH-SUFFIX");
         else      
             throw new IllegalArgumentException("Unsupported authentication type: " + scheme.name());
 
@@ -169,6 +173,7 @@ public class MockMslContext implements MslContext {
         entityAuthFactories.put(EntityAuthenticationScheme.RSA, new MockRsaAuthenticationFactory());
         entityAuthFactories.put(EntityAuthenticationScheme.NONE, new UnauthenticatedAuthenticationFactory(authutils));
         entityAuthFactories.put(EntityAuthenticationScheme.X509, new MockX509AuthenticationFactory());
+        entityAuthFactories.put(EntityAuthenticationScheme.NONE_SUFFIXED, new UnauthenticatedSuffixedAuthenticationFactory(authutils));
 
         userAuthFactories = new HashMap<UserAuthenticationScheme,UserAuthenticationFactory>();
         userAuthFactories.put(UserAuthenticationScheme.EMAIL_PASSWORD, new MockEmailPasswordAuthenticationFactory());

--- a/src/test/javascript/entityauth/UnauthenticatedAuthenticationDataTest.js
+++ b/src/test/javascript/entityauth/UnauthenticatedAuthenticationDataTest.js
@@ -45,7 +45,7 @@ describe("UnauthenticatedAuthenticationData", function() {
 
     it("ctors", function() {
         var data = new UnauthenticatedAuthenticationData(IDENTITY);
-        expect(data.identity).toEqual(IDENTITY);
+        expect(data.getIdentity()).toEqual(IDENTITY);
         expect(data.scheme).toEqual(EntityAuthenticationScheme.NONE);
         var authdata = data.getAuthData();
         expect(authdata).not.toBeNull();
@@ -53,7 +53,7 @@ describe("UnauthenticatedAuthenticationData", function() {
         expect(jsonString).not.toBeNull();
         
         var joData = UnauthenticatedAuthenticationData$parse(authdata);
-        expect(joData.identity).toEqual(data.identity);
+        expect(joData.getIdentity()).toEqual(data.getIdentity());
         expect(joData.scheme).toEqual(data.scheme);
         var joAuthdata = joData.getAuthData();
         expect(joAuthdata).not.toBeNull();
@@ -80,7 +80,7 @@ describe("UnauthenticatedAuthenticationData", function() {
         expect(entitydata instanceof UnauthenticatedAuthenticationData).toBeTruthy();
         
         var joData = entitydata;
-        expect(joData.identity).toEqual(data.identity);
+        expect(joData.getIdentity()).toEqual(data.getIdentity());
         expect(joData.scheme).toEqual(data.scheme);
         var joAuthdata = joData.getAuthData();
         expect(joAuthdata).not.toBeNull();

--- a/src/test/javascript/entityauth/UnauthenticatedSuffixedAuthenticationDataTest.js
+++ b/src/test/javascript/entityauth/UnauthenticatedSuffixedAuthenticationDataTest.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unauthenticated suffixed entity authentication data unit tests.
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+describe("UnauthenticatedSuffixedAuthenticationData", function() {
+    /** JSON key entity authentication scheme. */
+    var KEY_SCHEME = "scheme";
+    /** JSON key entity authentication data. */
+    var KEY_AUTHDATA = "authdata";
+    
+    /** JSON key entity root. */
+    var KEY_ROOT = "root";
+    /** JSON key entity suffix. */
+    var KEY_SUFFIX = "suffix";
+    
+    /** Identity concatenation character. */
+    var CONCAT_CHAR = ".";
+    
+    var ROOT = "root";
+    var SUFFIX = "suffix";
+    
+    /** MSL context. */
+    var ctx;
+    beforeEach(function() {
+        if (!ctx) {
+            runs(function() {
+                MockMslContext$create(EntityAuthenticationScheme.X509, false, {
+                    result: function(c) { ctx = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return ctx; }, "ctx", 100);
+        }
+    });
+
+    it("ctors", function() {
+        var data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        expect(data.getIdentity()).toEqual(ROOT + CONCAT_CHAR + SUFFIX);
+        expect(data.root).toEqual(ROOT);
+        expect(data.suffix).toEqual(SUFFIX);
+        expect(data.scheme).toEqual(EntityAuthenticationScheme.NONE_SUFFIXED);
+        var authdata = data.getAuthData();
+        expect(authdata).not.toBeNull();
+        var jsonString = JSON.stringify(data);
+        expect(jsonString).not.toBeNull();
+        
+        var joData = UnauthenticatedSuffixedAuthenticationData$parse(authdata);
+        expect(joData.getIdentity()).toEqual(data.getIdentity());
+        expect(joData.root).toEqual(data.root);
+        expect(joData.suffix).toEqual(data.suffix);
+        expect(joData.scheme).toEqual(data.scheme);
+        var joAuthdata = joData.getAuthData();
+        expect(joAuthdata).not.toBeNull();
+        expect(joAuthdata).toEqual(authdata);
+        var joJsonString = JSON.stringify(joData);
+        expect(joJsonString).not.toBeNull();
+        expect(joJsonString).toEqual(jsonString);
+    });
+    
+    it("json is correct", function() {
+        var data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        var jo = JSON.parse(JSON.stringify(data));
+        expect(jo[KEY_SCHEME]).toEqual(EntityAuthenticationScheme.NONE_SUFFIXED.name);
+        var authdata = jo[KEY_AUTHDATA];
+        expect(authdata[KEY_ROOT]).toEqual(ROOT);
+        expect(authdata[KEY_SUFFIX]).toEqual(SUFFIX);
+    });
+    
+    it("create", function() {
+        var data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        var jsonString = JSON.stringify(data);
+        var jo = JSON.parse(jsonString);
+        var entitydata = EntityAuthenticationData$parse(ctx, jo);
+        expect(entitydata).not.toBeNull();
+        expect(entitydata instanceof UnauthenticatedSuffixedAuthenticationData).toBeTruthy();
+        
+        var joData = entitydata;
+        expect(joData.getIdentity()).toEqual(data.getIdentity());
+        expect(joData.root).toEqual(data.root);
+        expect(joData.suffix).toEqual(data.suffix);
+        expect(joData.scheme).toEqual(data.scheme);
+        var joAuthdata = joData.getAuthData();
+        expect(joAuthdata).not.toBeNull();
+        expect(joAuthdata).toEqual(data.getAuthData());
+        var joJsonString = JSON.stringify(joData);
+        expect(joJsonString).not.toBeNull();
+        expect(joJsonString).toEqual(jsonString);
+    });
+    
+    it("missing root", function() {
+    	var f = function() {
+	        var data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+	        var authdata = data.getAuthData();
+	        delete authdata[KEY_ROOT];
+	        UnauthenticatedSuffixedAuthenticationData$parse(authdata);
+    	};
+    	expect(f).toThrow(new MslEncodingException(MslError.JSON_PARSE_ERROR));
+    });
+    
+    it("missing suffix", function() {
+        var f = function() {
+            var data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+            var authdata = data.getAuthData();
+            delete authdata[KEY_SUFFIX];
+            UnauthenticatedSuffixedAuthenticationData$parse(authdata);
+        };
+        expect(f).toThrow(new MslEncodingException(MslError.JSON_PARSE_ERROR));
+    });
+
+    it("equals root", function() {
+        var dataA = new UnauthenticatedSuffixedAuthenticationData(ROOT + "A", SUFFIX);
+        var dataB = new UnauthenticatedSuffixedAuthenticationData(ROOT + "B", SUFFIX);
+        var dataA2 = EntityAuthenticationData$parse(ctx, JSON.parse(JSON.stringify(dataA)));
+        
+        expect(dataA.equals(dataA)).toBeTruthy();
+        
+        expect(dataA.equals(dataB)).toBeFalsy();
+        expect(dataB.equals(dataA)).toBeFalsy();
+        
+        expect(dataA.equals(dataA2)).toBeTruthy();
+        expect(dataA2.equals(dataA)).toBeTruthy();
+    });
+
+    it("equals suffix", function() {
+        var dataA = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX + "A");
+        var dataB = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX + "B");
+        var dataA2 = EntityAuthenticationData$parse(ctx, JSON.parse(JSON.stringify(dataA)));
+        
+        expect(dataA.equals(dataA)).toBeTruthy();
+        
+        expect(dataA.equals(dataB)).toBeFalsy();
+        expect(dataB.equals(dataA)).toBeFalsy();
+        
+        expect(dataA.equals(dataA2)).toBeTruthy();
+        expect(dataA2.equals(dataA)).toBeTruthy();
+    });
+    
+    it("equals object", function() {
+        var data = new UnauthenticatedSuffixedAuthenticationData(ROOT, SUFFIX);
+        expect(data.equals(null)).toBeFalsy();
+        expect(data.equals(KEY_ROOT)).toBeFalsy();
+    });
+});

--- a/src/test/javascript/entityauth/UnauthenticatedSuffixedAuthenticationFactoryTest.js
+++ b/src/test/javascript/entityauth/UnauthenticatedSuffixedAuthenticationFactoryTest.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2015 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unauthenticated suffixed authentication factory unit tests.
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+describe("UnauthenticatedSuffixedAuthenticationFactory", function() {
+    /** JSON key root. */
+    var KEY_ROOT = "root";
+    
+    var UNAUTHENTICATED_ROOT = "MOCKUNAUTH-ROOT";
+    var UNAUTHENTICATED_SUFFIX = "MOCKUNAUTH-SUFFIX";
+    
+    /** MSL context. */
+    var ctx;
+    /** Entity authentication factory. */
+    var factory = new UnauthenticatedSuffixedAuthenticationFactory();
+    
+    var initialized = false;
+    beforeEach(function() {
+        if (!initialized) {
+            runs(function() {
+                MockMslContext$create(EntityAuthenticationScheme.NONE_SUFFIXED, false, {
+                    result: function(c) { ctx = c; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            });
+            waitsFor(function() { return ctx; }, "ctx", 100);
+            runs(function() {
+                ctx.addEntityAuthenticationFactory(factory);
+                initialized = true;
+            });
+        }
+    });
+    
+    it("createData", function() {
+        var data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        var entityAuthJO = data.getAuthData();
+        
+        var authdata = factory.createData(ctx, entityAuthJO);
+        expect(authdata).not.toBeNull();
+        expect(authdata instanceof UnauthenticatedSuffixedAuthenticationData).toBeTruthy();
+        
+        var dataJo = JSON.parse(JSON.stringify(data));
+        var authdataJo = JSON.parse(JSON.stringify(authdata));
+        expect(authdataJo).toEqual(dataJo);
+    });
+    
+    it("encode exception", function() {
+        var f = function() {
+        	var data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        	var entityAuthJO = data.getAuthData();
+        	delete entityAuthJO[KEY_ROOT];
+        	factory.createData(ctx, entityAuthJO);
+        };
+        expect(f).toThrow(new MslEncodingException(MslError.JSON_PARSE_ERROR));
+    });
+    
+    it("crypto context", function() {
+        var data = new UnauthenticatedSuffixedAuthenticationData(UNAUTHENTICATED_ROOT, UNAUTHENTICATED_SUFFIX);
+        var cryptoContext = factory.getCryptoContext(ctx, data);
+        expect(cryptoContext).not.toBeNull();
+    });
+});

--- a/src/test/javascript/msltests.html
+++ b/src/test/javascript/msltests.html
@@ -112,6 +112,7 @@
 <script type="text/javascript" src="../../main/javascript/entityauth/RsaAuthenticationData.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/X509AuthenticationData.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/UnauthenticatedAuthenticationData.js"></script>
+<script type="text/javascript" src="../../main/javascript/entityauth/UnauthenticatedSuffixedAuthenticationData.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/EntityAuthenticationFactory.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/PresharedAuthenticationFactory.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/PresharedProfileAuthenticationFactory.js"></script>
@@ -120,6 +121,7 @@
 <script type="text/javascript" src="../../main/javascript/entityauth/X509Store.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/X509AuthenticationFactory.js"></script>
 <script type="text/javascript" src="../../main/javascript/entityauth/UnauthenticatedAuthenticationFactory.js"></script>
+<script type="text/javascript" src="../../main/javascript/entityauth/UnauthenticatedSuffixedAuthenticationFactory.js"></script>
 <script type="text/javascript" src="../../main/javascript/io/InputStream.js"></script>
 <script type="text/javascript" src="../../main/javascript/io/OutputStream.js"></script>
 <script type="text/javascript" src="../../main/javascript/io/ByteArrayInputStream.js"></script>
@@ -222,11 +224,13 @@
 <script type="text/javascript" src="../../test/javascript/entityauth/RsaAuthenticationDataTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/X509AuthenticationDataTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/UnauthenticatedAuthenticationDataTest.js"></script>
+<script type="text/javascript" src="../../test/javascript/entityauth/UnauthenticatedSuffixedAuthenticationDataTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/PresharedAuthenticationFactoryTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/PresharedProfileAuthenticationFactoryTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/RsaAuthenticationFactoryTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/X509AuthenticationFactoryTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/entityauth/UnauthenticatedAuthenticationFactoryTest.js"></script>
+<script type="text/javascript" src="../../test/javascript/entityauth/UnauthenticatedSuffixedAuthenticationFactoryTest.js"></script>
 <script type="text/javascript" src="../../test/javascript/keyx/AsymmetricWrappedExchangeSuite.js"></script>
 <script type="text/javascript" src="../../test/javascript/keyx/DiffieHellmanExchangeSuite.js"></script>
 <script type="text/javascript" src="../../test/javascript/keyx/JsonWebEncryptionLadderExchangeSuite.js"></script>

--- a/src/test/javascript/util/MockMslContext.js
+++ b/src/test/javascript/util/MockMslContext.js
@@ -87,6 +87,7 @@ var MockMslContext$create;
 		    function syncEntityAuthFactories(entityAuthFactories) {
 		        entityAuthFactories[EntityAuthenticationScheme.X509.name] = new MockX509AuthenticationFactory();
 		        entityAuthFactories[EntityAuthenticationScheme.NONE.name] = new UnauthenticatedAuthenticationFactory();
+		        entityAuthFactories[EntityAuthenticationScheme.NONE_SUFFIXED.name] = new UnauthenticatedSuffixedAuthenticationFactory();
                 syncUserAuthFactories(entityAuthFactories);
 		    }
 		    function syncUserAuthFactories(entityAuthFactories, userAuthFactories) {
@@ -133,6 +134,8 @@ var MockMslContext$create;
 		                entityAuthData = new RsaAuthenticationData(MockRsaAuthenticationFactory.RSA_ESN, MockRsaAuthenticationFactory.RSA_PUBKEY_ID);
 		            } else if (EntityAuthenticationScheme.NONE == scheme) {
 		                entityAuthData = new UnauthenticatedAuthenticationData("MOCKUNAUTH-ESN");
+		            } else if (EntityAuthenticationScheme.NONE_SUFFIXED == scheme) {
+		                entityAuthData = new UnauthenticatedSuffixedAuthenticationData("MOCKUNAUTH-ROOT", "MOCKUNAUTH-SUFFIX");
 		            } else {
 		                throw new MslInternalException("Unsupported authentication type: " + scheme);
 		            };


### PR DESCRIPTION
This scheme allows multiple entities to share a common root value among themselves, without resulting in identity or master token sequence number collisions.