### PR TITLE
Move scheme lookup to the MslContext

### DIFF
--- a/src/examples/java/burp/msl/util/WiretapMslContext.java
+++ b/src/examples/java/burp/msl/util/WiretapMslContext.java
@@ -88,7 +88,7 @@ public class WiretapMslContext implements MslContext {
          * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
          */
         @Override
-        public int compare(KeyExchangeFactory a, KeyExchangeFactory b) {
+        public int compare(final KeyExchangeFactory a, final KeyExchangeFactory b) {
             final KeyExchangeScheme schemeA = a.getScheme();
             final KeyExchangeScheme schemeB = b.getScheme();
             final Integer priorityA = schemePriorities.get(schemeA);
@@ -197,11 +197,27 @@ public class WiretapMslContext implements MslContext {
     }
 
     /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getEntityAuthenticationScheme(java.lang.String)
+     */
+    @Override
+    public EntityAuthenticationScheme getEntityAuthenticationScheme(final String name) {
+        return EntityAuthenticationScheme.getScheme(name);
+    }
+
+    /* (non-Javadoc)
      * @see com.netflix.msl.util.MslContext#getEntityAuthenticationFactory(com.netflix.msl.entityauth.EntityAuthenticationScheme)
      */
     @Override
     public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme) {
         return entityAuthFactories.get(scheme);
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getUserAuthenticationScheme(java.lang.String)
+     */
+    @Override
+    public UserAuthenticationScheme getUserAuthenticationScheme(final String name) {
+        return UserAuthenticationScheme.getScheme(name);
     }
 
     /* (non-Javadoc)
@@ -218,6 +234,14 @@ public class WiretapMslContext implements MslContext {
     @Override
     public TokenFactory getTokenFactory() {
         return tokenFactory;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getKeyExchangeScheme(java.lang.String)
+     */
+    @Override
+    public KeyExchangeScheme getKeyExchangeScheme(final String name) {
+        return KeyExchangeScheme.getScheme(name);
     }
 
     /* (non-Javadoc)

--- a/src/examples/java/kancolle/util/KanColleMslContext.java
+++ b/src/examples/java/kancolle/util/KanColleMslContext.java
@@ -128,11 +128,27 @@ public abstract class KanColleMslContext implements MslContext {
     }
 
     /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getEntityAuthenticationScheme(java.lang.String)
+     */
+    @Override
+    public EntityAuthenticationScheme getEntityAuthenticationScheme(final String name) {
+        return EntityAuthenticationScheme.getScheme(name);
+    }
+
+    /* (non-Javadoc)
      * @see com.netflix.msl.util.MslContext#getEntityAuthenticationFactory(com.netflix.msl.entityauth.EntityAuthenticationScheme)
      */
     @Override
     public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme) {
         return entityAuthFactories.get(scheme);
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getUserAuthenticationScheme(java.lang.String)
+     */
+    @Override
+    public UserAuthenticationScheme getUserAuthenticationScheme(final String name) {
+        return UserAuthenticationScheme.getScheme(name);
     }
 
     /* (non-Javadoc)
@@ -149,6 +165,14 @@ public abstract class KanColleMslContext implements MslContext {
     @Override
     public TokenFactory getTokenFactory() {
         return tokenFactory;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getKeyExchangeScheme(java.lang.String)
+     */
+    @Override
+    public KeyExchangeScheme getKeyExchangeScheme(final String name) {
+        return KeyExchangeScheme.getScheme(name);
     }
 
     /* (non-Javadoc)

--- a/src/examples/java/server/util/SimpleMslContext.java
+++ b/src/examples/java/server/util/SimpleMslContext.java
@@ -103,7 +103,7 @@ public class SimpleMslContext implements MslContext {
          * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
          */
         @Override
-        public int compare(KeyExchangeFactory a, KeyExchangeFactory b) {
+        public int compare(final KeyExchangeFactory a, final KeyExchangeFactory b) {
             final KeyExchangeScheme schemeA = a.getScheme();
             final KeyExchangeScheme schemeB = b.getScheme();
             final Integer priorityA = schemePriorities.get(schemeA);
@@ -199,6 +199,14 @@ public class SimpleMslContext implements MslContext {
     public ICryptoContext getMslCryptoContext() throws MslCryptoException {
         return mslCryptoContext;
     }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getEntityAuthenticationScheme(java.lang.String)
+     */
+    @Override
+    public EntityAuthenticationScheme getEntityAuthenticationScheme(final String name) {
+        return EntityAuthenticationScheme.getScheme(name);
+    }
 
     /* (non-Javadoc)
      * @see com.netflix.msl.util.MslContext#getEntityAuthenticationFactory(com.netflix.msl.entityauth.EntityAuthenticationScheme)
@@ -210,6 +218,14 @@ public class SimpleMslContext implements MslContext {
                 return factory;
         }
         return null;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getUserAuthenticationScheme(java.lang.String)
+     */
+    @Override
+    public UserAuthenticationScheme getUserAuthenticationScheme(final String name) {
+        return UserAuthenticationScheme.getScheme(name);
     }
 
     /* (non-Javadoc)
@@ -228,6 +244,14 @@ public class SimpleMslContext implements MslContext {
     @Override
     public TokenFactory getTokenFactory() {
         return tokenFactory;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.MslContext#getKeyExchangeScheme(java.lang.String)
+     */
+    @Override
+    public KeyExchangeScheme getKeyExchangeScheme(final String name) {
+        return KeyExchangeScheme.getScheme(name);
     }
 
     /* (non-Javadoc)

--- a/src/examples/javascript/client/util/SimpleMslContext.js
+++ b/src/examples/javascript/client/util/SimpleMslContext.js
@@ -97,12 +97,22 @@ var SimpleMslContext;
         getMslCryptoContext: function getMslCryptoContext() {
             return this._mslCryptoContext;
         },
+        
+        /** @inheritDoc */
+        getEntityAuthenticationScheme: function getEntityAuthenticationScheme(name) {
+            return EntityAuthenticationScheme$getScheme(name);
+        },
     
         /** @inheritDoc */
         getEntityAuthenticationFactory: function getEntityAuthenticationFactory(scheme) {
             if (this._entityAuthFactories[scheme])
                 return this._entityAuthFactories[scheme];
             return null;
+        },
+        
+        /** @inheritDoc */
+        getUserAuthenticationScheme: function getUserAuthenticationScheme(name) {
+            return UserAuthenticationScheme$getScheme(name);
         },
     
         /** @inheritDoc */
@@ -113,6 +123,11 @@ var SimpleMslContext;
         /** @inheritDoc */
         getTokenFactory: function getTokenFactory() {
             return _tokenFactory;
+        },
+        
+        /** @inheritDoc */
+        getKeyExchangeScheme: function getKeyExchangeScheme(name) {
+            return KeyExchangeScheme$getScheme(name);
         },
     
         /** @inheritDoc */

--- a/src/main/java/com/netflix/msl/entityauth/EntityAuthenticationData.java
+++ b/src/main/java/com/netflix/msl/entityauth/EntityAuthenticationData.java
@@ -21,8 +21,8 @@ import org.json.JSONString;
 import org.json.JSONStringer;
 
 import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEntityAuthException;
 import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslEntityAuthException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.MslInternalException;
 import com.netflix.msl.util.MslContext;
@@ -81,7 +81,7 @@ public abstract class EntityAuthenticationData implements JSONString {
         try {
             // Identify the concrete subclass from the authentication scheme.
             final String schemeName = entityAuthJO.getString(KEY_SCHEME);
-            final EntityAuthenticationScheme scheme = EntityAuthenticationScheme.getScheme(schemeName);
+            final EntityAuthenticationScheme scheme = ctx.getEntityAuthenticationScheme(schemeName);
             if (scheme == null)
                 throw new MslEntityAuthException(MslError.UNIDENTIFIED_ENTITYAUTH_SCHEME, schemeName);
             final JSONObject authdata = entityAuthJO.getJSONObject(KEY_AUTHDATA);

--- a/src/main/java/com/netflix/msl/keyx/KeyRequestData.java
+++ b/src/main/java/com/netflix/msl/keyx/KeyRequestData.java
@@ -84,7 +84,7 @@ public abstract class KeyRequestData implements JSONString {
         try {
             // Pull the key data.
             final String schemeName = keyRequestDataJO.getString(KEY_SCHEME);
-            final KeyExchangeScheme scheme = KeyExchangeScheme.getScheme(schemeName);
+            final KeyExchangeScheme scheme = ctx.getKeyExchangeScheme(schemeName);
             if (scheme == null)
                 throw new MslKeyExchangeException(MslError.UNIDENTIFIED_KEYX_SCHEME, schemeName);
             final JSONObject keyData = keyRequestDataJO.getJSONObject(KEY_KEYDATA);

--- a/src/main/java/com/netflix/msl/keyx/KeyResponseData.java
+++ b/src/main/java/com/netflix/msl/keyx/KeyResponseData.java
@@ -92,7 +92,7 @@ public abstract class KeyResponseData implements JSONString {
             // Pull the key data.
             final MasterToken masterToken = new MasterToken(ctx, keyResponseDataJO.getJSONObject(KEY_MASTER_TOKEN));
             final String schemeName = keyResponseDataJO.getString(KEY_SCHEME);
-            final KeyExchangeScheme scheme = KeyExchangeScheme.getScheme(schemeName);
+            final KeyExchangeScheme scheme = ctx.getKeyExchangeScheme(schemeName);
             if (scheme == null)
                 throw new MslKeyExchangeException(MslError.UNIDENTIFIED_KEYX_SCHEME, schemeName);
             final JSONObject keyData = keyResponseDataJO.getJSONObject(KEY_KEYDATA);

--- a/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -373,6 +373,14 @@ public class MslControl {
         public ICryptoContext getMslCryptoContext() throws MslCryptoException {
             return new NullCryptoContext();
         }
+        
+        /* (non-Javadoc)
+         * @see com.netflix.msl.util.MslContext#getEntityAuthenticationScheme(java.lang.String)
+         */
+        @Override
+        public EntityAuthenticationScheme getEntityAuthenticationScheme(final String name) {
+            return EntityAuthenticationScheme.getScheme(name);
+        }
 
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getEntityAuthenticationFactory(com.netflix.msl.entityauth.EntityAuthenticationScheme)
@@ -380,6 +388,14 @@ public class MslControl {
         @Override
         public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme) {
             return null;
+        }
+        
+        /* (non-Javadoc)
+         * @see com.netflix.msl.util.MslContext#getUserAuthenticationScheme(java.lang.String)
+         */
+        @Override
+        public UserAuthenticationScheme getUserAuthenticationScheme(final String name) {
+            return UserAuthenticationScheme.getScheme(name);
         }
 
         /* (non-Javadoc)
@@ -396,6 +412,14 @@ public class MslControl {
         @Override
         public TokenFactory getTokenFactory() {
             throw new MslInternalException("Dummy token factory should never actually get used.");
+        }
+        
+        /* (non-Javadoc)
+         * @see com.netflix.msl.util.MslContext#getKeyExchangeScheme(java.lang.String)
+         */
+        @Override
+        public KeyExchangeScheme getKeyExchangeScheme(final String name) {
+            return KeyExchangeScheme.getScheme(name);
         }
 
         /* (non-Javadoc)
@@ -2815,7 +2839,7 @@ public class MslControl {
         /** Request message input stream. */
         private final MessageInputStream request;
         /** Remote entity output stream. */
-        private OutputStream out;
+        private final OutputStream out;
         
         /**
          * Create a new error service.
@@ -2934,7 +2958,7 @@ public class MslControl {
             }
 
             @Override
-            public synchronized void mark(int readlimit) {
+            public synchronized void mark(final int readlimit) {
             }
 
             @Override
@@ -2950,14 +2974,14 @@ public class MslControl {
             }
 
             @Override
-            public int read(byte[] b, int off, int len) throws IOException {
+            public int read(final byte[] b, final int off, final int len) throws IOException {
                 if (in == null)
                     in = conn.getInputStream();
                 return super.read(b, off, len);
             }
 
             @Override
-            public int read(byte[] b) throws IOException {
+            public int read(final byte[] b) throws IOException {
                 if (in == null)
                     in = conn.getInputStream();
                 return super.read(b);
@@ -2971,7 +2995,7 @@ public class MslControl {
             }
 
             @Override
-            public long skip(long n) throws IOException {
+            public long skip(final long n) throws IOException {
                 if (in == null)
                     in = conn.getInputStream();
                 return super.skip(n);

--- a/src/main/java/com/netflix/msl/userauth/UserAuthenticationData.java
+++ b/src/main/java/com/netflix/msl/userauth/UserAuthenticationData.java
@@ -70,7 +70,7 @@ public abstract class UserAuthenticationData implements JSONString {
         try {
             // Pull the scheme.
             final String schemeName = userAuthJO.getString(KEY_SCHEME);
-            final UserAuthenticationScheme scheme = UserAuthenticationScheme.getScheme(schemeName);
+            final UserAuthenticationScheme scheme = ctx.getUserAuthenticationScheme(schemeName);
             if (scheme == null)
                 throw new MslUserAuthException(MslError.UNIDENTIFIED_USERAUTH_SCHEME, schemeName);
             

--- a/src/main/java/com/netflix/msl/util/MslContext.java
+++ b/src/main/java/com/netflix/msl/util/MslContext.java
@@ -166,6 +166,16 @@ public interface MslContext {
      *         context.
      */
     public ICryptoContext getMslCryptoContext() throws MslCryptoException;
+    
+    /**
+     * <p>Returns the entity authentication scheme identified by the specified
+     * name or {@code null} if there is none.</p>
+     * 
+     * @param name the entity authentication scheme name.
+     * @return the scheme identified by the specified name or {@code null} if
+     *         there is none.
+     */
+    public EntityAuthenticationScheme getEntityAuthenticationScheme(final String name);
 
     /**
      * Returns the entity authentication factory for the specified scheme.
@@ -175,6 +185,16 @@ public interface MslContext {
      *         available.
      */
     public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme);
+
+    /**
+     * <p>Returns the user authentication scheme identified by the specified
+     * name or {@code null} if there is none.</p>
+     * 
+     * @param name the user authentication scheme name.
+     * @return the scheme identified by the specified name or {@code null} if
+     *         there is none.
+     */
+    public UserAuthenticationScheme getUserAuthenticationScheme(final String name);
 
     /**
      * Returns the user authentication factory for the specified scheme.
@@ -195,6 +215,16 @@ public interface MslContext {
      * @return the token factory.
      */
     public TokenFactory getTokenFactory();
+
+    /**
+     * <p>Returns the key exchange scheme identified by the specified name or
+     * {@code null} if there is none.</p>
+     * 
+     * @param name the key exchange scheme name.
+     * @return the scheme identified by the specified name or {@code null} if
+     *         there is none.
+     */
+    public KeyExchangeScheme getKeyExchangeScheme(final String name);
 
     /**
      * Returns the key exchange factory for the specified scheme.

--- a/src/main/javascript/entityauth/EntityAuthenticationData.js
+++ b/src/main/javascript/entityauth/EntityAuthenticationData.js
@@ -120,7 +120,7 @@ var EntityAuthenticationData$parse;
         }
 
         // Verify entity authentication scheme.
-        var scheme = EntityAuthenticationScheme$getScheme(schemeName);
+        var scheme = ctx.getEntityAuthenticationScheme(schemeName);
         if (!scheme)
             throw new MslEntityAuthException(MslError.UNIDENTIFIED_ENTITYAUTH_SCHEME, schemeName);
 

--- a/src/main/javascript/keyx/KeyRequestData.js
+++ b/src/main/javascript/keyx/KeyRequestData.js
@@ -135,7 +135,7 @@ var KeyRequestData$parse;
             }
 
             // Verify scheme.
-            var scheme = KeyExchangeScheme$getScheme(schemeName);
+            var scheme = ctx.getKeyExchangeScheme(schemeName);
             if (!scheme)
                 throw new MslKeyExchangeException(MslError.UNIDENTIFIED_KEYX_SCHEME, schemeName);
 

--- a/src/main/javascript/keyx/KeyResponseData.js
+++ b/src/main/javascript/keyx/KeyResponseData.js
@@ -148,7 +148,7 @@ var KeyResponseData$parse;
             }
 
             // Verify scheme.
-            var scheme = KeyExchangeScheme$getScheme(schemeName);
+            var scheme = ctx.getKeyExchangeScheme(schemeName);
             if (!scheme)
                 throw new MslKeyExchangeException(MslError.UNIDENTIFIED_KEYX_SCHEME, schemeName);
 

--- a/src/main/javascript/userauth/UserAuthenticationData.js
+++ b/src/main/javascript/userauth/UserAuthenticationData.js
@@ -131,7 +131,7 @@ var UserAuthenticationData$parse;
             }
 
             // Verify user authentication scheme.
-            var scheme = UserAuthenticationScheme$getScheme(schemeName);
+            var scheme = ctx.getUserAuthenticationScheme(schemeName);
             if (!scheme)
                 throw new MslUserAuthException(MslError.UNIDENTIFIED_USERAUTH_SCHEME, schemeName);
 

--- a/src/main/javascript/util/MslContext.js
+++ b/src/main/javascript/util/MslContext.js
@@ -129,6 +129,16 @@ var MslContext = util.Class.create({
     getMslCryptoContext: function() {},
 
     /**
+     * <p>Returns the entity authentication scheme identified by the specified
+     * name or {@code null} if there is none.</p>
+     * 
+     * @param {string} name the entity authentication scheme name.
+     * @return {EntityAuthenticationScheme} the scheme identified by the specified name or {@code null} if
+     *         there is none.
+     */
+    getEntityAuthenticationScheme: function(name) {},
+    
+    /**
      * Returns the entity authentication factory for the specified scheme.
      *
      * @param {EntityAuthenticationScheme} scheme the entity authentication scheme.
@@ -136,6 +146,16 @@ var MslContext = util.Class.create({
      *         available.
      */
     getEntityAuthenticationFactory: function(scheme) {},
+
+    /**
+     * <p>Returns the user authentication scheme identified by the specified
+     * name or {@code null} if there is none.</p>
+     * 
+     * @param {string} name the user authentication scheme name.
+     * @return {UserAuthenticationScheme} the scheme identified by the specified name or {@code null} if
+     *         there is none.
+     */
+    getUserAuthenticationScheme: function getUserAuthenticationScheme(name) {},
 
     /**
      * Returns the user authentication factory for the specified scheme.
@@ -156,6 +176,16 @@ var MslContext = util.Class.create({
      * @return {TokenFactory} the token factory.
      */
     getTokenFactory: function() {},
+
+    /**
+     * <p>Returns the key exchange scheme identified by the specified name or
+     * {@code null} if there is none.</p>
+     * 
+     * @param {string} name the key exchange scheme name.
+     * @return {KeyExchangeScheme} the scheme identified by the specified name or {@code null} if
+     *         there is none.
+     */
+    getKeyExchangeScheme: function getKeyExchangeScheme(name) {},
 
     /**
      * Returns the key exchange factory for the specified scheme.

--- a/src/test/java/com/netflix/msl/util/MockMslContext.java
+++ b/src/test/java/com/netflix/msl/util/MockMslContext.java
@@ -112,7 +112,7 @@ public class MockMslContext implements MslContext {
          * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
          */
         @Override
-        public int compare(KeyExchangeFactory a, KeyExchangeFactory b) {
+        public int compare(final KeyExchangeFactory a, final KeyExchangeFactory b) {
             final KeyExchangeScheme schemeA = a.getScheme();
             final KeyExchangeScheme schemeB = b.getScheme();
             final Integer priorityA = schemePriorities.get(schemeA);
@@ -241,10 +241,10 @@ public class MockMslContext implements MslContext {
     public ICryptoContext getMslCryptoContext() throws MslCryptoException {
         return mslCryptoContext;
     }
-
+    
     @Override
-    public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme) {
-        return entityAuthFactories.get(scheme);
+    public EntityAuthenticationScheme getEntityAuthenticationScheme(final String name) {
+        return EntityAuthenticationScheme.getScheme(name);
     }
 
     /**
@@ -268,8 +268,13 @@ public class MockMslContext implements MslContext {
     }
 
     @Override
-    public UserAuthenticationFactory getUserAuthenticationFactory(final UserAuthenticationScheme scheme) {
-        return userAuthFactories.get(scheme);
+    public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme) {
+        return entityAuthFactories.get(scheme);
+    }
+    
+    @Override
+    public UserAuthenticationScheme getUserAuthenticationScheme(final String name) {
+        return UserAuthenticationScheme.getScheme(name);
     }
 
     /**
@@ -292,6 +297,11 @@ public class MockMslContext implements MslContext {
         userAuthFactories.remove(scheme);
     }
 
+    @Override
+    public UserAuthenticationFactory getUserAuthenticationFactory(final UserAuthenticationScheme scheme) {
+        return userAuthFactories.get(scheme);
+    }
+
     /**
      * Sets the token factory.
      *
@@ -305,19 +315,10 @@ public class MockMslContext implements MslContext {
     public TokenFactory getTokenFactory() {
         return tokenFactory;
     }
-
+    
     @Override
-    public KeyExchangeFactory getKeyExchangeFactory(final KeyExchangeScheme scheme) {
-        for (final KeyExchangeFactory factory : keyxFactories) {
-            if (factory.getScheme().equals(scheme))
-                return factory;
-        }
-        return null;
-    }
-
-    @Override
-    public SortedSet<KeyExchangeFactory> getKeyExchangeFactories() {
-        return Collections.unmodifiableSortedSet(keyxFactories);
+    public KeyExchangeScheme getKeyExchangeScheme(final String name) {
+        return KeyExchangeScheme.getScheme(name);
     }
 
     /**
@@ -342,6 +343,20 @@ public class MockMslContext implements MslContext {
             if (factory.getScheme().equals(scheme))
                 factories.remove();
         }
+    }
+
+    @Override
+    public KeyExchangeFactory getKeyExchangeFactory(final KeyExchangeScheme scheme) {
+        for (final KeyExchangeFactory factory : keyxFactories) {
+            if (factory.getScheme().equals(scheme))
+                return factory;
+        }
+        return null;
+    }
+
+    @Override
+    public SortedSet<KeyExchangeFactory> getKeyExchangeFactories() {
+        return Collections.unmodifiableSortedSet(keyxFactories);
     }
 
     @Override

--- a/src/test/javascript/util/MockMslContext.js
+++ b/src/test/javascript/util/MockMslContext.js
@@ -233,6 +233,11 @@ var MockMslContext$create;
 		getMslCryptoContext: function getMslCryptoContext() {
 			return this._mslCryptoContext;
 		},
+        
+        /** @inheritDoc */
+		getEntityAuthenticationScheme: function getEntityAuthenticationScheme(name) {
+		    return EntityAuthenticationScheme$getScheme(name);
+		},
 
 		/**
 		 * Adds or replaces the entity authentication factory associated with the
@@ -257,6 +262,11 @@ var MockMslContext$create;
 		/** @inheritDoc */
 		getEntityAuthenticationFactory: function getEntityAuthenticationFactory(scheme) {
 			return this._entityAuthFactories[scheme.name];
+		},
+		
+		/** @inheritDoc */
+		getUserAuthenticationScheme: function getUserAuthenticationScheme(name) {
+		    return UserAuthenticationScheme$getScheme(name);
 		},
 
 		/**
@@ -306,6 +316,36 @@ var MockMslContext$create;
 		getDhParameterSpecs: function getDhParameterSpecs() {
 			return this._paramSpecs;
 		},
+		
+		/** @inheritDoc */
+		getKeyExchangeScheme: function getKeyExchangeScheme(name) {
+		    return KeyExchangeScheme$getScheme(name);
+		},
+
+        /**
+         * Adds a key exchange factory to the end of the preferred set.
+         * 
+         * @param {KeyExchangeFactory} factory key exchange factory.
+         */
+        addKeyExchangeFactory: function addKeyExchangeFactory(factory) {
+            this._keyxFactories.push(factory);
+        },
+
+        /**
+         * Removes all key exchange factories associated with the specified key
+         * exchange scheme.
+         * 
+         * @param {KeyExchangeScheme} scheme key exchange scheme.
+         */
+        removeKeyExchangeFactories: function removeKeyExchangeFactories(scheme) {
+            for (var i = 0; i < this._keyxFactories.length; ++i) {
+                var factory = this._keyxFactories[i];
+                if (factory.scheme == scheme) {
+                    this._keyxFactories.splice(i, 1);
+                    --i;
+                }
+            }
+        },
 
 		/** @inheritDoc */
 		getKeyExchangeFactory: function getKeyExchangeFactory(scheme) {
@@ -320,31 +360,6 @@ var MockMslContext$create;
 		/** @inheritDoc */
 		getKeyExchangeFactories: function getKeyExchangeFactories(scheme) {
 			return this._keyxFactories;
-		},
-
-		/**
-		 * Adds a key exchange factory to the end of the preferred set.
-		 * 
-		 * @param {KeyExchangeFactory} factory key exchange factory.
-		 */
-		addKeyExchangeFactory: function addKeyExchangeFactory(factory) {
-			this._keyxFactories.push(factory);
-		},
-
-		/**
-		 * Removes all key exchange factories associated with the specified key
-		 * exchange scheme.
-		 * 
-		 * @param {KeyExchangeScheme} scheme key exchange scheme.
-		 */
-		removeKeyExchangeFactories: function removeKeyExchangeFactories(scheme) {
-			for (var i = 0; i < this._keyxFactories.length; ++i) {
-				var factory = this._keyxFactories[i];
-				if (factory.scheme == scheme) {
-					this._keyxFactories.splice(i, 1);
-					--i;
-				}
-			}
 		},
 
 		/** @inheritDoc */


### PR DESCRIPTION
Add get*Scheme() functions to MslContext. This provides greater control to the MSL configuration and can support interesting behavior overrides and test setups.