### PR TITLE
Only populate MslControl.remoteClocks() for trusted clients and p2p entities.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -1739,9 +1739,10 @@ public class MslControl {
                     throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, sender);
             }
             
-            // Update the synchronized clock.
+            // Update the synchronized clock if we are a trusted network client
+            // (there is a request) or peer-to-peer entity.
             final Date timestamp = (responseHeader != null) ? responseHeader.getTimestamp() : errorHeader.getTimestamp();
-            if (timestamp != null) {
+            if (timestamp != null && (request != null || ctx.isPeerToPeer())) {
                 remoteClocks.putIfAbsent(ctx, new SynchronizedClock());
                 final SynchronizedClock clock = remoteClocks.get(ctx);
                 clock.update(ctx, timestamp);
@@ -3726,6 +3727,9 @@ public class MslControl {
      */
     private final ConcurrentHashMap<MasterToken,ReadWriteLock> masterTokenLocks = new ConcurrentHashMap<MasterToken,ReadWriteLock>();
     
-    /** Map of remote entity clocks by MSL context. */
+    /**
+     * Map of remote entity clocks by MSL context. This data is only relevant
+     * to trusted network clients and peer-to-peer entities.
+     */
     private final ConcurrentHashMap<MslContext,SynchronizedClock> remoteClocks = new ConcurrentHashMap<MslContext,SynchronizedClock>();
 }

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -604,7 +604,8 @@ var MslControl$MslChannel;
                  */
                 _masterTokenLocks: { value: {}, writable: false, enumerable: false, configurable: false },
                 /**
-                 * Map of remote entity clocks by MSL context.
+                 * Map of remote entity clocks by MSL context. This data is only relevant
+                 * to trusted network clients and peer-to-peer entities.
                  * @type {Array.<{ctx: MslContext, clock: SynchronizedClock}>}
                  */
                 _remoteClocks: { value: [], writable: false, enumerable: false, configurable: false },
@@ -1822,9 +1823,10 @@ var MslControl$MslChannel;
                                                             throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, sender);
                                                     }
                                                     
-                                                    // Update the synchronized clock.
+                                                    // Update the synchronized clock if we are a trusted network client
+                                                    // (there is a request) or peer-to-peer entity.
                                                     var timestamp = (responseHeader) ? responseHeader.timestamp : errorHeader.timestamp;
-                                                    if (timestamp) {
+                                                    if (timestamp && (request || ctx.isPeerToPeer())) {
                                                         var clock;
                                                         for (var i = 0; i < this._remoteClocks.length; ++i) {
                                                             var ctxClock = this._remoteClocks[i];


### PR DESCRIPTION
Related to #50.

Only populate the remoteClocks variable for trusted network clients and p2p entities. This avoids useless references to the MslContext in trusted network servers that will prevent garbage collection, which is particularly bad in the event a server is interacting with many clients.

This does not fix the situation where a MslContext is no longer viable and has been deleted external to the MslControl instance.