### PR TITLE
Set configuration data at construction time to avoid runtime exceptions during MslControl.request()

### DIFF
--- a/examples/mslcli/src/main/java/mslcli/client/Client.java
+++ b/examples/mslcli/src/main/java/mslcli/client/Client.java
@@ -18,32 +18,24 @@ package mslcli.client;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
-import com.netflix.msl.MslException;
-import com.netflix.msl.MslKeyExchangeException;
-import com.netflix.msl.keyx.KeyRequestData;
-import com.netflix.msl.msg.ErrorHeader;
-import com.netflix.msl.msg.MessageContext;
-import com.netflix.msl.msg.MslControl;
-import com.netflix.msl.msg.MslControl.MslChannel;
-import com.netflix.msl.userauth.UserAuthenticationData;
-import com.netflix.msl.util.MslContext;
-import com.netflix.msl.util.MslStore;
 
 import mslcli.client.msg.ClientRequestMessageContext;
 import mslcli.client.util.ClientMslContext;
 import mslcli.common.CmdArguments;
 import mslcli.common.IllegalCmdArgumentException;
-import mslcli.common.IllegalCmdArgumentRuntimeException;
 import mslcli.common.util.AppContext;
 import mslcli.common.util.ConfigurationException;
-import mslcli.common.util.ConfigurationRuntimeException;
 import mslcli.common.util.SharedUtil;
+
+import com.netflix.msl.MslException;
+import com.netflix.msl.msg.ErrorHeader;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MslControl;
+import com.netflix.msl.msg.MslControl.MslChannel;
+import com.netflix.msl.util.MslContext;
+import com.netflix.msl.util.MslStore;
 
 /**
  * <p>
@@ -116,9 +108,6 @@ public final class Client {
         this.mslCfg = new ClientMslConfig(appCtx, this.args);
         this.mslCfg.validate();
 
-        // Init up the MSL context
-        this.mslCtx = new ClientMslContext(appCtx, mslCfg);
-
         // Set up the MSL Control
         this.mslCtrl = appCtx.getMslControl();
 
@@ -177,6 +166,7 @@ public final class Client {
         // set remote URL
         final URL remoteUrl = args.getUrl();
 
+        final MslContext mslCtx = new ClientMslContext(appCtx, mslCfg);
         final MessageContext msgCtx = new ClientRequestMessageContext(mslCfg, request);
 
         final Future<MslChannel> f = mslCtrl.request(mslCtx, msgCtx, remoteUrl, TIMEOUT_MS);
@@ -225,9 +215,6 @@ public final class Client {
 
     /** Args */
     private final CmdArguments args;
-
-    /** MSL context */
-    private final MslContext mslCtx;
 
     /** MSL config */
     private final ClientMslConfig mslCfg;

--- a/examples/mslcli/src/main/java/mslcli/common/util/CommonMslContext.java
+++ b/examples/mslcli/src/main/java/mslcli/common/util/CommonMslContext.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.SortedSet;
 
 import mslcli.common.IllegalCmdArgumentException;
-import mslcli.common.IllegalCmdArgumentRuntimeException;
 import mslcli.common.MslConfig;
 
 import com.netflix.msl.MslConstants.CompressionAlgorithm;
@@ -68,6 +67,9 @@ public abstract class CommonMslContext extends MslContext {
 
         // Initialize MSL config.
         this.mslCfg = mslCfg;
+        
+        // Entity authentication data.
+        this.entityAuthData = mslCfg.getEntityAuthenticationData();
 
         // Message capabilities.
         final Set<CompressionAlgorithm> compressionAlgos = new HashSet<CompressionAlgorithm>(Arrays.asList(CompressionAlgorithm.GZIP, CompressionAlgorithm.LZW));
@@ -121,13 +123,7 @@ public abstract class CommonMslContext extends MslContext {
      */
     @Override
     public final EntityAuthenticationData getEntityAuthenticationData(final ReauthCode reauthCode) {
-        try {
-            return mslCfg.getEntityAuthenticationData();
-        } catch (final ConfigurationException e) {
-            throw new ConfigurationRuntimeException(e);
-        } catch (final IllegalCmdArgumentException e) {
-            throw new IllegalCmdArgumentRuntimeException(e);
-        }
+        return entityAuthData;
     }
 
     /* (non-Javadoc)
@@ -225,6 +221,8 @@ public abstract class CommonMslContext extends MslContext {
 
     /** MSL config */
     private final MslConfig mslCfg;
+    /** Entity authentication data. */
+    private final EntityAuthenticationData entityAuthData;
     /** message capabilities */
     private final MessageCapabilities messageCaps;
     /** entity authentication factories */


### PR DESCRIPTION
* Set ClientRequestMessageContext user ID, user auth data, and key request data at context creation.
* Set CommonMslContext entity auth data at context creation.
* Change Client to instantiate, and therefore reconfigure with the latest values, the MslContext just prior to calling MslControl.request(). This is OK for now because the MslStore is shared via the appCtx, and we don't really care about having the remote entity clock synchronized.

These changes together prevent RuntimeExceptions from being thrown as a result of the MslContext, MessageContext, or MslConfiguration being incomplete or unusable only after calling MslControl.request().