### PR TITLE
Ensure remote clock state is tied to MslContext lifetime.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -217,46 +217,43 @@ public class MslControl {
     }
     
     /**
-     * A clock synchronized against an external time.
+     * A map key based off a MSL context and master token pair.
      */
-    private static class SynchronizedClock {
-        /** Milliseconds per second. */
-        private static final long MILLISECONDS_PER_SECOND = 1000;
-        
+    private static class MslContextMasterTokenKey {
         /**
-         * Create a new synchronized clock. The clock is not synchronized until
-         * {@link #update(MslContext, Date)} is called.
-         */
-        public SynchronizedClock() {
-            offset = 0;
-        }
-        
-        /**
-         * Update the synchronized clock based on the remote entity time.
+         * Create a new MSL context and master token map key.
          * 
-         * @param ctx local entity MSL context.
-         * @param time remote entity time.
+         * @param ctx MSL context.
+         * @param masterToken master token.
          */
-        public void update(final MslContext ctx, final Date time) {
-            final long localSeconds = ctx.getTime() / MILLISECONDS_PER_SECOND;
-            final long remoteSeconds = time.getTime() / MILLISECONDS_PER_SECOND;
-            offset = remoteSeconds - localSeconds;
+        public MslContextMasterTokenKey(final MslContext ctx, final MasterToken masterToken) {
+            this.ctx = ctx;
+            this.masterToken = masterToken;
+        }
+
+        /* (non-Javadoc)
+         * @see java.lang.Object#hashCode()
+         */
+        @Override
+        public int hashCode() {
+            return this.ctx.hashCode() ^ this.masterToken.hashCode();
+        }
+
+        /* (non-Javadoc)
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
+        @Override
+        public boolean equals(final Object obj) {
+            if (obj == this) return true;
+            if (!(obj instanceof MslContextMasterTokenKey)) return false;
+            final MslContextMasterTokenKey that = (MslContextMasterTokenKey)obj;
+            return this.ctx.equals(that.ctx) && this.masterToken.equals(that.masterToken);
         }
         
-        /**
-         * Return the expected remote entity time.
-         * 
-         * @param ctx local entity MSL context.
-         * @return the expected remote entity time.
-         */
-        public Date getTime(final MslContext ctx) {
-            final long localSeconds = ctx.getTime() / MILLISECONDS_PER_SECOND;
-            final long remoteSeconds = localSeconds + offset;
-            return new Date(remoteSeconds * MILLISECONDS_PER_SECOND);
-        }
-        
-        /** Remote entity time offset from local time in seconds. */
-        private volatile long offset;
+        /** MSL context. */
+        private final MslContext ctx;
+        /** Master token. */
+        private final MasterToken masterToken;
     }
     
     /**
@@ -325,7 +322,7 @@ public class MslControl {
      * A dummy MSL context only used for our dummy
      * {@link MslControl#NULL_MASTER_TOKEN}.
      */
-    private static class DummyMslContext implements MslContext {
+    private static class DummyMslContext extends MslContext {
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getTime()
          */
@@ -839,8 +836,9 @@ public class MslControl {
             if (masterToken == null) return null;
 
             // Acquire the master token read lock, creating it if necessary.
+            final MslContextMasterTokenKey key = new MslContextMasterTokenKey(ctx, masterToken);
             final ReadWriteLock newLock = new ReentrantReadWriteLock();
-            final ReadWriteLock oldLock = masterTokenLocks.putIfAbsent(masterToken, newLock);
+            final ReadWriteLock oldLock = masterTokenLocks.putIfAbsent(key, newLock);
             final ReadWriteLock finalLock = (oldLock != null) ? oldLock : newLock;
             finalLock.readLock().lockInterruptibly();
 
@@ -857,7 +855,7 @@ public class MslControl {
             // lock (it may already be deleted). Then try again.
             finalLock.readLock().unlock();
             finalLock.writeLock().lockInterruptibly();
-            masterTokenLocks.remove(masterToken);
+            masterTokenLocks.remove(key);
             finalLock.writeLock().unlock();
         } while (true);
     }
@@ -880,8 +878,9 @@ public class MslControl {
         //
         // TODO it would be nice to do this on another thread to avoid delaying
         // the application.
+        final MslContextMasterTokenKey key = new MslContextMasterTokenKey(ctx, masterToken);
         final ReadWriteLock newLock = new ReentrantReadWriteLock();
-        final ReadWriteLock oldLock = masterTokenLocks.putIfAbsent(masterToken, newLock);
+        final ReadWriteLock oldLock = masterTokenLocks.putIfAbsent(key, newLock);
 
         // ReentrantReadWriteLock requires us to release the read lock if
         // we are holding it before acquiring the write lock. If there is
@@ -902,7 +901,7 @@ public class MslControl {
             // one should be using the deleted master token anymore; a new
             // master token would have been received before deleting the
             // old one.
-            masterTokenLocks.remove(masterToken);
+            masterTokenLocks.remove(key);
             writeLock.unlock();
         }
     }
@@ -911,12 +910,14 @@ public class MslControl {
      * Release the read lock of the provided master token. If no master token
      * is provided then this method is a no-op.
      * 
+     * @param ctx MSL context.
      * @param masterToken the master token. May be null.
      * @see #getNewestMasterToken(MslContext)
      */
-    private void releaseMasterToken(final MasterToken masterToken) {
+    private void releaseMasterToken(final MslContext ctx, final MasterToken masterToken) {
         if (masterToken != null) {
-            final ReadWriteLock lock = masterTokenLocks.get(masterToken);
+            final MslContextMasterTokenKey key = new MslContextMasterTokenKey(ctx, masterToken);
+            final ReadWriteLock lock = masterTokenLocks.get(key);
             
             // The lock may be null if the master token was deleted.
             if (lock != null)
@@ -1053,11 +1054,11 @@ public class MslControl {
             return builder;
         } catch (final MslException e) {
             // Release the master token lock.
-            releaseMasterToken(masterToken);
+            releaseMasterToken(ctx, masterToken);
             throw new MslInternalException("User ID token not bound to master token despite internal check.", e);
         } catch (final RuntimeException re) {
             // Release the master token lock.
-            releaseMasterToken(masterToken);
+            releaseMasterToken(ctx, masterToken);
             throw re;
         }
     }
@@ -1403,18 +1404,6 @@ public class MslControl {
     }
     
     /**
-     * <p>Return the current time of the remote entity (i.e. the remote peer-to-
-     * peer entity or the trusted services servers).</p>
-     * 
-     * @param ctx MSL context.
-     * @return the remote time or {@code null} if unknown.
-     */
-    private Date getRemoteTime(final MslContext ctx) {
-        final SynchronizedClock clock = remoteClocks.get(ctx);
-        return (clock != null) ? clock.getTime(ctx) : null;
-    }
-    
-    /**
      * The result of sending a message.
      */
     private static class SendResult {
@@ -1546,7 +1535,7 @@ public class MslControl {
             // Ask for key request data if we are using entity authentication
             // data or if the master token needs renewing or if the message is
             // non-replayable.
-            final Date now = getRemoteTime(ctx);
+            final Date now = ctx.getRemoteTime();
             if (masterToken == null || masterToken.isRenewable(now) || msgCtx.isNonReplayable()) {
                 keyRequests.addAll(msgCtx.getKeyRequestData());
                 for (final KeyRequestData keyRequest : keyRequests)
@@ -1746,11 +1735,8 @@ public class MslControl {
             // Update the synchronized clock if we are a trusted network client
             // (there is a request) or peer-to-peer entity.
             final Date timestamp = (responseHeader != null) ? responseHeader.getTimestamp() : errorHeader.getTimestamp();
-            if (timestamp != null && (request != null || ctx.isPeerToPeer())) {
-                remoteClocks.putIfAbsent(ctx, new SynchronizedClock());
-                final SynchronizedClock clock = remoteClocks.get(ctx);
-                clock.update(ctx, timestamp);
-            }
+            if (timestamp != null && (request != null || ctx.isPeerToPeer()))
+                ctx.updateRemoteTime(timestamp);
         } catch (final MslException e) {
             e.setEntity(masterToken);
             e.setEntity(entityAuthData);
@@ -1843,13 +1829,13 @@ public class MslControl {
             renewing = acquireRenewalLock(ctx, msgCtx, renewalQueue, builder, timeout);
         } catch (final InterruptedException e) {
             // Release the master token lock.
-            releaseMasterToken(builder.getMasterToken());
+            releaseMasterToken(ctx, builder.getMasterToken());
             
             // This should only be if we were cancelled so return null.
             return null;
         } catch (final RuntimeException e) {
             // Release the master token lock.
-            releaseMasterToken(builder.getMasterToken());
+            releaseMasterToken(ctx, builder.getMasterToken());
             throw e;
         }
 
@@ -1883,7 +1869,7 @@ public class MslControl {
                 releaseRenewalLock(ctx, renewalQueue, response);
             
             // Release the master token lock.
-            releaseMasterToken(builder.getMasterToken());
+            releaseMasterToken(ctx, builder.getMasterToken());
         }
         
         // Return the response.
@@ -1962,7 +1948,7 @@ public class MslControl {
         // If the message must be marked non-replayable and we do not have a
         // master token then we must mark this message as renewable to perform
         // a handshake or receive a new master token.
-        final Date startTime = getRemoteTime(ctx);
+        final Date startTime = ctx.getRemoteTime();
         if ((msgCtx.isEncrypted() && !builder.willEncryptPayloads()) ||
             (msgCtx.isIntegrityProtected() && !builder.willIntegrityProtectPayloads()) ||
             builder.isRenewable() ||
@@ -2003,7 +1989,7 @@ public class MslControl {
                 // have not acquired its master token lock.
                 final MasterToken previousMasterToken = masterToken;
                 if (masterToken == null || !masterToken.equals(newMasterToken)) {
-                    releaseMasterToken(masterToken);
+                    releaseMasterToken(ctx, masterToken);
                     masterToken = getNewestMasterToken(ctx);
                     
                     // If there is no newest master token (it could have been
@@ -2033,7 +2019,7 @@ public class MslControl {
                 
                 // If the new master token is still expired then try again to
                 // acquire renewal ownership.
-                final Date updateTime = getRemoteTime(ctx);
+                final Date updateTime = ctx.getRemoteTime();
                 if (masterToken.isExpired(updateTime))
                     continue;
                 
@@ -2059,7 +2045,7 @@ public class MslControl {
         // renewed, or we do not have a user ID token but the message is
         // associated with a user, or if the user ID token should be renewed,
         // then try to mark this message as renewable.
-        final Date finalTime = getRemoteTime(ctx);
+        final Date finalTime = ctx.getRemoteTime();
         if ((masterToken == null || masterToken.isRenewable(finalTime)) ||
             (userIdToken == null && msgCtx.getUserId() != null) ||
             (userIdToken != null && userIdToken.isRenewable(finalTime)))
@@ -2410,7 +2396,7 @@ public class MslControl {
                 } finally {
                     // Release the master token lock.
                     if (ctx.isPeerToPeer())
-                        releaseMasterToken(responseBuilder.getMasterToken());
+                        releaseMasterToken(ctx, responseBuilder.getMasterToken());
                 }
             }
             
@@ -2557,7 +2543,7 @@ public class MslControl {
                 return new MslChannel(request, result.request);
             } finally {
                 // Release the master token lock.
-                releaseMasterToken(builder.getMasterToken());
+                releaseMasterToken(ctx, builder.getMasterToken());
             }
         }
         
@@ -2586,7 +2572,7 @@ public class MslControl {
             //
             // Make sure to release the master token lock.
             if (msgCount + 2 > MslConstants.MAX_MESSAGES) {
-                releaseMasterToken(builder.getMasterToken());
+                releaseMasterToken(ctx, builder.getMasterToken());
                 return null;
             }
             
@@ -2596,7 +2582,7 @@ public class MslControl {
             if (msgCtx.getUser() != null && builder.getPeerMasterToken() == null && builder.getKeyExchangeData() == null) {
                 // Release the master token lock and try to send an error
                 // response.
-                releaseMasterToken(builder.getMasterToken());
+                releaseMasterToken(ctx, builder.getMasterToken());
                 try {
                     final String recipient = MslControl.getIdentity(request);
                     final long requestMessageId = MessageBuilder.decrementMessageId(builder.getMessageId());
@@ -3148,7 +3134,7 @@ public class MslControl {
             //
             // Make sure to release the master token lock.
             if (msgCount + 2 > MslConstants.MAX_MESSAGES) {
-                releaseMasterToken(builder.getMasterToken());
+                releaseMasterToken(ctx, builder.getMasterToken());
                 maxMessagesHit = true;
                 return null;
             }
@@ -3354,7 +3340,7 @@ public class MslControl {
                     }
                 } finally {
                     // Release the master token read lock.
-                    releaseMasterToken(keyxBuilder.getMasterToken());
+                    releaseMasterToken(ctx, keyxBuilder.getMasterToken());
                 }
             }
             
@@ -3396,7 +3382,7 @@ public class MslControl {
                     // If a message builder was provided then release the
                     // master token read lock.
                     if (builder != null)
-                        releaseMasterToken(builder.getMasterToken());
+                        releaseMasterToken(ctx, builder.getMasterToken());
                     
                     // Close any open streams.
                     if (out != null) out.close();
@@ -3409,7 +3395,7 @@ public class MslControl {
                     // If a message builder was provided then release the
                     // master token read lock.
                     if (builder != null)
-                        releaseMasterToken(builder.getMasterToken());
+                        releaseMasterToken(ctx, builder.getMasterToken());
                     
                     // Close any open streams.
                     if (out != null) out.close();
@@ -3727,13 +3713,8 @@ public class MslControl {
     private final MasterToken NULL_MASTER_TOKEN;
 
     /**
-     * Map of in-flight master token in-flight read-write locks by MSL context.
+     * Map of in-flight master token read-write locks by MSL context and master
+     * token.
      */
-    private final ConcurrentHashMap<MasterToken,ReadWriteLock> masterTokenLocks = new ConcurrentHashMap<MasterToken,ReadWriteLock>();
-    
-    /**
-     * Map of remote entity clocks by MSL context. This data is only relevant
-     * to trusted network clients and peer-to-peer entities.
-     */
-    private final ConcurrentHashMap<MslContext,SynchronizedClock> remoteClocks = new ConcurrentHashMap<MslContext,SynchronizedClock>();
+    private final ConcurrentHashMap<MslContextMasterTokenKey,ReadWriteLock> masterTokenLocks = new ConcurrentHashMap<MslContextMasterTokenKey,ReadWriteLock>();
 }

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -139,52 +139,46 @@ var MslControl$MslChannel;
         Object.defineProperties(this, props);
         return this;
     };
-
+    
     /**
-     * Milliseconds per second.
-     * @const
-     * @type {number}
+     * A map key based off a MSL context and master token pair.
      */
-    var MILLISECONDS_PER_SECOND = 1000;
-
-    /**
-     * A clock synchronized against an external time.
-     */
-    var SynchronizedClock = util.Class.create({
+    var MslContextMasterTokenKey = util.Class.create({
         /**
-         * Create a new synchronized clock. The clock is not synchronized until
-         * {@link #update(MslContext, Date)} is called.
+         * Create a new MSL context and master token map key.
+         * 
+         * @param {MslContext} ctx MSL context.
+         * @param {MasterToken} masterToken master token.
          */
-        init: function init() {
+        init: function init(ctx, masterToken) {
             // The properties.
-            var props = {
-                _offset: { value: 0, writable: true, enumerable: false, configurable: false },
+            var props = { 
+                _ctx: { value: ctx, writable: false, enumerable: false, configurable: false },
+                _masterToken: { value: masterToken, writable: false, enumerable: false, configurable: false },
             };
             Object.defineProperties(this, props);
         },
 
         /**
-         * Update the synchronized clock based on the remote entity time.
-         * 
-         * @param {MslContext} ctx local entity MSL context.
-         * @param {Date} time remote entity time.
+         * @param {?} that the reference object with which to compare.
+         * @return {boolean} true if the other object is an instance of this
+         *         class pointing at the exact same MSL context and with an
+         *         equal master token.
+         * @see #uniqueKey()
          */
-        update: function update(ctx, time) {
-            var localSeconds = ctx.getTime() / MILLISECONDS_PER_SECOND;
-            var remoteSeconds = time.getTime() / MILLISECONDS_PER_SECOND;
-            this._offset = remoteSeconds - localSeconds;
+        equals: function equals(that) {
+            if (this === that) return true;
+            if (!(that instanceof MslContextMasterTokenKey)) return false;
+            return this.ctx === that.ctx && this.masterToken.equals(that.masterToken);
         },
 
         /**
-         * Return the expected remote entity time.
-         * 
-         * @param {MslContext} ctx local entity MSL context.
-         * @return {Date} the expected remote entity time.
+         * @return {string} a string that uniquely identifies this MSL context
+         *         and master token key pair.
+         * @see #equals(that)
          */
-        getTime: function getTime(ctx) {
-            var localSeconds = ctx.getTime() / MILLISECONDS_PER_SECOND;
-            var remoteSeconds = localSeconds + this._offset;
-            return new Date(remoteSeconds * MILLISECONDS_PER_SECOND);
+        uniqueKey: function uniqueKey() {
+            return this.ctx.uniqueKey() + ':' + this.masterToken.uniqueKey();
         },
     });
 
@@ -599,8 +593,9 @@ var MslControl$MslChannel;
                  */
                 _renewingContexts: { value: [], writable: false, enumerable: false, configurable: false },
                 /**
-                 * Map of in-flight master token in-flight read-write locks by MSL context.
-                 * @type {Object.<MasterToken,ReadWriteLock>}
+                 * Map of in-flight master token read-write locks by MSL context and master
+                 * token.
+                 * @type {Object.<MslContextMasterTokenKey,ReadWriteLock>}
                  */
                 _masterTokenLocks: { value: {}, writable: false, enumerable: false, configurable: false },
                 /**
@@ -655,7 +650,7 @@ var MslControl$MslChannel;
                 if (!masterToken) return null;
 
                 // Acquire the master token read lock, creating it if necessary.
-                var key = masterToken.uniqueKey();
+                var key = new MslContextMasterTokenKey(ctx, masterToken).uniqueKey();
                 var rwlock = this._masterTokenLocks[key];
                 if (!rwlock) {
                     rwlock = new ReadWriteLock();
@@ -731,7 +726,7 @@ var MslControl$MslChannel;
             // The timeout will be clamped.
             var self = this;
             setTimeout(function() {
-                var key = masterToken.uniqueKey();
+                var key = new MslContextMasterTokenKey(ctx, masterToken).uniqueKey();
                 var rwlock = self._masterTokenLocks[key];
                 if (!rwlock) {
                     rwlock = new ReadWriteLock();
@@ -759,14 +754,15 @@ var MslControl$MslChannel;
          * Release the read lock of the provided master token. If no master token
          * is provided then this method is a no-op.
          *
+         * @param {MslContext} ctx MSL context.
          * @param {?TokenTicket} tokenTicket the
          *        master token (which may be null) and lock ticket.
          * @see #getNewestMasterToken(MslContext)
          */
-        releaseMasterToken: function releaseMasterToken(tokenTicket) {
+        releaseMasterToken: function releaseMasterToken(ctx, tokenTicket) {
             if (tokenTicket && tokenTicket.masterToken) {
                 var masterToken = tokenTicket.masterToken;
-                var key = masterToken.uniqueKey();
+                var key = new MslContextMasterTokenKey(ctx, masterToken).uniqueKey();
                 var rwlock = this._masterTokenLocks[key];
                 
                 // The lock may be null if the master token was deleted.
@@ -925,7 +921,7 @@ var MslControl$MslChannel;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     // Release the master token lock.
-                                    this.releaseMasterToken(tokenTicket);
+                                    this.releaseMasterToken(ctx, tokenTicket);
                                     if (e instanceof MslException)
                                         e = new MslInternalException("User ID token not bound to master token despite internal check.", e);
                                     throw e;
@@ -1381,25 +1377,6 @@ var MslControl$MslChannel;
 	                // No cleanup required.
             }
         },
-        
-        /**
-         * <p>Return the current time of the remote entity (i.e. the remote peer-to-
-         * peer entity or the trusted services servers).</p>
-         * 
-         * @param {MslContext} ctx MSL context.
-         * @return {Date} the remote time or {@code null} if unknown.
-         */
-        getRemoteTime: function getRemoteTime(ctx) {
-            var clock;
-            for (var i = 0; i < this._remoteClocks.length; ++i) {
-                var ctxClock = this._remoteClocks[i];
-                if (ctxClock.ctx === ctx) {
-                    clock = ctxClock.clock;
-                    break;
-                }
-            }
-            return (clock) ? clock.getTime(ctx) : null;
-        },
 
         /**
          * <p>Send a message. The message context will be used to build the message.
@@ -1545,7 +1522,7 @@ var MslControl$MslChannel;
                         // Ask for key request data if we are using entity authentication
                         // data or if the master token needs renewing or if the message is
                         // non-replayable.
-                        var now = this.getRemoteTime(ctx);
+                        var now = ctx.getRemoteTime();
                         if (!masterToken || masterToken.isRenewable(now) || msgCtx.isNonReplayable()) {
                             msgCtx.getKeyRequestData({
                                 result: function(requests) {
@@ -1830,21 +1807,8 @@ var MslControl$MslChannel;
                                                     // Update the synchronized clock if we are a trusted network client
                                                     // (there is a request) or peer-to-peer entity.
                                                     var timestamp = (responseHeader) ? responseHeader.timestamp : errorHeader.timestamp;
-                                                    if (timestamp && (request || ctx.isPeerToPeer())) {
-                                                        var clock;
-                                                        for (var i = 0; i < this._remoteClocks.length; ++i) {
-                                                            var ctxClock = this._remoteClocks[i];
-                                                            if (ctxClock.ctx === ctx) {
-                                                                clock = ctxClock.clock;
-                                                                break;
-                                                            }
-                                                        }
-                                                        if (!clock) {
-                                                            clock = new SynchronizedClock();
-                                                            this._remoteClocks.push({ctx: ctx, clock: clock});
-                                                        }
-                                                        clock.update(ctx, timestamp);
-                                                    }
+                                                    if (timestamp && (request || ctx.isPeerToPeer()))
+                                                        ctx.updateRemoteTime(timestamp);
                                                 } catch (e) {
                                                     if (e instanceof MslException) {
                                                         e.setEntity(masterToken);
@@ -1948,14 +1912,14 @@ var MslControl$MslChannel;
                     timeout: function() {
                         InterruptibleExecutor(callback, function() {
                             // Release the master token lock.
-                            this.releaseMasterToken(builderTokenTicket.ticket);
+                            this.releaseMasterToken(ctx, builderTokenTicket.ticket);
                             callback.timeout();
                         }, self);
                     },
                     error: function(e) {
                         InterruptibleExecutor(callback, function() {
                             // Release the master token lock.
-                            this.releaseMasterToken(builderTokenTicket.ticket);
+                            this.releaseMasterToken(ctx, builderTokenTicket.ticket);
 
                             // This should only be if we were cancelled so return null.
                             if (e instanceof MslInterruptedException) {
@@ -2000,7 +1964,7 @@ var MslControl$MslChannel;
                                                     this.releaseRenewalLock(ctx, renewalQueue, response);
                                                 
                                                 // Release the master token lock.
-                                                this.releaseMasterToken(tokenTicket);
+                                                this.releaseMasterToken(ctx, tokenTicket);
 
                                                 // Return the response.
                                                 response.closeSource(closeStreams);
@@ -2014,7 +1978,7 @@ var MslControl$MslChannel;
                                                     this.releaseRenewalLock(ctx, renewalQueue, null);
                                                 
                                                 // Release the master token lock.
-                                                this.releaseMasterToken(tokenTicket);
+                                                this.releaseMasterToken(ctx, tokenTicket);
                                                 
                                                 callback.timeout();
                                             }, self);
@@ -2026,7 +1990,7 @@ var MslControl$MslChannel;
                                                     this.releaseRenewalLock(ctx, renewalQueue, null);
                                                 
                                                 // Release the master token lock.
-                                                this.releaseMasterToken(tokenTicket);
+                                                this.releaseMasterToken(ctx, tokenTicket);
                                                 
                                                 callback.error(e);
                                             }, self);
@@ -2041,7 +2005,7 @@ var MslControl$MslChannel;
                                             this.releaseRenewalLock(ctx, renewalQueue, response);
                                         
                                         // Release the master token lock.
-                                        this.releaseMasterToken(tokenTicket);
+                                        this.releaseMasterToken(ctx, tokenTicket);
 
                                         // Return the response.
                                         return new SendReceiveResult(response, sent);
@@ -2056,7 +2020,7 @@ var MslControl$MslChannel;
                                     this.releaseRenewalLock(ctx, renewalQueue, null);
                                 
                                 // Release the master token lock.
-                                this.releaseMasterToken(tokenTicket);
+                                this.releaseMasterToken(ctx, tokenTicket);
                                 
                                 callback.timeout();
                             }, self);
@@ -2070,7 +2034,7 @@ var MslControl$MslChannel;
                                     this.releaseRenewalLock(ctx, renewalQueue, response);
                                 
                                 // Release the master token lock.
-                                this.releaseMasterToken(tokenTicket);
+                                this.releaseMasterToken(ctx, tokenTicket);
                                 
                                 callback.error(e);
                             }, self);
@@ -2162,7 +2126,7 @@ var MslControl$MslChannel;
                 // If the message must be marked non-replayable and we do not have a
                 // master token then we must mark this message as renewable to perform
                 // a handshake or receive a new master token.
-                var startTime = this.getRemoteTime(ctx);
+                var startTime = ctx.getRemoteTime();
                 if ((msgCtx.isEncrypted() && !builder.willEncryptPayloads()) ||
                     (msgCtx.isIntegrityProtected() && !builder.willIntegrityProtectPayloads()) ||
                     builder.isRenewable() ||
@@ -2230,7 +2194,7 @@ var MslControl$MslChannel;
                                 // have not acquired its master token lock.
                                 var previousMasterToken = masterToken;
                                 if (!masterToken || !masterToken.equals(newMasterToken)) {
-                                    this.releaseMasterToken(tokenTicket);
+                                    this.releaseMasterToken(ctx, tokenTicket);
                                     this.getNewestMasterToken(service, ctx, timeout, {
                                         result: function(tokenTicket) {
                                             InterruptibleExecutor(callback, function() {
@@ -2297,7 +2261,7 @@ var MslControl$MslChannel;
                     
                     // If the new master token is still expired then try again to
                     // acquire renewal ownership.
-                    var updateTime = this.getRemoteTime(ctx);
+                    var updateTime = ctx.getRemoteTime();
                     if (masterToken.isExpired(updateTime)) {
                         blockingAcquisition(masterToken, userIdToken, userId, builder, tokenTicket);
                         return;
@@ -2336,7 +2300,7 @@ var MslControl$MslChannel;
                     // renewed, or we do not have a user ID token but the message is
                     // associated with a user, or if the user ID token should be renewed,
                     // then try to mark this message as renewable.
-                    var finalTime = this.getRemoteTime(ctx);
+                    var finalTime = ctx.getRemoteTime();
                     if ((!masterToken || masterToken.isRenewable(finalTime)) ||
                         (!userIdToken && msgCtx.getUserId()) ||
                         (userIdToken && userIdToken.isRenewable(finalTime)))
@@ -3075,7 +3039,7 @@ var MslControl$MslChannel;
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
                                 if (this._ctx.isPeerToPeer())
-                                    this._ctrl.releaseMasterToken(tokenTicket);
+                                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                 return null;
                             }, self);
                         },
@@ -3083,7 +3047,7 @@ var MslControl$MslChannel;
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
                                 if (this._ctx.isPeerToPeer())
-                                    this._ctrl.releaseMasterToken(tokenTicket);
+                                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                 callback.timeout();
                             }, self);
                         },
@@ -3091,7 +3055,7 @@ var MslControl$MslChannel;
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
                                 if (this._ctx.isPeerToPeer())
-                                    this._ctrl.releaseMasterToken(tokenTicket);
+                                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
 
                                 // If we were cancelled then return null.
                                 if (cancelled(e)) return null;
@@ -3228,7 +3192,7 @@ var MslControl$MslChannel;
                     // Do nothing if we cannot send one more message.
                     if (msgCount + 1 > MslConstants$MAX_MESSAGES) {
                         // Release the master token lock.
-                        this._ctrl.releaseMasterToken(tokenTicket);
+                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                         
                         return null;
                     }
@@ -3261,7 +3225,7 @@ var MslControl$MslChannel;
                         });
                         
                         // Release the master token lock.
-                        this._ctrl.releaseMasterToken(tokenTicket);
+                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                         
                         return;
                     }
@@ -3287,7 +3251,7 @@ var MslControl$MslChannel;
                         });
 
                         // Release the master token lock.
-                        this._ctrl.releaseMasterToken(tokenTicket);
+                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                         
                         return;
                     }
@@ -3298,7 +3262,7 @@ var MslControl$MslChannel;
                         result: function(result) {
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
-                                this._ctrl.releaseMasterToken(tokenTicket);
+                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                 
                                 return new MslChannel(this._request, result.request);
                             }, self);
@@ -3306,7 +3270,7 @@ var MslControl$MslChannel;
                         timeout: function() {
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
-                                this._ctrl.releaseMasterToken(tokenTicket);
+                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                 
                                 callback.timeout();
                             }, self);
@@ -3314,7 +3278,7 @@ var MslControl$MslChannel;
                         error: function(e) {
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
-                                this._ctrl.releaseMasterToken(tokenTicket);
+                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                 
                                 callback.error(e);
                             }, self);
@@ -3322,7 +3286,7 @@ var MslControl$MslChannel;
                     });
                 } catch (e) {
                     // Release the master token lock.
-                    this._ctrl.releaseMasterToken(tokenTicket);
+                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                     
                     throw e;
                 }
@@ -3362,7 +3326,7 @@ var MslControl$MslChannel;
                 //
                 // Make sure to release the master token lock.
                 if (msgCount + 2 > MslConstants$MAX_MESSAGES) {
-                    this._ctrl.releaseMasterToken(tokenTicket);
+                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                     return null;
                 }
 
@@ -3372,7 +3336,7 @@ var MslControl$MslChannel;
                 if (msgCtx.getUser() != null && builder.getPeerMasterToken() == null && builder.getKeyExchangeData() == null) {
                     // Release the master token lock and try to send an error
                     // response.
-                    this._ctrl.releaseMasterToken(tokenTicket);
+                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                     var recipient = getIdentity(this._request);
                     var requestMessageId = MessageBuilder$decrementMessageId(builder.getMessageId());
                     sendError(this, this._ctrl, this._ctx, msgCtx.getDebugContext(), recipient, requestMessageId, MslError.RESPONSE_REQUIRES_MASTERTOKEN, null, this._output, this._timeout, {
@@ -3947,7 +3911,7 @@ var MslControl$MslChannel;
                 // Make sure to release the master token lock.
                 if (msgCount + 2 > MslConstants$MAX_MESSAGES) {
                     var tokenTicket = builderTokenTicket.tokenTicket;
-                    this._ctrl.releaseMasterToken(tokenTicket);
+                    this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                     this._maxMessagesHit = true;
                     return null;
                 }
@@ -4105,7 +4069,7 @@ var MslControl$MslChannel;
                                         result: function(newChannel) {
                                             InterruptibleExecutor(callback, function() {
                                                 // Release the error message's master token read lock.
-                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
 
                                                 processErrorResponse(result, newChannel);
                                             }, self);
@@ -4113,7 +4077,7 @@ var MslControl$MslChannel;
                                         timeout: function() {
                                             InterruptibleExecutor(callback, function() {
                                                 // Release the error message's master token read lock.
-                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
 
                                                 callback.timeout();
                                             }, self);
@@ -4121,7 +4085,7 @@ var MslControl$MslChannel;
                                         error: function(e) {
                                             InterruptibleExecutor(callback, function() {
                                                 // Release the error message's master token read lock.
-                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
 
                                                 callback.error(e);
                                             }, self);
@@ -4254,7 +4218,7 @@ var MslControl$MslChannel;
                                                             // If cancelled return null.
                                                             if (!success) {
                                                                 // Release the master token read lock.
-                                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                                 return null;
                                                             }
 
@@ -4270,7 +4234,7 @@ var MslControl$MslChannel;
                                                                 result: function(newResult) {
                                                                     InterruptibleExecutor(callback, function() {
                                                                         // Release the master token read lock.
-                                                                        this._ctrl.releaseMasterToken(tokenTicket);
+                                                                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                                         return new MslChannel(response, newResult.request);
                                                                     }, self);
                                                                 },
@@ -4291,7 +4255,7 @@ var MslControl$MslChannel;
                                                             // If cancelled return null.
                                                             if (!success) {
                                                                 // Release the master token read lock.
-                                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                                 return null;
                                                             }
 
@@ -4299,21 +4263,21 @@ var MslControl$MslChannel;
                                                                 result: function(newResponse) {
                                                                     InterruptibleExecutor(callback, function() {
                                                                         // Release the master token read lock.
-                                                                        this._ctrl.releaseMasterToken(tokenTicket);
+                                                                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                                         return newResponse;
                                                                     }, self);
                                                                 },
                                                                 timeout: function() {
                                                                     InterruptibleExecutor(callback, function() {
                                                                         // Release the master token read lock.
-                                                                        this._ctrl.releaseMasterToken(tokenTicket);
+                                                                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                                         callback.timeout();
                                                                     }, self);
                                                                 },
                                                                 error: function(e) {
                                                                     InterruptibleExecutor(callback, function() {
                                                                         // Release the master token read lock.
-                                                                        this._ctrl.releaseMasterToken(tokenTicket);
+                                                                        this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                                         callback.error(e);
                                                                     }, self);
                                                                 }
@@ -4326,14 +4290,14 @@ var MslControl$MslChannel;
                                         timeout: function() {
                                             InterruptibleExecutor(callback, function() {
                                                 // Release the master token read lock.
-                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                 callback.timeout();
                                             }, self);
                                         },
                                         error: function(e) {
                                             InterruptibleExecutor(callback, function() {
                                                 // Release the master token read lock.
-                                                this._ctrl.releaseMasterToken(tokenTicket);
+                                                this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
                                                 callback.error(e);
                                             }, self);
                                         }
@@ -4388,7 +4352,7 @@ var MslControl$MslChannel;
                         // If a message builder was provided then release the
                         // master token read lock.
                         if (this._builder)
-                            this._ctrl.releaseMasterToken(this._tokenTicket);
+                            this._ctrl.releaseMasterToken(this._ctx, this._tokenTicket);
 
                         // Close any open streams.
                         if (this._output) this._output.close(this._timeout, NULL_CLOSE_HANDLER);

--- a/core/src/main/javascript/util/MslContext.js
+++ b/core/src/main/javascript/util/MslContext.js
@@ -37,176 +37,276 @@ Object.freeze(MslContext$ReauthCode);
  * @author Wesley Miaw <wmiaw@netflix.com>
  * @interface
  */
-var MslContext = util.Class.create({
-    /**
-     * <p>Returns the local entity time. This need not be the real time as long
-     * as it moves forward accurately (i.e. this time value should increase by
-     * one second for each second of elapsed real time).</p>
-     *
-     * <p>It is advisable that this time value be persistently stored so that
-     * it does not roll back at next application launch. This is not necessary
-     * but it will ensure issued tokens are eventually renewed.</p>
-     *
-     * @return {number} the local entity time in milliseconds since the epoch.
-     */
-    getTime: function() {},
+var MslContext;
 
-    /**
-     * <p>Returns a random number generator.</p>
-     * 
-     * <p>It is extremely important to provide a secure (pseudo-)random number
-     * generator with a good source of entropy. Many random number generators,
-     * including those found in the Java Runtime Environment, JavaScript, and
-     * operating systems do not provide sufficient randomness.</p>
-     * 
-     * <p>If in doubt, performing an {@code XOR} on the output of two or more
-     * independent random sources can be used to provide better random
-     * values.</p>
-     *
-     * @return {Random} a random number generator.
-     */
-    getRandom: function() {},
-
-    /**
-     * Returns true if the context is operating in a peer-to-peer network. The
-     * message processing logic is slightly different in peer-to-peer networks.
-     *
-     * @return {boolean} true if in peer-to-peer mode.
-     */
-    isPeerToPeer: function() {},
-
-    /**
-     * Returns the message capabilities for this entity.
-     *
-     * @return {MessageCapabilities} this entity's message capabilities.
-     */
-    getMessageCapabilities: function() {},
-
-    /**
-     * <p>Returns the entity authentication data for this entity. This is used
-     * to authenticate messages prior to generation of a master token.</p>
-     * 
-     * <p>This method should never return {@code null} but may do so in the one
-     * situation when the {@code reauthCode} parameter is provided and the
-     * application knows that the request being sent can no longer succeed
-     * because the existing master token, user ID token, or service tokens are
-     * no longer valid. This will abort the request.</p>
-     * 
-     * <p>If the {@code reauthCode} parameter is equal to
-     * {@link ReauthCode#ENTITY_REAUTH} then the existing master token has been
-     * rejected, along with its bound user ID tokens and service tokens.</p>
-     * 
-     * <p>If the {@code reauthCode} parameter is equal to
-     * {@link ReauthCode#ENTITYDATA_REAUTH} then new entity re-authentication
-     * data should be returned for this and all subsequent calls.</p>
-     * 
-     * <p>The entity authentication scheme must never change.</p>
-     * 
-     * <p>This method will be called multiple times.</p>
-     *
-     * @param {MslControl$ReauthCode} reauthCode non-{@code null} if the master token or entity
-     *        authentication data was rejected. If the entity authentication
-     *        data was rejected then new entity authentication data is
-     *        required.
-     * @param {{result: function(?EntityAuthenticationData), error: function(Error)}}
-     *        callback the callback that will receive the entity authentication
-     *        data or null or any thrown exceptions.
-     */
-    getEntityAuthenticationData: function(reauthCode, callback) {},
-
-    /**
-     * <p>Returns the primary crypto context used for MSL-level crypto
-     * operations. This is used for the master tokens and user ID tokens.</p>
-     * 
-     * <p>Trusted network clients should return a crypto context that always
-     * returns false for verification. The other crypto context methods will
-     * not be used by trusted network clients.</p>
-     *
-     * @return {ICryptoContext} the primary MSL crypto context.
-     * @throws MslCryptoException if there is an error creating the crypto
-     *         context.
-     */
-    getMslCryptoContext: function() {},
-
-    /**
-     * <p>Returns the entity authentication scheme identified by the specified
-     * name or {@code null} if there is none.</p>
-     * 
-     * @param {string} name the entity authentication scheme name.
-     * @return {EntityAuthenticationScheme} the scheme identified by the specified name or {@code null} if
-     *         there is none.
-     */
-    getEntityAuthenticationScheme: function(name) {},
+(function() {
+    "use strict";
+    
+    /** Milliseconds per second. */
+    var MILLISECONDS_PER_SECOND = 1000;
     
     /**
-     * Returns the entity authentication factory for the specified scheme.
-     *
-     * @param {EntityAuthenticationScheme} scheme the entity authentication scheme.
-     * @return {EntityAuthenticationFactory} the entity authentication factory, or null if no factory is
-     *         available.
-     */
-    getEntityAuthenticationFactory: function(scheme) {},
-
-    /**
-     * <p>Returns the user authentication scheme identified by the specified
-     * name or {@code null} if there is none.</p>
+     * Unique MSL Context ID counter. Hopefully this will never wrap around in
+     * practice.
      * 
-     * @param {string} name the user authentication scheme name.
-     * @return {UserAuthenticationScheme} the scheme identified by the specified name or {@code null} if
-     *         there is none.
+     * We're unfortunately left with doing things this way because there is no
+     * way to access JavaScript object memory addresses in order to provide a
+     * string representation of an object instance.
      */
-    getUserAuthenticationScheme: function getUserAuthenticationScheme(name) {},
+    var uniqueId = 0;
+    
+    MslContext = util.Class.create({
+        /**
+         * Create a new MSL context without a synchronized remote clock.
+         */
+        init: function init() {
+            // Compute the new MSL context ID. Throw an exception if it ever
+            // wraps around; this is unlikely to ever happen in practice.
+            var id = ++uniqueId;
+            if (id <= 0 || !isFinite(id))
+                throw new MslInternalException("MSL context unique ID has overflowed. Are you sure you are using MSL context's correctly?");
+            
+            // The properties.
+            var props = {
+                /**
+                 * Unique MSL context ID.
+                 * @type {number}
+                 */
+                _uniqueId: { value: id, writable: false, enumerable: false, configurable: false },
+                /**
+                 * Remote clock is synchronized.
+                 * @type {boolean}
+                 */
+                _synced: { value: false, writable: true, enumerable: false, configurable: false },
+                /**
+                 * Remote entity time offset from local time in seconds.
+                 * @type {number}
+                 */
+                _offset: { value: 0, writable: true, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+        
+        /**
+         * <p>Returns the local entity time. This need not be the real time as long
+         * as it moves forward accurately (i.e. this time value should increase by
+         * one second for each second of elapsed real time).</p>
+         *
+         * <p>It is advisable that this time value be persistently stored so that
+         * it does not roll back at next application launch. This is not necessary
+         * but it will ensure issued tokens are eventually renewed.</p>
+         *
+         * @return {number} the local entity time in milliseconds since the epoch.
+         */
+        getTime: function() {},
+    
+        /**
+         * <p>Returns a random number generator.</p>
+         * 
+         * <p>It is extremely important to provide a secure (pseudo-)random number
+         * generator with a good source of entropy. Many random number generators,
+         * including those found in the Java Runtime Environment, JavaScript, and
+         * operating systems do not provide sufficient randomness.</p>
+         * 
+         * <p>If in doubt, performing an {@code XOR} on the output of two or more
+         * independent random sources can be used to provide better random
+         * values.</p>
+         *
+         * @return {Random} a random number generator.
+         */
+        getRandom: function() {},
+    
+        /**
+         * Returns true if the context is operating in a peer-to-peer network. The
+         * message processing logic is slightly different in peer-to-peer networks.
+         *
+         * @return {boolean} true if in peer-to-peer mode.
+         */
+        isPeerToPeer: function() {},
+    
+        /**
+         * Returns the message capabilities for this entity.
+         *
+         * @return {MessageCapabilities} this entity's message capabilities.
+         */
+        getMessageCapabilities: function() {},
+    
+        /**
+         * <p>Returns the entity authentication data for this entity. This is used
+         * to authenticate messages prior to generation of a master token.</p>
+         * 
+         * <p>This method should never return {@code null} but may do so in the one
+         * situation when the {@code reauthCode} parameter is provided and the
+         * application knows that the request being sent can no longer succeed
+         * because the existing master token, user ID token, or service tokens are
+         * no longer valid. This will abort the request.</p>
+         * 
+         * <p>If the {@code reauthCode} parameter is equal to
+         * {@link ReauthCode#ENTITY_REAUTH} then the existing master token has been
+         * rejected, along with its bound user ID tokens and service tokens.</p>
+         * 
+         * <p>If the {@code reauthCode} parameter is equal to
+         * {@link ReauthCode#ENTITYDATA_REAUTH} then new entity re-authentication
+         * data should be returned for this and all subsequent calls.</p>
+         * 
+         * <p>The entity authentication scheme must never change.</p>
+         * 
+         * <p>This method will be called multiple times.</p>
+         *
+         * @param {MslControl$ReauthCode} reauthCode non-{@code null} if the master token or entity
+         *        authentication data was rejected. If the entity authentication
+         *        data was rejected then new entity authentication data is
+         *        required.
+         * @param {{result: function(?EntityAuthenticationData), error: function(Error)}}
+         *        callback the callback that will receive the entity authentication
+         *        data or null or any thrown exceptions.
+         */
+        getEntityAuthenticationData: function(reauthCode, callback) {},
+    
+        /**
+         * <p>Returns the primary crypto context used for MSL-level crypto
+         * operations. This is used for the master tokens and user ID tokens.</p>
+         * 
+         * <p>Trusted network clients should return a crypto context that always
+         * returns false for verification. The other crypto context methods will
+         * not be used by trusted network clients.</p>
+         *
+         * @return {ICryptoContext} the primary MSL crypto context.
+         * @throws MslCryptoException if there is an error creating the crypto
+         *         context.
+         */
+        getMslCryptoContext: function() {},
+    
+        /**
+         * <p>Returns the entity authentication scheme identified by the specified
+         * name or {@code null} if there is none.</p>
+         * 
+         * @param {string} name the entity authentication scheme name.
+         * @return {EntityAuthenticationScheme} the scheme identified by the specified name or {@code null} if
+         *         there is none.
+         */
+        getEntityAuthenticationScheme: function(name) {},
+        
+        /**
+         * Returns the entity authentication factory for the specified scheme.
+         *
+         * @param {EntityAuthenticationScheme} scheme the entity authentication scheme.
+         * @return {EntityAuthenticationFactory} the entity authentication factory, or null if no factory is
+         *         available.
+         */
+        getEntityAuthenticationFactory: function(scheme) {},
+    
+        /**
+         * <p>Returns the user authentication scheme identified by the specified
+         * name or {@code null} if there is none.</p>
+         * 
+         * @param {string} name the user authentication scheme name.
+         * @return {UserAuthenticationScheme} the scheme identified by the specified name or {@code null} if
+         *         there is none.
+         */
+        getUserAuthenticationScheme: function getUserAuthenticationScheme(name) {},
+    
+        /**
+         * Returns the user authentication factory for the specified scheme.
+         *
+         * Trusted network clients should always return null.
+         *
+         * @param {UserAuthenticationScheme} scheme the user authentication scheme.
+         * @return {UserAuthenticationFactory} the user authentication factory, or null if no factory is
+         *         available.
+         */
+        getUserAuthenticationFactory: function(scheme) {},
+    
+        /**
+         * Returns the token factory.
+         *
+         * This method will not be called by trusted network clients.
+         *
+         * @return {TokenFactory} the token factory.
+         */
+        getTokenFactory: function() {},
+    
+        /**
+         * <p>Returns the key exchange scheme identified by the specified name or
+         * {@code null} if there is none.</p>
+         * 
+         * @param {string} name the key exchange scheme name.
+         * @return {KeyExchangeScheme} the scheme identified by the specified name or {@code null} if
+         *         there is none.
+         */
+        getKeyExchangeScheme: function getKeyExchangeScheme(name) {},
+    
+        /**
+         * Returns the key exchange factory for the specified scheme.
+         *
+         * @param {KeyExchangeScheme} scheme the key exchange scheme.
+         * @return {KeyExchangeFactory} the key exchange factory, or null if no factory is available.
+         */
+        getKeyExchangeFactory: function(scheme) {},
+    
+        /**
+         * Returns the supported key exchange factories in order of preferred use.
+         * This should return an immutable collection.
+         *
+         * @return {Array.<KeyExchangeFactory>} the key exchange factories, or the empty set.
+         */
+        getKeyExchangeFactories: function() {},
+    
+        /**
+         * Returns the MSL store specific to this MSL context.
+         *
+         * @return {MslStore} the MSL store.
+         */
+        getMslStore: function() {},
 
-    /**
-     * Returns the user authentication factory for the specified scheme.
-     *
-     * Trusted network clients should always return null.
-     *
-     * @param {UserAuthenticationScheme} scheme the user authentication scheme.
-     * @return {UserAuthenticationFactory} the user authentication factory, or null if no factory is
-     *         available.
-     */
-    getUserAuthenticationFactory: function(scheme) {},
+        /**
+         * <p>Update the remote entity time.</p>
+         * 
+         * <p>This function is only used by {@link MslControl} and should not be
+         * used by the application.</p>
+         * 
+         * @param {Date} time remote entity time.
+         */
+        updateRemoteTime: function updateRemoteTime(time) {
+            var localSeconds = this.getTime() / MILLISECONDS_PER_SECOND;
+            var remoteSeconds = time.getTime() / MILLISECONDS_PER_SECOND;
+            this.offset = remoteSeconds - localSeconds;
+            this.synced = true;
+        },
 
-    /**
-     * Returns the token factory.
-     *
-     * This method will not be called by trusted network clients.
-     *
-     * @return {TokenFactory} the token factory.
-     */
-    getTokenFactory: function() {},
+        /**
+         * <p>Return the expected remote entity time or {@code null} if the clock
+         * is not yet synchronized.</p>
+         * 
+         * <p>This function is only used by {@link MslControl} and should not be
+         * used by the application.</p>
+         * 
+         * @return {Date} the expected remote entity time or {@code null} if not known.
+         */
+        getRemoteTime: function getRemoteTime() {
+            if (!this.synced) return null;
+            var localSeconds = this.getTime() / MILLISECONDS_PER_SECOND;
+            var remoteSeconds = localSeconds + offset;
+            return new Date(remoteSeconds * MILLISECONDS_PER_SECOND);
+        },
 
-    /**
-     * <p>Returns the key exchange scheme identified by the specified name or
-     * {@code null} if there is none.</p>
-     * 
-     * @param {string} name the key exchange scheme name.
-     * @return {KeyExchangeScheme} the scheme identified by the specified name or {@code null} if
-     *         there is none.
-     */
-    getKeyExchangeScheme: function getKeyExchangeScheme(name) {},
+        /**
+         * @param {?} that the reference object with which to compare.
+         * @return {boolean} true if the other object is the exact same MSL
+         *         context as this one.
+         * @see #uniqueKey()
+         */
+        equals: function equals(that) {
+            if (this === that) return true;
+            return false;
+        },
 
-    /**
-     * Returns the key exchange factory for the specified scheme.
-     *
-     * @param {KeyExchangeScheme} scheme the key exchange scheme.
-     * @return {KeyExchangeFactory} the key exchange factory, or null if no factory is available.
-     */
-    getKeyExchangeFactory: function(scheme) {},
-
-    /**
-     * Returns the supported key exchange factories in order of preferred use.
-     * This should return an immutable collection.
-     *
-     * @return {Array.<KeyExchangeFactory>} the key exchange factories, or the empty set.
-     */
-    getKeyExchangeFactories: function() {},
-
-    /**
-     * Returns the MSL store specific to this MSL context.
-     *
-     * @return {MslStore} the MSL store.
-     */
-    getMslStore: function() {},
-});
+        /**
+         * @return {string} a string that uniquely identifies this MSL context.
+         * @see #equals(that)
+         */
+        uniqueKey: function uniqueKey() {
+            return this._uniqueId;
+        },
+    });
+})();

--- a/examples/burp/src/main/java/burp/msl/util/WiretapMslContext.java
+++ b/examples/burp/src/main/java/burp/msl/util/WiretapMslContext.java
@@ -51,7 +51,6 @@ import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.keyx.MockDiffieHellmanParameters;
 import com.netflix.msl.keyx.SymmetricWrappedExchange;
 import com.netflix.msl.msg.MessageCapabilities;
-import com.netflix.msl.msg.MessageStreamFactory;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
@@ -65,7 +64,7 @@ import com.netflix.msl.util.NullMslStore;
  * User: skommidi
  * Date: 9/22/14
  */
-public class WiretapMslContext implements MslContext {
+public class WiretapMslContext extends MslContext {
 
     /**
      * Key exchange factory comparator.
@@ -111,8 +110,6 @@ public class WiretapMslContext implements MslContext {
         final SecretKey mslWrappingKey = new SecretKeySpec(MSL_WRAPPING_KEY, JcaAlgorithm.AESKW);
         this.mslCryptoContext = new SymmetricCryptoContext(this, "TestMslKeys", mslEncryptionKey, mslHmacKey, mslWrappingKey);
         
-        this.messageStreamFactory = new MessageStreamFactory();
-
         // Entity authentication factories are mapped as-is.
         final Map<EntityAuthenticationScheme,EntityAuthenticationFactory> entityAuthFactoriesMap = new HashMap<EntityAuthenticationScheme,EntityAuthenticationFactory>();
         for (final EntityAuthenticationFactory factory : entityAuthFactories) {
@@ -299,8 +296,6 @@ public class WiretapMslContext implements MslContext {
     private EntityAuthenticationData entityAuthData = new UnauthenticatedAuthenticationData("WireTap");
     /** MSL token crypto context. */
     private final ICryptoContext mslCryptoContext;
-    /** Message factory. */
-    private final MessageStreamFactory messageStreamFactory;
     /** Map of supported entity authentication schemes onto factories. */
     private final Map<EntityAuthenticationScheme, EntityAuthenticationFactory> entityAuthFactories;
     /** Map of supported user authentication schemes onto factories. */

--- a/examples/kancolle/src/main/java/kancolle/util/KanColleMslContext.java
+++ b/examples/kancolle/src/main/java/kancolle/util/KanColleMslContext.java
@@ -49,7 +49,6 @@ import com.netflix.msl.keyx.DiffieHellmanParameters;
 import com.netflix.msl.keyx.KeyExchangeFactory;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageCapabilities;
-import com.netflix.msl.msg.MessageStreamFactory;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
@@ -62,7 +61,7 @@ import com.netflix.msl.util.SimpleMslStore;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public abstract class KanColleMslContext implements MslContext {
+public abstract class KanColleMslContext extends MslContext {
     /**
      * Create a new KanColle MSL context.
      * 
@@ -76,9 +75,6 @@ public abstract class KanColleMslContext implements MslContext {
         compressionAlgos.add(CompressionAlgorithm.GZIP);
         final List<String> languages = Arrays.asList(KanColleConstants.en_US, KanColleConstants.ja_JP);
         this.messageCaps = new MessageCapabilities(compressionAlgos, languages);
-        
-        // Message factory.
-        this.messageStreamFactory = new MessageStreamFactory();
         
         // Auxiliary authentication classes.
         final DiffieHellmanParameters params = new KanColleDiffieHellmanParameters();
@@ -209,8 +205,6 @@ public abstract class KanColleMslContext implements MslContext {
     
     /** Message capabilities. */
     private final MessageCapabilities messageCaps;
-    /** Message factory. */
-    private final MessageStreamFactory messageStreamFactory;
     /** Entity authentication factories by scheme. */
     private final Map<EntityAuthenticationScheme,EntityAuthenticationFactory> entityAuthFactories = new HashMap<EntityAuthenticationScheme,EntityAuthenticationFactory>();
     /** User authentication factories by scheme. */

--- a/examples/mslcli/src/main/java/mslcli/common/util/CommonMslContext.java
+++ b/examples/mslcli/src/main/java/mslcli/common/util/CommonMslContext.java
@@ -37,7 +37,6 @@ import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.keyx.KeyExchangeFactory;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageCapabilities;
-import com.netflix.msl.msg.MessageStreamFactory;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
@@ -50,7 +49,7 @@ import com.netflix.msl.util.MslStore;
  * @author Vadim Spector <vspector@netflix.com>
  */
 
-public abstract class CommonMslContext implements MslContext {
+public abstract class CommonMslContext extends MslContext {
     /**
      * <p>Create a new MSL context.</p>
      * 
@@ -74,9 +73,6 @@ public abstract class CommonMslContext implements MslContext {
         final Set<CompressionAlgorithm> compressionAlgos = new HashSet<CompressionAlgorithm>(Arrays.asList(CompressionAlgorithm.GZIP, CompressionAlgorithm.LZW));
         final List<String> languages = Arrays.asList("en-US");
         this.messageCaps = new MessageCapabilities(compressionAlgos, languages);
-        
-        // Message factory.
-        this.messageStreamFactory = new MessageStreamFactory();
         
         // Entity authentication factories.
         this.entityAuthFactories = mslCfg.getEntityAuthenticationFactories();
@@ -231,8 +227,6 @@ public abstract class CommonMslContext implements MslContext {
     private final MslConfig mslCfg;
     /** message capabilities */
     private final MessageCapabilities messageCaps;
-    /** message factory */
-    private final MessageStreamFactory messageStreamFactory;
     /** entity authentication factories */
     private final Set<EntityAuthenticationFactory> entityAuthFactories;
     /** user authentication factories */

--- a/examples/mslcli/src/main/java/mslcli/common/util/SharedUtil.java
+++ b/examples/mslcli/src/main/java/mslcli/common/util/SharedUtil.java
@@ -421,7 +421,7 @@ public final class SharedUtil {
     /**
      * this class is needed exclusively for deserialization of SimpleMslStore on the client side
      */
-    private static final class DummyMslContext implements MslContext {
+    private static final class DummyMslContext extends MslContext {
         @Override
         public long getTime() {
             return System.currentTimeMillis();

--- a/examples/simple/src/main/java/server/util/SimpleMslContext.java
+++ b/examples/simple/src/main/java/server/util/SimpleMslContext.java
@@ -47,7 +47,6 @@ import com.netflix.msl.keyx.AsymmetricWrappedExchange;
 import com.netflix.msl.keyx.KeyExchangeFactory;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageCapabilities;
-import com.netflix.msl.msg.MessageStreamFactory;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.userauth.EmailPasswordAuthenticationFactory;
 import com.netflix.msl.userauth.EmailPasswordStore;
@@ -63,7 +62,7 @@ import com.netflix.msl.util.NullMslStore;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public class SimpleMslContext implements MslContext {
+public class SimpleMslContext extends MslContext {
     /** MSL encryption key. */
     private static final byte[] MSL_ENCRYPTION_KEY = {
         (byte)0x1d, (byte)0x58, (byte)0xf3, (byte)0xb8, (byte)0xf7, (byte)0x47, (byte)0xd1, (byte)0x6a,
@@ -134,9 +133,6 @@ public class SimpleMslContext implements MslContext {
         
         // Create authentication utils.
         final AuthenticationUtils authutils = new SimpleAuthenticationUtils(serverId);
-        
-        // Message factory.
-        this.messageStreamFactory = new MessageStreamFactory();
         
         // Entity authentication.
         //
@@ -289,7 +285,6 @@ public class SimpleMslContext implements MslContext {
     private final MessageCapabilities messageCaps;
     private final EntityAuthenticationData entityAuthData;
     private final ICryptoContext mslCryptoContext;
-    private final MessageStreamFactory messageStreamFactory;
     private final Set<EntityAuthenticationFactory> entityAuthFactories;
     private final UserAuthenticationFactory userAuthFactory;
     private final TokenFactory tokenFactory = new SimpleTokenFactory();

--- a/examples/simple/src/main/javascript/client/util/SimpleMslContext.js
+++ b/examples/simple/src/main/javascript/client/util/SimpleMslContext.js
@@ -61,7 +61,6 @@ var SimpleMslContext;
                 _entityAuthData: { value: entityAuthData, writable: false, enumerable: false, configurable: false },
                 _mslCryptoContext: { value: new ClientMslCryptoContext(), writable: false, enumerable: false, configurable: false },
                 _entityAuthFactories: { value: entityAuthFactories, writable: false, enumerable: false, configurable: false },
-                _messageStreamFactory: { value: new MessageStreamFactory(), writable: false, enumerable: false, configurable: false },
                 _tokenFactory: { value: new ClientTokenFactory(), writable: false, enumerable: false, configurable: false },
                 _keyxFactories: { value: keyxFactories, writable: false, enumerable: false, configurable: false },
                 _store: { value: store, writable: false, enumerable: false, configurable: false },

--- a/tests/src/main/java/com/netflix/msl/util/MockMslContext.java
+++ b/tests/src/main/java/com/netflix/msl/util/MockMslContext.java
@@ -60,7 +60,6 @@ import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.keyx.MockDiffieHellmanParameters;
 import com.netflix.msl.keyx.SymmetricWrappedExchange;
 import com.netflix.msl.msg.MessageCapabilities;
-import com.netflix.msl.msg.MessageStreamFactory;
 import com.netflix.msl.tokens.MockTokenFactory;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.userauth.MockEmailPasswordAuthenticationFactory;
@@ -73,7 +72,7 @@ import com.netflix.msl.userauth.UserAuthenticationScheme;
  *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public class MockMslContext implements MslContext {
+public class MockMslContext extends MslContext {
     /** MSL encryption key. */
     private static final byte[] MSL_ENCRYPTION_KEY = {
         (byte)0x1d, (byte)0x58, (byte)0xf3, (byte)0xb8, (byte)0xf7, (byte)0x47, (byte)0xd1, (byte)0x6a,
@@ -304,15 +303,6 @@ public class MockMslContext implements MslContext {
     public UserAuthenticationFactory getUserAuthenticationFactory(final UserAuthenticationScheme scheme) {
         return userAuthFactories.get(scheme);
     }
-    
-    /**
-     * Sets the message factory.
-     * 
-     * @param factory the message factory.
-     */
-    public void setMessageStreamFactory(final MessageStreamFactory factory) {
-        this.messageStreamFactory = factory;
-    }
 
     /**
      * Sets the token factory.
@@ -388,8 +378,6 @@ public class MockMslContext implements MslContext {
     private EntityAuthenticationData entityAuthData;
     /** MSL crypto context. */
     private ICryptoContext mslCryptoContext;
-    /** Message factory. */
-    private MessageStreamFactory messageStreamFactory;
     /** Map of supported entity authentication schemes onto factories. */
     private final Map<EntityAuthenticationScheme,EntityAuthenticationFactory> entityAuthFactories;
     /** Map of supported user authentication schemes onto factories. */

--- a/tests/src/main/javascript/util/MockMslContext.js
+++ b/tests/src/main/javascript/util/MockMslContext.js
@@ -147,9 +147,6 @@ var MockMslContext$create;
 
 		            // Set the MSL crypto context.
 		            var mslCryptoContext = new SymmetricCryptoContext(this, "TestMslKeys", mslEncryptionKey, mslHmacKey, mslWrapKey);
-		            
-		            // Set up message factory.
-		            var messageStreamFactory = new MessageStreamFactory();
 
 		            // Set up token factory.
 		            var tokenFactory = new MockTokenFactory();
@@ -174,7 +171,6 @@ var MockMslContext$create;
 		                _entityAuthData: { value: entityAuthData, writable: true, enumerable: false, configurable: false },
 		                _entityAuthFactories: { value: entityAuthFactories, writable: false, enumerable: false, configurable: false },
 		                _userAuthFactories: { value: userAuthFactories, writable: false, enumerable: false, configurable: false },
-		                _messageStreamFactory: { value: messageStreamFactory, writable: true, enumerable: false, configurable: false },
 		                _tokenFactory: { value: tokenFactory, writable: true, enumerable: false, configurable: false },
 		                _paramSpecs: { value: paramSpecs, writable: false, enumerable: false, configurable: false },
 		                _keyxFactories: { value: keyxFactories, writable: false, enumerable: false, configurable: false },


### PR DESCRIPTION
Fixes #50.

* Move MSL context remote clock state out of MslControl and into MslContext. This changes MslContext from an interface to an abstract class.
* Change MslControl master token read-write lock state to include the MslContext in the lookup key; this prevents collisions in the rare case multiple MslContexts have master tokens with the same serial number, sequence number, and expiration (very unlikely).
* Remove leftover unused definitions of MessageStreamFactory from MslContext derived classes.