### PR TITLE
Use correct master token when updating service tokens in MslControl.send()

### DIFF
--- a/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -1542,8 +1542,9 @@ public class MslControl {
         updateCryptoContexts(ctx, requestHeader, keyExchangeData);
         
         // Update the stored service tokens.
+        final MasterToken tokenVerificationMasterToken = (keyExchangeData != null) ? keyExchangeData.keyResponseData.getMasterToken() : masterToken;
         final Set<ServiceToken> serviceTokens = requestHeader.getServiceTokens();
-        storeServiceTokens(ctx, masterToken, userIdToken, serviceTokens);
+        storeServiceTokens(ctx, tokenVerificationMasterToken, userIdToken, serviceTokens);
         
         // We will either use the header crypto context or the key exchange
         // data crypto context in trusted network mode to process the message

--- a/src/main/javascript/msg/MslControl.js
+++ b/src/main/javascript/msg/MslControl.js
@@ -1575,8 +1575,9 @@ var MslControl$MslChannel;
                                         this.updateOutgoingCryptoContexts(ctx, requestHeader, keyExchangeData);
 
                                         // Update the stored service tokens.
+                                        var tokenVerificationMasterToken = (keyExchangeData) ? keyExchangeData.keyResponseData.masterToken : masterToken;
                                         var serviceTokens = requestHeader.serviceTokens;
-                                        this.storeServiceTokens(ctx, masterToken, userIdToken, serviceTokens);
+                                        this.storeServiceTokens(ctx, tokenVerificationMasterToken, userIdToken, serviceTokens);
 
                                         // We will either use the header crypto context or the key exchange
                                         // data crypto context in trusted network mode to process the message


### PR DESCRIPTION
When updating service tokens during the send() operation, use the key response data master token if it exists. This handles the case where there is no previous master token or where the master token serial number has changed.