### PR TITLE
Increase readability of equals/hashCode for MessageHeader/ErrorHeader

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -335,7 +335,7 @@ public class ErrorHeader extends Header {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof ErrorHeader)) {
             return false;
         }
         final ErrorHeader other = (ErrorHeader) obj;

--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -332,12 +332,10 @@ public class ErrorHeader extends Header {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof ErrorHeader)) {
-            return false;
-        }
+        if (this == obj) return true;
+
+        if (!(obj instanceof ErrorHeader)) return false;
+
         final ErrorHeader that = (ErrorHeader) obj;
         return Objects.equals(this.entityAuthData, that.entityAuthData)
                 && Objects.equals(this.recipient, that.recipient)

--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -338,15 +338,15 @@ public class ErrorHeader extends Header {
         if (!(obj instanceof ErrorHeader)) {
             return false;
         }
-        final ErrorHeader other = (ErrorHeader) obj;
-        return Objects.equals(this.entityAuthData, other.entityAuthData)
-                && Objects.equals(this.recipient, other.recipient)
-                && Objects.equals(this.timestamp, other.timestamp)
-                && Objects.equals(this.messageId, other.messageId)
-                && Objects.equals(this.errorCode, other.errorCode)
-                && Objects.equals(this.internalCode, other.internalCode)
-                && Objects.equals(this.errorMsg, other.errorMsg)
-                && Objects.equals(this.userMsg, other.userMsg);
+        final ErrorHeader that = (ErrorHeader) obj;
+        return Objects.equals(this.entityAuthData, that.entityAuthData)
+                && Objects.equals(this.recipient, that.recipient)
+                && Objects.equals(this.timestamp, that.timestamp)
+                && Objects.equals(this.messageId, that.messageId)
+                && Objects.equals(this.errorCode, that.errorCode)
+                && Objects.equals(this.internalCode, that.internalCode)
+                && Objects.equals(this.errorMsg, that.errorMsg)
+                && Objects.equals(this.userMsg, that.userMsg);
     }
 
     /* (non-Javadoc)

--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -16,6 +16,7 @@
 package com.netflix.msl.msg;
 
 import java.util.Date;
+import java.util.Objects;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -330,19 +331,22 @@ public class ErrorHeader extends Header {
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
-    public boolean equals(final Object obj) {
-        if (obj == this) return true;
-        if (!(obj instanceof ErrorHeader)) return false;
-        final ErrorHeader that = (ErrorHeader)obj;
-        return entityAuthData.equals(that.entityAuthData) &&
-            (recipient == that.recipient || (recipient != null && recipient.equals(that.recipient))) &&
-            (timestamp != null && timestamp.equals(that.timestamp) ||
-             timestamp == null && that.timestamp == null) &&
-            messageId == that.messageId &&
-            errorCode == that.errorCode &&
-            internalCode == that.internalCode &&
-            (errorMsg == that.errorMsg || (errorMsg != null && errorMsg.equals(that.errorMsg))) &&
-            (userMsg == that.userMsg || (userMsg != null && userMsg.equals(that.userMsg)));
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ErrorHeader other = (ErrorHeader) obj;
+        return Objects.equals(this.entityAuthData, other.entityAuthData)
+                && Objects.equals(this.recipient, other.recipient)
+                && Objects.equals(this.timestamp, other.timestamp)
+                && Objects.equals(this.messageId, other.messageId)
+                && Objects.equals(this.errorCode, other.errorCode)
+                && Objects.equals(this.internalCode, other.internalCode)
+                && Objects.equals(this.errorMsg, other.errorMsg)
+                && Objects.equals(this.userMsg, other.userMsg);
     }
 
     /* (non-Javadoc)
@@ -350,14 +354,7 @@ public class ErrorHeader extends Header {
      */
     @Override
     public int hashCode() {
-        return entityAuthData.hashCode() ^
-            ((recipient != null) ? recipient.hashCode() : 0) ^
-            ((timestamp != null) ? timestamp.hashCode() : 0) ^
-            Long.valueOf(messageId).hashCode() ^
-            errorCode.hashCode() ^
-            Integer.valueOf(internalCode).hashCode() ^
-            ((errorMsg != null) ? errorMsg.hashCode() : 0) ^
-            ((userMsg != null) ? userMsg.hashCode() : 0);
+        return Objects.hash(entityAuthData, recipient, timestamp, messageId, errorCode, internalCode, errorMsg, userMsg);
     }
 
     /** Entity authentication data. */

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -961,7 +961,7 @@ public class MessageHeader extends Header {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof MessageHeader)) {
             return false;
         }
         final MessageHeader other = (MessageHeader) obj;

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -964,25 +964,25 @@ public class MessageHeader extends Header {
         if (!(obj instanceof MessageHeader)) {
             return false;
         }
-        final MessageHeader other = (MessageHeader) obj;
-        return (Objects.equals(this.entityAuthData, other.entityAuthData)
-                || Objects.equals(this.masterToken, other.masterToken))
-                && Objects.equals(this.sender, other.sender)
-                && Objects.equals(this.recipient, other.recipient)
-                && Objects.equals(this.timestamp, other.timestamp)
-                && Objects.equals(this.messageId, other.messageId)
-                && Objects.equals(this.nonReplayableId, other.nonReplayableId)
-                && Objects.equals(this.renewable, other.renewable)
-                && Objects.equals(this.handshake, other.handshake)
-                && Objects.equals(this.capabilities, other.capabilities)
-                && Objects.equals(this.keyRequestData, other.keyRequestData)
-                && Objects.equals(this.keyResponseData, other.keyResponseData)
-                && Objects.equals(this.userAuthData, other.userAuthData)
-                && Objects.equals(this.userIdToken, other.userIdToken)
-                && Objects.equals(this.serviceTokens, other.serviceTokens)
-                && Objects.equals(this.peerMasterToken, other.peerMasterToken)
-                && Objects.equals(this.peerUserIdToken, other.peerUserIdToken)
-                && Objects.equals(this.peerServiceTokens, other.peerServiceTokens);
+        final MessageHeader that = (MessageHeader) obj;
+        return (Objects.equals(this.entityAuthData, that.entityAuthData)
+                || Objects.equals(this.masterToken, that.masterToken))
+                && Objects.equals(this.sender, that.sender)
+                && Objects.equals(this.recipient, that.recipient)
+                && Objects.equals(this.timestamp, that.timestamp)
+                && Objects.equals(this.messageId, that.messageId)
+                && Objects.equals(this.nonReplayableId, that.nonReplayableId)
+                && Objects.equals(this.renewable, that.renewable)
+                && Objects.equals(this.handshake, that.handshake)
+                && Objects.equals(this.capabilities, that.capabilities)
+                && Objects.equals(this.keyRequestData, that.keyRequestData)
+                && Objects.equals(this.keyResponseData, that.keyResponseData)
+                && Objects.equals(this.userAuthData, that.userAuthData)
+                && Objects.equals(this.userIdToken, that.userIdToken)
+                && Objects.equals(this.serviceTokens, that.serviceTokens)
+                && Objects.equals(this.peerMasterToken, that.peerMasterToken)
+                && Objects.equals(this.peerUserIdToken, that.peerUserIdToken)
+                && Objects.equals(this.peerServiceTokens, that.peerServiceTokens);
     }
 
     /* (non-Javadoc)

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.xml.bind.DatatypeConverter;
@@ -956,38 +957,32 @@ public class MessageHeader extends Header {
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
-    public boolean equals(final Object obj) {
-        if (obj == this) return true;
-        if (!(obj instanceof MessageHeader)) return false;
-        final MessageHeader that = (MessageHeader)obj;
-        return (masterToken != null && masterToken.equals(that.masterToken) ||
-                entityAuthData != null && entityAuthData.equals(that.entityAuthData)) &&
-               (sender != null && sender.equals(that.sender) ||
-                sender == that.sender) &&
-               (recipient != null && recipient.equals(that.recipient) ||
-                recipient == that.recipient) &&
-               (timestamp != null && timestamp.equals(that.timestamp) ||
-                timestamp == null && that.timestamp == null) &&
-               messageId == that.messageId &&
-               (nonReplayableId != null && nonReplayableId.equals(that.nonReplayableId) ||
-                nonReplayableId == null && that.nonReplayableId == null) &&
-               renewable == that.renewable &&
-               handshake == that.handshake &&
-               (capabilities != null && capabilities.equals(that.capabilities) ||
-                capabilities == that.capabilities) &&
-               keyRequestData.equals(that.keyRequestData) &&
-               (keyResponseData != null && keyResponseData.equals(that.keyResponseData) ||
-                keyResponseData == that.keyResponseData) &&
-               (userAuthData != null && userAuthData.equals(that.userAuthData) ||
-                userAuthData == that.userAuthData) &&
-               (userIdToken != null && userIdToken.equals(that.userIdToken) ||
-                userIdToken == that.userIdToken) &&
-               serviceTokens.equals(that.serviceTokens) &&
-               (peerMasterToken != null && peerMasterToken.equals(that.peerMasterToken) ||
-                peerMasterToken == that.peerMasterToken) &&
-               (peerUserIdToken != null && peerUserIdToken.equals(that.peerUserIdToken) ||
-                peerUserIdToken == that.peerUserIdToken) &&
-               peerServiceTokens.equals(that.peerServiceTokens);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final MessageHeader other = (MessageHeader) obj;
+        return (Objects.equals(this.entityAuthData, other.entityAuthData)
+                || Objects.equals(this.masterToken, other.masterToken))
+                && Objects.equals(this.sender, other.sender)
+                && Objects.equals(this.recipient, other.recipient)
+                && Objects.equals(this.timestamp, other.timestamp)
+                && Objects.equals(this.messageId, other.messageId)
+                && Objects.equals(this.nonReplayableId, other.nonReplayableId)
+                && Objects.equals(this.renewable, other.renewable)
+                && Objects.equals(this.handshake, other.handshake)
+                && Objects.equals(this.capabilities, other.capabilities)
+                && Objects.equals(this.keyRequestData, other.keyRequestData)
+                && Objects.equals(this.keyResponseData, other.keyResponseData)
+                && Objects.equals(this.userAuthData, other.userAuthData)
+                && Objects.equals(this.userIdToken, other.userIdToken)
+                && Objects.equals(this.serviceTokens, other.serviceTokens)
+                && Objects.equals(this.peerMasterToken, other.peerMasterToken)
+                && Objects.equals(this.peerUserIdToken, other.peerUserIdToken)
+                && Objects.equals(this.peerServiceTokens, other.peerServiceTokens);
     }
 
     /* (non-Javadoc)
@@ -995,23 +990,24 @@ public class MessageHeader extends Header {
      */
     @Override
     public int hashCode() {
-        return ((masterToken != null) ? masterToken.hashCode() : entityAuthData.hashCode()) ^
-            ((sender != null) ? sender.hashCode() : 0) ^
-            ((recipient != null) ? recipient.hashCode() : 0) ^
-            ((timestamp != null) ? timestamp.hashCode() : 0) ^
-            Long.valueOf(messageId).hashCode() ^
-            ((nonReplayableId != null) ? nonReplayableId.hashCode() : 0) ^
-            Boolean.valueOf(renewable).hashCode() ^
-            Boolean.valueOf(handshake).hashCode() ^
-            ((capabilities != null) ? capabilities.hashCode() : 0) ^
-            keyRequestData.hashCode() ^
-            ((keyResponseData != null) ? keyResponseData.hashCode() : 0) ^
-            ((userAuthData != null) ? userAuthData.hashCode() : 0) ^
-            ((userIdToken != null) ? userIdToken.hashCode() : 0) ^
-            serviceTokens.hashCode() ^
-            ((peerMasterToken != null) ? peerMasterToken.hashCode() : 0) ^
-            ((peerUserIdToken != null) ? peerUserIdToken.hashCode() : 0) ^
-            peerServiceTokens.hashCode();
+        Object target = (masterToken != null) ? masterToken : entityAuthData;
+        return Objects.hash(target,
+                sender,
+                recipient,
+                timestamp,
+                messageId,
+                nonReplayableId,
+                renewable,
+                handshake,
+                capabilities,
+                keyRequestData,
+                keyResponseData,
+                userAuthData,
+                userIdToken,
+                serviceTokens,
+                peerMasterToken,
+                peerUserIdToken,
+                peerServiceTokens);
     }
 
     /** Entity authentication data. */

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -958,12 +958,10 @@ public class MessageHeader extends Header {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof MessageHeader)) {
-            return false;
-        }
+        if (this == obj) return true;
+
+        if (!(obj instanceof MessageHeader)) return false;
+
         final MessageHeader that = (MessageHeader) obj;
         return (Objects.equals(this.entityAuthData, that.entityAuthData)
                 || Objects.equals(this.masterToken, that.masterToken))


### PR DESCRIPTION
Also avoid == on strings, even if it's to check if both are null.