### PR TITLE
Specify context path for gretty deployment.

### DIFF
--- a/examples/simple/build.gradle
+++ b/examples/simple/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'eclipse-wtp'
 
 apply plugin: 'org.akhikhl.gretty'
 gretty {
-    integrationTestTask = 'test'
+    contextPath = "/msl-example-server"
 }
 
 dependencies {


### PR DESCRIPTION
Fixes #62.

Also remove gretty test integration test task (there is no test target for this project).