### PR TITLE
Remove old non-replayable logic and message header field.

### DIFF
--- a/src/examples/java/burp/MSLHttpListener.java
+++ b/src/examples/java/burp/MSLHttpListener.java
@@ -299,7 +299,6 @@ public class MSLHttpListener implements IHttpListener {
                 headerdataJO.put(KEY_RECIPIENT, messageHeader.getRecipient());
                 headerdataJO.put(KEY_MESSAGE_ID, messageHeader.getMessageId());
                 headerdataJO.put(KEY_NON_REPLAYABLE_ID, messageHeader.getNonReplayableId());
-                headerdataJO.put(KEY_NON_REPLAYABLE, messageHeader.isNonReplayable());
                 headerdataJO.put(KEY_RENEWABLE, messageHeader.isRenewable());
                 headerdataJO.put(KEY_HANDSHAKE, messageHeader.isHandshake());
                 headerdataJO.put(KEY_CAPABILITIES, messageHeader.getMessageCapabilities());

--- a/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -254,10 +254,9 @@ public class MessageBuilder {
                 // If the message contains a master token...
                 if (masterToken != null) {
                     // If the master token is renewable/expired or not the
-                    // newest master token, or the message is non-replayable,
-                    // then renew the master token.
+                    // newest master token, then renew the master token.
                     final TokenFactory factory = ctx.getTokenFactory();
-                    if (masterToken.isRenewable(null) || masterToken.isExpired(null) || !factory.isNewestMasterToken(ctx, masterToken) || requestHeader.isNonReplayable())
+                    if (masterToken.isRenewable(null) || masterToken.isExpired(null) || !factory.isNewestMasterToken(ctx, masterToken))
                         keyExchangeData = issueMasterToken(ctx, keyRequestData, masterToken, null);
                     // Otherwise we don't need to do anything special.
                     else

--- a/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -80,7 +80,6 @@ import com.netflix.msl.util.MslContext;
  *   "timestamp" : "int64(0,2^53^)",
  *   "messageid" : "int64(0,2^53^)",
  *   "nonreplayableid" : "int64(0,2^53^)",
- *   "nonreplayable" : "boolean",
  *   "renewable" : "boolean",
  *   "handshake" : "boolean",
  *   "capabilities" : capabilities,
@@ -99,7 +98,6 @@ import com.netflix.msl.util.MslContext;
  * <li>{@code timestamp} is the sender time when the header is created in seconds since the UNIX epoch</li>
  * <li>{@code messageid} is the message ID</li>
  * <li>{@code nonreplayableid} is the non-replayable ID</li>
- * <li>{@code nonreplayable} indicates if the message is nonreplayable</li>
  * <li>{@code renewable} indicates if the master token and user ID are renewable</li>
  * <li>{@code handshake} indicates a handshake message</li>
  * <li>{@code capabilities} lists the sender's message capabilities</li>
@@ -130,8 +128,6 @@ public class MessageHeader extends Header {
     private static final String KEY_MESSAGE_ID = "messageid";
     /** JSON key non-replayable ID. */
     private static final String KEY_NON_REPLAYABLE_ID = "nonreplayableid";
-    /** JSON key non-replayable flag. */
-    private static final String KEY_NON_REPLAYABLE = "nonreplayable";
     /** JSON key renewable flag. */
     private static final String KEY_RENEWABLE = "renewable";
     /** JSON key handshake flag */
@@ -268,7 +264,6 @@ public class MessageHeader extends Header {
         this.entityAuthData = (masterToken == null) ? entityAuthData : null;
         this.masterToken = masterToken;
         this.nonReplayableId = headerData.nonReplayableId;
-        this.nonReplayable = false;
         this.renewable = headerData.renewable;
         this.handshake = headerData.handshake;
         this.capabilities = headerData.capabilities;
@@ -351,7 +346,6 @@ public class MessageHeader extends Header {
             if (this.recipient != null) headerJO.put(KEY_RECIPIENT, this.recipient);
             headerJO.put(KEY_TIMESTAMP, this.timestamp);
             headerJO.put(KEY_MESSAGE_ID, this.messageId);
-            headerJO.put(KEY_NON_REPLAYABLE, this.nonReplayable);
             if (this.nonReplayableId != null) headerJO.put(KEY_NON_REPLAYABLE_ID, this.nonReplayableId);
             headerJO.put(KEY_RENEWABLE, this.renewable);
             headerJO.put(KEY_HANDSHAKE, this.handshake);
@@ -541,7 +535,6 @@ public class MessageHeader extends Header {
             this.user = null;
             this.serviceTokens = Collections.emptySet();
             this.nonReplayableId = null;
-            this.nonReplayable = false;
             this.renewable = false;
             this.handshake = false;
             this.capabilities = null;
@@ -638,7 +631,6 @@ public class MessageHeader extends Header {
         
         try {
             this.nonReplayableId = (headerdataJO.has(KEY_NON_REPLAYABLE_ID)) ? headerdataJO.getLong(KEY_NON_REPLAYABLE_ID) : null;
-            this.nonReplayable = (headerdataJO.has(KEY_NON_REPLAYABLE)) ? headerdataJO.getBoolean(KEY_NON_REPLAYABLE) : false;
             this.renewable = headerdataJO.getBoolean(KEY_RENEWABLE);
             // FIXME: Make handshake required once all MSL stacks are updated.
             this.handshake = (headerdataJO.has(KEY_HANDSHAKE)) ? headerdataJO.getBoolean(KEY_HANDSHAKE) : false;
@@ -834,13 +826,6 @@ public class MessageHeader extends Header {
     }
     
     /**
-     * @return true if the message non-replayable flag is set.
-     */
-    public boolean isNonReplayable() {
-        return nonReplayable;
-    }
-    
-    /**
      * @return true if the message renewable flag is set.
      */
     public boolean isRenewable() {
@@ -983,7 +968,6 @@ public class MessageHeader extends Header {
                messageId == that.messageId &&
                (nonReplayableId != null && nonReplayableId.equals(that.nonReplayableId) ||
                 nonReplayableId == null && that.nonReplayableId == null) &&
-               nonReplayable == that.nonReplayable &&
                renewable == that.renewable &&
                handshake == that.handshake &&
                (capabilities != null && capabilities.equals(that.capabilities) ||
@@ -1014,7 +998,6 @@ public class MessageHeader extends Header {
             ((timestamp != null) ? timestamp.hashCode() : 0) ^
             Long.valueOf(messageId).hashCode() ^
             ((nonReplayableId != null) ? nonReplayableId.hashCode() : 0) ^
-            Boolean.valueOf(nonReplayable).hashCode() ^
             Boolean.valueOf(renewable).hashCode() ^
             Boolean.valueOf(handshake).hashCode() ^
             ((capabilities != null) ? capabilities.hashCode() : 0) ^
@@ -1049,8 +1032,6 @@ public class MessageHeader extends Header {
     private final long messageId;
     /** Non-replayable ID. */
     private final Long nonReplayableId;
-    /** Non-replayable. */
-    private final boolean nonReplayable;
     /** Renewable. */
     private final boolean renewable;
     /** Handshake message. */

--- a/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -292,29 +292,6 @@ public class MessageInputStream extends InputStream {
                 }
             }
             
-            // TODO: This is the old non-replayable logic for backwards
-            // compatibility. It should be removed once all MSL stacks have
-            // migrated to the newer non-replayable ID logic.
-            //
-            // If the message is non-replayable (it is not from a trusted
-            // network server).
-            if (messageHeader.isNonReplayable()) {
-                // ...and not also renewable with key request data and a
-                // master token then reject the message.
-                if (!messageHeader.isRenewable() ||
-                    messageHeader.getKeyRequestData().isEmpty() ||
-                    masterToken == null)
-                {
-                    throw new MslMessageException(MslError.INCOMPLETE_NONREPLAYABLE_MESSAGE, messageHeader.toJSONString());
-                }
-
-                // If the message does not have the newest master token
-                // then notify the sender.
-                final TokenFactory factory = ctx.getTokenFactory();
-                if (!factory.isNewestMasterToken(ctx, masterToken))
-                    throw new MslMessageException(MslError.MESSAGE_REPLAYED, messageHeader.toJSONString());
-            }
-            
             // If the message is non-replayable (it is not from a trusted
             // network server).
             final Long nonReplayableId = messageHeader.getNonReplayableId();

--- a/src/main/javascript/msg/MessageBuilder.js
+++ b/src/main/javascript/msg/MessageBuilder.js
@@ -180,9 +180,8 @@ var MessageBuilder$createErrorResponse;
                 // If the message contains a master token...
                 if (masterToken) {
                     // If the master token is renewable/expired or not the
-                    // newest master token, or the message is non-replayable,
-                    // then renew the master token.
-                    if (masterToken.isRenewable(null) || masterToken.isExpired(null) || requestHeader.isNonReplayable()) {
+                    // newest master token, then renew the master token.
+                    if (masterToken.isRenewable(null) || masterToken.isExpired(null)) {
                         issueMasterToken(ctx, keyRequestData, masterToken, null, callback);
                     } else {
                         var factory = ctx.getTokenFactory();

--- a/src/main/javascript/msg/MessageHeader.js
+++ b/src/main/javascript/msg/MessageHeader.js
@@ -39,7 +39,6 @@
  *   "timestamp" : "int64(0,2^53^)",
  *   "messageid" : "int64(0,2^53^)",
  *   "nonreplayableid" : "int64(0,2^53^)",
- *   "nonreplayable" : "boolean",
  *   "renewable" : "boolean",
  *   "handshake" : "boolean",
  *   "capabilities" : capabilities,
@@ -58,7 +57,6 @@
  * <li>{@code timestamp} is the sender time when the header is created in seconds since the UNIX epoch</li>
  * <li>{@code messageid} is the message ID</li>
  * <li>{@code nonreplayableid} is the non-replayable ID</li>
- * <li>{@code nonreplayable} indicates if the message is nonreplayable</li>
  * <li>{@code renewable} indicates if the master token and user ID are renewable</li>
  * <li>{@code handshake} indicates a handshake message</li>
  * <li>{@code capabilities} lists the sender's message capabilities</li>
@@ -115,12 +113,6 @@ var MessageHeader$HeaderPeerData;
      * @type {string}
      */
     var KEY_NON_REPLAYABLE_ID = "nonreplayableid";
-    /**
-     * JSON key non-replayable flag.
-     * @const
-     * @type {string}
-     */
-    var KEY_NON_REPLAYABLE = "nonreplayable";
     /**
      * JSON key renewable flag.
      * @const
@@ -272,10 +264,9 @@ var MessageHeader$HeaderPeerData;
      * @param {Uint8Array} plaintext decrypted header data.
      * @param {Uint8Array} signature raw signature.
      * @param {boolean} verified true if the headerdata was verified.
-     * @param {number} legacy non-replayable boolean.
      * @constructor
      */
-    function CreationData(user, sender, timestampSeconds, messageCryptoContext, headerdata, plaintext, signature, verified, nonReplayable) {
+    function CreationData(user, sender, timestampSeconds, messageCryptoContext, headerdata, plaintext, signature, verified) {
         this.user = user;
         this.sender = sender;
         this.timestampSeconds = timestampSeconds;
@@ -284,7 +275,6 @@ var MessageHeader$HeaderPeerData;
         this.plaintext = plaintext;
         this.signature = signature;
         this.verified = verified;
-        this.nonReplayable = nonReplayable;
     };
 
     /**
@@ -308,7 +298,6 @@ var MessageHeader$HeaderPeerData;
      * @param {UserIdToken} peerUserIdToken
      * @param {Array.<ServiceToken>} peerServiceTokens
      * @param {number} nonReplayableId
-     * @param {boolean} nonReplayable
      * @param {boolean} renewable
      * @param {MessageCapabilities} capabilities
      * @param {Uint8Array} headerdata
@@ -322,7 +311,7 @@ var MessageHeader$HeaderPeerData;
             keyRequestData, keyResponseData,
             userAuthData, userIdToken, serviceTokens,
             peerMasterToken, peerUserIdToken, peerServiceTokens,
-            nonReplayableId, nonReplayable, renewable, handshake, capabilities,
+            nonReplayableId, renewable, handshake, capabilities,
             headerdata, plaintext, signature, verified)
     {
         // The properties.
@@ -392,7 +381,6 @@ var MessageHeader$HeaderPeerData;
             /** Message capabilities. */
             messageCapabilities: { value: capabilities, writable: false, configurable: false },
             // Private properties.
-            nonReplayable: { value: nonReplayable, writable: false, enumerable: false, configurable: false },
             renewable: { value: renewable, writable: false, enumerable: false, configurable: false },
             handshake: { value: handshake, writable: false, enumerable: false, configurable: false },
             headerdata: { value: headerdata, writable: false, enumerable: false, configurable: false },
@@ -497,7 +485,6 @@ var MessageHeader$HeaderPeerData;
                 AsyncExecutor(callback, function() {
                     entityAuthData = (!masterToken) ? entityAuthData : null;
                     var nonReplayableId = headerData.nonReplayableId;
-                    var nonReplayable = false;
                     var renewable = headerData.renewable;
                     var handshake = headerData.handshake;
                     var capabilities = headerData.capabilities;
@@ -580,7 +567,6 @@ var MessageHeader$HeaderPeerData;
                         if (recipient) headerJO[KEY_RECIPIENT] = recipient;
                         headerJO[KEY_TIMESTAMP] = timestampSeconds;
                         headerJO[KEY_MESSAGE_ID] = messageId;
-                        headerJO[KEY_NON_REPLAYABLE] = nonReplayable;
                         if (typeof nonReplayableId === 'number') headerJO[KEY_NON_REPLAYABLE_ID] = nonReplayableId;
                         headerJO[KEY_RENEWABLE] = renewable;
                         headerJO[KEY_HANDSHAKE] = handshake;
@@ -622,7 +608,7 @@ var MessageHeader$HeaderPeerData;
                                                     keyRequestData, keyResponseData,
                                                     userAuthData, userIdToken, serviceTokens,
                                                     peerMasterToken, peerUserIdToken, peerServiceTokens,
-                                                    nonReplayableId, nonReplayable, renewable, handshake, capabilities,
+                                                    nonReplayableId, renewable, handshake, capabilities,
                                                     headerdata, plaintext, signature, true);
                                                 Object.defineProperties(this, props);
                                                 return this;
@@ -664,14 +650,13 @@ var MessageHeader$HeaderPeerData;
                         var plaintext = creationData.plaintext;
                         var signature = creationData.signature;
                         var verified = creationData.verified;
-                        nonReplayable = creationData.nonReplayable;
-
+                        
                         var props = buildProperties(ctx, messageCryptoContext, user, entityAuthData,
                             masterToken, sender, recipient, timestampSeconds, messageId,
                             keyRequestData, keyResponseData,
                             userAuthData, userIdToken, serviceTokens,
                             peerMasterToken, peerUserIdToken, peerServiceTokens,
-                            nonReplayableId, nonReplayable, renewable, handshake, capabilities,
+                            nonReplayableId, renewable, handshake, capabilities,
                             headerdata, plaintext, signature, verified);
                         Object.defineProperties(this, props);
                         return this;
@@ -712,13 +697,6 @@ var MessageHeader$HeaderPeerData;
          */
         isEncrypting: function isEncrypting() {
             return this.masterToken || this.entityAuthenticationData.scheme.encrypts;
-        },
-
-        /**
-         * @return {boolean} true if the message non-replayable flag is set.
-         */
-        isNonReplayable: function isNonReplayable() {
-            return this.nonReplayable;
         },
 
         /**
@@ -1234,15 +1212,13 @@ var MessageHeader$HeaderPeerData;
                                                         result: function(serviceTokens) {
                                                             AsyncExecutor(callback, function() {
                                                                 var nonReplayableId = (headerdataJO[KEY_NON_REPLAYABLE_ID] !== undefined) ? parseInt(headerdataJO[KEY_NON_REPLAYABLE_ID]) : null;
-                                                                var nonReplayable = (headerdataJO[KEY_NON_REPLAYABLE] !== undefined) ? headerdataJO[KEY_NON_REPLAYABLE] : false;
                                                                 var renewable = headerdataJO[KEY_RENEWABLE];
                                                                 var handshake = (headerdataJO[KEY_HANDSHAKE] !== undefined) ? headerdataJO[KEY_HANDSHAKE] : false;
 
                                                                 // Verify values.
                                                                 if (nonReplayableId != nonReplayableId ||
-                                                                        typeof nonReplayable !== 'boolean' ||
-                                                                        typeof renewable !== 'boolean' ||
-                                                                        typeof handshake !== 'boolean')
+                                                                    typeof renewable !== 'boolean' ||
+                                                                    typeof handshake !== 'boolean')
                                                                 {
                                                                     throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson);
                                                                 }
@@ -1274,7 +1250,7 @@ var MessageHeader$HeaderPeerData;
                                                                                             keyRequestData, keyResponseData, userAuthData, userIdToken,
                                                                                             serviceTokens);
                                                                                     var headerPeerData = new HeaderPeerData(peerMasterToken, peerUserIdToken, peerServiceTokens);
-                                                                                    var creationData = new CreationData(user, sender, timestampSeconds, messageCryptoContext, headerdata, plaintext, signature, verified, nonReplayable);
+                                                                                    var creationData = new CreationData(user, sender, timestampSeconds, messageCryptoContext, headerdata, plaintext, signature, verified);
                                                                                     new MessageHeader(ctx, entityAuthData, masterToken, headerData, headerPeerData, creationData, callback);
                                                                                 });
                                                                             },

--- a/src/main/javascript/msg/MslControl.js
+++ b/src/main/javascript/msg/MslControl.js
@@ -1211,9 +1211,21 @@ var MslControl$MslChannel;
                         this.getNewestMasterToken(service, ctx, timeout, {
                             result: function(tokenTicket) {
                                 InterruptibleExecutor(callback, function() {
+                                    var masterToken = (tokenTicket && tokenTicket.masterToken);
+                                    var userIdToken;
+                                    if (masterToken) {
+                                        // Grab the user ID token for the message's user. It may not be bound
+                                        // to the newest master token if the newest master token invalidated
+                                        // it.
+                                        var userId = msgCtx.getUserId();
+                                        var store = ctx.getMslStore();
+                                        var storedUserIdToken = (userId) ? store.getUserIdToken(userId) : null;
+                                        userIdToken = (storedUserIdToken && storedUserIdToken.isBoundTo(masterToken)) ? storedUserIdToken : null;
+                                    } else {
+                                        userIdToken = null;
+                                    }
+                                    
                                     // Resend the request.
-                                    var masterToken = tokenTicket && tokenTicket.masterToken;
-                                    var userIdToken = requestHeader.userIdToken;
                                     var messageId = MessageBuilder$incrementMessageId(errorHeader.messageId);
                                     var resendMsgCtx = new ResendMessageContext(payloads, msgCtx);
                                     var recipient = resendMsgCtx.getRecipient();
@@ -1252,23 +1264,29 @@ var MslControl$MslChannel;
                     }
                     case MslConstants$ResponseCode.REPLAYED:
                     {
-                        // TODO: The master token-oriented logic remains to support the
-                        // legacy non-replayable flag implementation. It can be removed
-                        // once support for the flag is removed.
+                        // This error will be received if the previous request's non-
+                        // replayable ID is not accepted by the remote entity. In this
+                        // situation simply try again.
                         //
-                        // This error will only be received if the previous request's
-                        // master token has an old sequence number. If a new master
-                        // token was issued then we know that this old master token's
-                        // renewal window has already been entered and we should get a
-                        // new master token by sending a renewable message.
-
                         // Grab the newest master token and its read lock.
                         this.getNewestMasterToken(service, ctx, timeout, {
                             result: function(tokenTicket) {
                                 InterruptibleExecutor(callback, function() {
+                                    var masterToken = (tokenTicket && tokenTicket.masterToken);
+                                    var userIdToken;
+                                    if (masterToken) {
+                                        // Grab the user ID token for the message's user. It may not be bound
+                                        // to the newest master token if the newest master token invalidated
+                                        // it.
+                                        var userId = msgCtx.getUserId();
+                                        var store = ctx.getMslStore();
+                                        var storedUserIdToken = (userId) ? store.getUserIdToken(userId) : null;
+                                        userIdToken = (storedUserIdToken && storedUserIdToken.isBoundTo(masterToken)) ? storedUserIdToken : null;
+                                    } else {
+                                        userIdToken = null;
+                                    }
+                                    
                                     // Resend the request.
-                                    var masterToken = tokenTicket && tokenTicket.masterToken;
-                                    var userIdToken = requestHeader.userIdToken;
                                     var messageId = MessageBuilder$incrementMessageId(errorHeader.messageId);
                                     var resendMsgCtx = new ResendMessageContext(payloads, msgCtx);
                                     var recipient = resendMsgCtx.getRecipient();
@@ -1280,28 +1298,10 @@ var MslControl$MslChannel;
                                                     var peerUserIdToken = requestHeader.peerUserIdToken;
                                                     requestBuilder.setPeerAuthTokens(peerMasterToken, peerUserIdToken);
                                                 }
-                                                // If the newest master token is equal to the previous
-                                                // request's master token then mark this message as renewable
-                                                // and replayable.
-                                                //
-                                                // During renewal lock acquisition we will either block until
-                                                // we acquire the renewal lock or receive a master token.
-                                                //
-                                                // During send the application data will be delayed because the
-                                                // message is replayable but the message context indicates the
-                                                // application data must sent in a non-replayable message.
-                                                //
-                                                // Check for a missing master token in case the error is incorrect
-                                                var requestMasterToken = requestHeader.masterToken;
-                                                if (!requestMasterToken || requestMasterToken.equals(masterToken)) {
-                                                    requestBuilder.setRenewable(true);
-                                                    requestBuilder.setNonReplayable(false);
-                                                }
-                                                // Otherwise mark it as replayable as dictated by the message
-                                                // context.
-                                                else {
-                                                    requestBuilder.setNonReplayable(resendMsgCtx.isNonReplayable());
-                                                }
+                                                
+                                                // Mark the message as replayable or not as dictated by the
+                                                // message context.
+                                                requestBuilder.setNonReplayable(resendMsgCtx.isNonReplayable());
                                                 return {
                                                     errorResult: new ErrorResult(requestBuilder, resendMsgCtx),
                                                     tokenTicket: tokenTicket

--- a/src/test/java/com/netflix/msl/msg/MessageBuilderSuite.java
+++ b/src/test/java/com/netflix/msl/msg/MessageBuilderSuite.java
@@ -262,8 +262,8 @@ public class MessageBuilderSuite {
             assertTrue(builder.willIntegrityProtectPayloads());
             final MessageHeader header = builder.getHeader();
             assertNotNull(header);
-            
-            assertFalse(header.isNonReplayable());
+
+            assertNull(header.getNonReplayableId());
             assertFalse(header.isRenewable());
             assertFalse(header.isHandshake());
             assertNotNull(header.getCryptoContext());
@@ -292,7 +292,7 @@ public class MessageBuilderSuite {
             final MessageHeader header = builder.getHeader();
             assertNotNull(header);
             
-            assertFalse(header.isNonReplayable());
+            assertNull(header.getNonReplayableId());
             assertFalse(header.isRenewable());
             assertFalse(header.isHandshake());
             assertNotNull(header.getCryptoContext());
@@ -330,8 +330,8 @@ public class MessageBuilderSuite {
             
             final MessageHeader header = builder.getHeader();
             assertNotNull(header);
-            
-            assertFalse(header.isNonReplayable());
+
+            assertNotNull(header.getNonReplayableId());
             assertTrue(header.isRenewable());
             assertFalse(header.isHandshake());
             assertNotNull(header.getCryptoContext());
@@ -692,8 +692,8 @@ public class MessageBuilderSuite {
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             final MessageHeader header = builder.getHeader();
-            
-            assertFalse(header.isNonReplayable());
+
+            assertNull(header.getNonReplayableId());
             assertFalse(header.isRenewable());
             assertNotNull(header.getCryptoContext());
             assertEquals(trustedNetCtx.getEntityAuthenticationData(null), header.getEntityAuthenticationData());
@@ -721,8 +721,8 @@ public class MessageBuilderSuite {
             builder.removeKeyRequestData(keyRequestData);
             builder.removeKeyRequestData(keyRequestData);
             final MessageHeader header = builder.getHeader();
-            
-            assertFalse(header.isNonReplayable());
+
+            assertNull(header.getNonReplayableId());
             assertFalse(header.isRenewable());
             assertNotNull(header.getCryptoContext());
             assertEquals(trustedNetCtx.getEntityAuthenticationData(null), header.getEntityAuthenticationData());
@@ -1310,7 +1310,7 @@ public class MessageBuilderSuite {
             
             final MessageHeader response = responseBuilder.getHeader();
             assertNotNull(response);
-            assertFalse(response.isNonReplayable());
+            assertNull(response.getNonReplayableId());
             assertFalse(response.isRenewable());
             assertFalse(response.isHandshake());
             assertNotNull(response.getCryptoContext());
@@ -1351,7 +1351,7 @@ public class MessageBuilderSuite {
             assertEquals(peerServiceTokens, responseBuilder.getServiceTokens());
             final MessageHeader response = responseBuilder.getHeader();
             assertNotNull(response);
-            assertFalse(response.isNonReplayable());
+            assertNull(response.getNonReplayableId());
             assertFalse(response.isRenewable());
             assertFalse(response.isHandshake());
             assertNotNull(response.getCryptoContext());
@@ -1386,7 +1386,7 @@ public class MessageBuilderSuite {
             
             final MessageHeader response = responseBuilder.getHeader();
             assertNotNull(response);
-            assertFalse(response.isNonReplayable());
+            assertNull(response.getNonReplayableId());
             assertFalse(response.isRenewable());
             assertFalse(response.isHandshake());
             assertNotNull(response.getCryptoContext());
@@ -1426,7 +1426,7 @@ public class MessageBuilderSuite {
             assertEquals(peerServiceTokens, responseBuilder.getServiceTokens());
             final MessageHeader response = responseBuilder.getHeader();
             assertNotNull(response);
-            assertFalse(response.isNonReplayable());
+            assertNull(response.getNonReplayableId());
             assertFalse(response.isRenewable());
             assertFalse(response.isHandshake());
             assertNotNull(response.getCryptoContext());

--- a/src/test/javascript/msg/MessageBuilderSuite.js
+++ b/src/test/javascript/msg/MessageBuilderSuite.js
@@ -247,7 +247,7 @@ describe("MessageBuilder", function() {
 			runs(function() {
 				expect(header).not.toBeNull();
 	
-				expect(header.nonReplayableId).toBeNull();
+				expect(header.nonReplayableId).toBeFalsy();
 				expect(header.isRenewable()).toBeFalsy();
 				expect(header.isHandshake()).toBeFalsy();
 				expect(header.cryptoContext).not.toBeNull();
@@ -295,7 +295,7 @@ describe("MessageBuilder", function() {
 			runs(function() {
 				expect(header).not.toBeNull();
 
-				expect(header.nonReplayableId).toBeNull();
+				expect(header.nonReplayableId).toBeFalsy();
 				expect(header.isRenewable()).toBeFalsy();
 				expect(header.isHandshake()).toBeFalsy();
 				expect(header.cryptoContext).not.toBeNull();
@@ -360,7 +360,7 @@ describe("MessageBuilder", function() {
 			runs(function() {
 				expect(header).not.toBeNull();
 	
-				expect(header.isNonReplayable()).toBeFalsy();
+				expect(header.nonReplayableId).toBeTruthy();
 				expect(header.isRenewable()).toBeTruthy();
 				expect(header.cryptoContext).not.toBeNull();
 				expect(header.entityAuthenticationData).toBeNull();
@@ -533,7 +533,7 @@ describe("MessageBuilder", function() {
                 builder.setNonReplayable(true);
                 builder.setRenewable(false);
                 builder.setHandshake(true);
-                expect(builder.isNonReplayable()).toBeFalsy();
+                expect(builder.nonReplayableId).toBeFalsy();
                 expect(builder.isRenewable()).toBeTruthy();
                 expect(builder.isHandshake()).toBeTruthy();
                 builder.getHeader({
@@ -555,7 +555,7 @@ describe("MessageBuilder", function() {
                 expect(header.masterToken).toBeNull();
                 expect(header.messageId).toBeGreaterThan(0);
                 expect(header.messageCapabilities).toEqual(trustedNetCtx.getMessageCapabilities());
-                expect(header.nonReplayableId).toBeNull();
+                expect(header.nonReplayableId).toBeFalsy();
                 expect(header.peerMasterToken).toBeNull();
                 expect(header.peerServiceTokens.length).toEqual(0);
                 expect(header.peerUserIdToken).toBeNull();
@@ -581,7 +581,7 @@ describe("MessageBuilder", function() {
                 builder.setNonReplayable(true);
                 builder.setRenewable(false);
                 builder.setHandshake(true);
-                expect(builder.isNonReplayable()).toBeFalsy();
+                expect(builder.nonReplayableId).toBeFalsy();
                 expect(builder.isRenewable()).toBeTruthy();
                 expect(builder.isHandshake()).toBeTruthy();
                 
@@ -603,7 +603,7 @@ describe("MessageBuilder", function() {
                 expect(header.masterToken).toBeNull();
                 expect(header.messageId).toBeGreaterThan(0);
                 expect(header.messageCapabilities).toEqual(p2pCtx.getMessageCapabilities());
-                expect(header.nonReplayableId).toBeNull();
+                expect(header.nonReplayableId).toBeFalsy();
                 expect(header.peerMasterToken).toBeNull();
                 expect(header.peerServiceTokens.length).toEqual(0);
                 expect(header.peerUserIdToken).toBeNull();
@@ -991,7 +991,7 @@ describe("MessageBuilder", function() {
 			waitsFor(function() { return header; }, "header not received", 100);
 
 			runs(function() {
-				expect(header.nonReplayableId).toBeNull();
+				expect(header.nonReplayableId).toBeFalsy();
 				expect(header.isRenewable()).toBeFalsy();
 				expect(header.isHandshake()).toBeFalsy();
 				expect(header.cryptoContext).not.toBeNull();
@@ -1038,7 +1038,7 @@ describe("MessageBuilder", function() {
 			waitsFor(function() { return header; }, "header not received", 100);
 
 			runs(function() {
-				expect(header.nonReplayableId).toBeNull();
+				expect(header.nonReplayableId).toBeFalsy();
 				expect(header.isRenewable()).toBeFalsy();
 				expect(header.isHandshake()).toBeFalsy();
 				expect(header.cryptoContext).not.toBeNull();
@@ -2387,7 +2387,7 @@ describe("MessageBuilder", function() {
 			
 			runs(function() {
 				expect(response).not.toBeNull();
-				expect(response.isNonReplayable()).toBeFalsy();
+                expect(response.nonReplayableId).toBeFalsy();
 				expect(response.isRenewable()).toBeFalsy();
 				expect(response.isHandshake()).toBeFalsy();
 				expect(response.cryptoContext).not.toBeNull();
@@ -2475,7 +2475,7 @@ describe("MessageBuilder", function() {
 			waitsFor(function() { return response; }, "response not received", 100);
 			runs(function() {
 				expect(response).not.toBeNull();
-				expect(response.isNonReplayable()).toBeFalsy();
+                expect(response.nonReplayableId).toBeFalsy();
 				expect(response.isRenewable()).toBeFalsy();
                 expect(response.isHandshake()).toBeFalsy();
 				expect(response.cryptoContext).not.toBeNull();
@@ -2558,7 +2558,7 @@ describe("MessageBuilder", function() {
             
             runs(function() {
                 expect(response).not.toBeNull();
-                expect(response.isNonReplayable()).toBeFalsy();
+                expect(response.nonReplayableId).toBeFalsy();
                 expect(response.isRenewable()).toBeFalsy();
                 expect(response.isHandshake()).toBeFalsy();
                 expect(response.cryptoContext).not.toBeNull();
@@ -2649,7 +2649,7 @@ describe("MessageBuilder", function() {
             
             runs(function() {
                 expect(response).not.toBeNull();
-                expect(response.isNonReplayable()).toBeFalsy();
+                expect(response.nonReplayableId).toBeFalsy();
                 expect(response.isRenewable()).toBeFalsy();
                 expect(response.isHandshake()).toBeFalsy();
                 expect(response.cryptoContext).not.toBeNull();
@@ -2818,7 +2818,7 @@ describe("MessageBuilder", function() {
 			
 			runs(function() {
 				expect(response).not.toBeNull();
-				expect(response.nonReplayableId).toBeNull();
+				expect(response.nonReplayableId).toBeFalsy();
 				expect(response.isRenewable()).toBeFalsy();
                 expect(response.isHandshake()).toBeFalsy();
 				expect(response.cryptoContext).not.toBeNull();
@@ -2901,7 +2901,7 @@ describe("MessageBuilder", function() {
             
             runs(function() {
                 expect(response).not.toBeNull();
-                expect(response.nonReplayableId).toBeNull();
+                expect(response.nonReplayableId).toBeFalsy();
                 expect(response.isRenewable()).toBeTruthy();
                 expect(response.isHandshake()).toBeTruthy();
                 expect(response.cryptoContext).not.toBeNull();
@@ -2992,7 +2992,7 @@ describe("MessageBuilder", function() {
             waitsFor(function() { return response; }, "response not received", 100);
             runs(function() {
                 expect(response).not.toBeNull();
-                expect(response.nonReplayableId).toBeNull();
+                expect(response.nonReplayableId).toBeFalsy();
                 expect(response.isRenewable()).toBeTruthy();
                 expect(response.isHandshake()).toBeTruthy();
                 expect(response.cryptoContext).not.toBeNull();

--- a/src/test/javascript/msg/MessageHeaderTest.js
+++ b/src/test/javascript/msg/MessageHeaderTest.js
@@ -2054,7 +2054,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -2121,7 +2121,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -2187,7 +2187,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -2251,7 +2251,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -2317,7 +2317,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -2381,7 +2381,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -2656,7 +2656,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -3061,7 +3061,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -3163,7 +3163,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -3229,7 +3229,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);
@@ -3326,7 +3326,7 @@ describe("MessageHeader", function() {
             expect(header instanceof MessageHeader).toBeTruthy();
             var joMessageHeader = header;
     
-            expect(joMessageHeader.isNonReplayable()).toEqual(messageHeader.isNonReplayable());
+            expect(joMessageHeader.nonReplayableId).toEqual(messageHeader.nonReplayableId);
             expect(joMessageHeader.isRenewable()).toEqual(messageHeader.isRenewable());
             expect(messageHeader.cryptoContext).not.toBeNull();
             expect(joMessageHeader.entityAuthenticationData).toEqual(messageHeader.entityAuthenticationData);


### PR DESCRIPTION
Remove support for the old non-replayable logic based on renewing master tokens.
Remove the nonreplayable flag from message headers; they are neither sent nor parsed.