### PR TITLE
Using gretty plugin to run the simple server

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,14 @@
+# MSL Simple
+
+Project represents a client and server configured to be used together.
+
+# Running server
+
+Gradle is configured to be able to run the server on port 8080:
+
+    ./gradlew :msl-example:appRun
+    
+    
+# Running client
+
+Open _src/main/javascript/client/SimpleClient.html_ in your web browser.

--- a/examples/simple/build.gradle
+++ b/examples/simple/build.gradle
@@ -1,5 +1,15 @@
+buildscript {
+    repositories { jcenter() }
+    dependencies { classpath 'org.akhikhl.gretty:gretty:latest.release' }
+}
+
 apply plugin: 'war'
 apply plugin: 'eclipse-wtp'
+
+apply plugin: 'org.akhikhl.gretty'
+gretty {
+    integrationTestTask = 'test'
+}
 
 dependencies {
     compile 'javax.servlet:servlet-api:2.5'


### PR DESCRIPTION
Similar to how integration tests are run.

@semmypurewal Just run ./gradlew :msl-example:appRun and the server will start.