### PR TITLE
Allow key exchange factories to provide issuer data to master tokens.

### DIFF
--- a/core/src/main/java/com/netflix/msl/keyx/AsymmetricWrappedExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/AsymmetricWrappedExchange.java
@@ -666,7 +666,7 @@ public class AsymmetricWrappedExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey);
+        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, null);
         
         // Create crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);
@@ -734,7 +734,7 @@ public class AsymmetricWrappedExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken masterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey);
+        final MasterToken masterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey, null);
         
         // Create crypto context.
         final ICryptoContext cryptoContext;

--- a/core/src/main/java/com/netflix/msl/keyx/DiffieHellmanExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/DiffieHellmanExchange.java
@@ -490,7 +490,7 @@ public class DiffieHellmanExchange extends KeyExchangeFactory {
 
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, sessionKeys.encryptionKey, sessionKeys.hmacKey);
+        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, sessionKeys.encryptionKey, sessionKeys.hmacKey, null);
 
         // Create crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);
@@ -553,7 +553,7 @@ public class DiffieHellmanExchange extends KeyExchangeFactory {
 
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken masterToken = tokenFactory.createMasterToken(ctx, entityAuthData, sessionKeys.encryptionKey, sessionKeys.hmacKey);
+        final MasterToken masterToken = tokenFactory.createMasterToken(ctx, entityAuthData, sessionKeys.encryptionKey, sessionKeys.hmacKey, null);
 
         // Create crypto context.
         final ICryptoContext cryptoContext;

--- a/core/src/main/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchange.java
@@ -527,7 +527,7 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey);
+        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, null);
         
         // Create session crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);
@@ -588,7 +588,7 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey);
+        final MasterToken newMasterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey, null);
         
         // Create session crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);

--- a/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
@@ -699,7 +699,7 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey);
+        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, null);
         
         // Create session crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);
@@ -758,7 +758,7 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey);
+        final MasterToken newMasterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey, null);
         
         // Create session crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);

--- a/core/src/main/java/com/netflix/msl/keyx/SymmetricWrappedExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/SymmetricWrappedExchange.java
@@ -395,7 +395,7 @@ public class SymmetricWrappedExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey);
+        final MasterToken newMasterToken = tokenFactory.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, null);
         
         // Create crypto context.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, newMasterToken);
@@ -440,7 +440,7 @@ public class SymmetricWrappedExchange extends KeyExchangeFactory {
         
         // Create the master token.
         final TokenFactory tokenFactory = ctx.getTokenFactory();
-        final MasterToken masterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey);
+        final MasterToken masterToken = tokenFactory.createMasterToken(ctx, entityAuthData, encryptionKey, hmacKey, null);
         
         // Create crypto context.
         final ICryptoContext cryptoContext;

--- a/core/src/main/java/com/netflix/msl/tokens/ClientTokenFactory.java
+++ b/core/src/main/java/com/netflix/msl/tokens/ClientTokenFactory.java
@@ -17,6 +17,8 @@ package com.netflix.msl.tokens;
 
 import javax.crypto.SecretKey;
 
+import org.json.JSONObject;
+
 import com.netflix.msl.MslError;
 import com.netflix.msl.MslInternalException;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
@@ -48,10 +50,10 @@ public class ClientTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey) {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) {
         throw new MslInternalException("Creating master tokens is unsupported by the token factory.");
     }
 
@@ -64,10 +66,10 @@ public class ClientTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) {
         throw new MslInternalException("Renewing master tokens is unsupported by the token factory.");
     }
 

--- a/core/src/main/java/com/netflix/msl/tokens/TokenFactory.java
+++ b/core/src/main/java/com/netflix/msl/tokens/TokenFactory.java
@@ -17,6 +17,8 @@ package com.netflix.msl.tokens;
 
 import javax.crypto.SecretKey;
 
+import org.json.JSONObject;
+
 import com.netflix.msl.MslConstants.ResponseCode;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
@@ -95,7 +97,7 @@ public interface TokenFactory {
      * @throws MslMasterTokenException if the master token is not trusted.
      * @throws MslException if there is an error comparing or updating the non-
      *         replayable ID associated with this master token.
-     * @see #createMasterToken(MslContext, EntityAuthenticationData, SecretKey, SecretKey)
+     * @see #createMasterToken(MslContext, EntityAuthenticationData, SecretKey, SecretKey, JSONObject)
      * @see MslError.MESSAGE_REPLAYED
      * @see MslError.MESSAGE_REPLAYED_UNRECOVERABLE
      */
@@ -114,6 +116,8 @@ public interface TokenFactory {
      * @param entityAuthData the entity authentication data.
      * @param encryptionKey the session encryption key.
      * @param hmacKey the session HMAC key.
+     * @param issuerData optional master token issuer data that should be
+     *        included in the master token.
      * @return the new master token.
      * @throws MslEncodingException if there is an error encoding the JSON
      *         data.
@@ -122,7 +126,7 @@ public interface TokenFactory {
      * @throws MslException if there is an error creating the master token.
      * @see #acceptNonReplayableId(MslContext, MasterToken, long)
      */
-    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException, MslException;
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException, MslException;
 
     /**
      * <p>Check if the master token would be renewed by a call to
@@ -138,7 +142,7 @@ public interface TokenFactory {
      * @throws MslMasterTokenException if the master token is not trusted.
      * @throws MslException if there is an error checking the master token
      *         renewability.
-     * @see #renewMasterToken(MslContext, MasterToken, SecretKey, SecretKey)
+     * @see #renewMasterToken(MslContext, MasterToken, SecretKey, SecretKey, JSONObject)
      */
     public MslError isMasterTokenRenewable(final MslContext ctx, final MasterToken masterToken) throws MslMasterTokenException, MslException;
     
@@ -152,6 +156,8 @@ public interface TokenFactory {
      * @param masterToken the master token to renew.
      * @param encryptionKey the session encryption key.
      * @param hmacKey the session HMAC key.
+     * @param issuerData optional master token issuer data that should be
+     *        merged into or overwrite any existing issuer data.
      * @return the new master token.
      * @throws MslEncodingException if there is an error encoding the JSON
      *         data.
@@ -162,7 +168,7 @@ public interface TokenFactory {
      * @throws MslException if there is an error renewing the master token.
      * @see #isMasterTokenRenewable(MslContext, MasterToken)
      */
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslException;
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslException;
     
     /**
      * <p>Return false if the user ID token has been revoked.</p>

--- a/core/src/main/java/com/netflix/msl/tokens/TokenFactory.java
+++ b/core/src/main/java/com/netflix/msl/tokens/TokenFactory.java
@@ -117,7 +117,7 @@ public interface TokenFactory {
      * @param encryptionKey the session encryption key.
      * @param hmacKey the session HMAC key.
      * @param issuerData optional master token issuer data that should be
-     *        included in the master token.
+     *        included in the master token. May be {@code null}.
      * @return the new master token.
      * @throws MslEncodingException if there is an error encoding the JSON
      *         data.
@@ -157,7 +157,8 @@ public interface TokenFactory {
      * @param encryptionKey the session encryption key.
      * @param hmacKey the session HMAC key.
      * @param issuerData optional master token issuer data that should be
-     *        merged into or overwrite any existing issuer data.
+     *        merged into or overwrite any existing issuer data. May be
+     *        {@code null}.
      * @return the new master token.
      * @throws MslEncodingException if there is an error encoding the JSON
      *         data.

--- a/core/src/main/java/com/netflix/msl/util/JsonUtils.java
+++ b/core/src/main/java/com/netflix/msl/util/JsonUtils.java
@@ -299,4 +299,32 @@ public class JsonUtils {
         }
         return s1.equals(s2);
     }
+    
+    /**
+     * Merge two JSON objects into a single JSON object. If the same key is
+     * found in both objects, the second object's value is used. The values are
+     * copied by reference so this is a shallow copy.
+     * 
+     * @param jo1 first JSON object. May be null.
+     * @param jo2 second JSON object. May be null.
+     * @return the merged JSON object or null if both arguments are null.
+     */
+    public static JSONObject merge(final JSONObject jo1, final JSONObject jo2) {
+        // Return null if both objects are null.
+        if (jo1 == null && jo2 == null);
+        
+        // Make a copy of the first object, or create an empty object.
+        final JSONObject jo = (jo1 != null)
+            ? new JSONObject(jo1, JSONObject.getNames(jo1))
+            : new JSONObject();
+        
+        // If the second object is null, we're done and just return the copy.
+        if (jo2 == null)
+            return jo;
+        
+        // Copy the contents of the second object into the final object.
+        for (final String key : JSONObject.getNames(jo2))
+            jo.put(key, jo2.get(key));
+        return jo;
+    }
 }

--- a/core/src/main/java/com/netflix/msl/util/JsonUtils.java
+++ b/core/src/main/java/com/netflix/msl/util/JsonUtils.java
@@ -311,7 +311,8 @@ public class JsonUtils {
      */
     public static JSONObject merge(final JSONObject jo1, final JSONObject jo2) {
         // Return null if both objects are null.
-        if (jo1 == null && jo2 == null);
+        if (jo1 == null && jo2 == null)
+            return null;
         
         // Make a copy of the first object, or create an empty object.
         final JSONObject jo = (jo1 != null)

--- a/core/src/main/javascript/keyx/AsymmetricWrappedExchange.js
+++ b/core/src/main/javascript/keyx/AsymmetricWrappedExchange.js
@@ -453,7 +453,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                     // Create the master token.
                     var tokenFactory = ctx.getTokenFactory();
                     if (entityToken instanceof MasterToken) {
-                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create crypto context.
@@ -473,7 +473,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                             }
                         });
                     } else {
-                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create crypto context.

--- a/core/src/main/javascript/keyx/DiffieHellmanExchange.js
+++ b/core/src/main/javascript/keyx/DiffieHellmanExchange.js
@@ -413,7 +413,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                             // Create the master token.
                             var tokenFactory = ctx.getTokenFactory();
                             if (entityToken instanceof MasterToken) {
-                                tokenFactory.renewMasterToken(ctx, entityToken, sessionKeys.encryptionKey, sessionKeys.hmacKey, {
+                                tokenFactory.renewMasterToken(ctx, entityToken, sessionKeys.encryptionKey, sessionKeys.hmacKey, null, {
                                     result: function(masterToken) {
                                         AsyncExecutor(callback, function() {
                                             // Create crypto context.
@@ -433,7 +433,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                                     }
                                 });
                             } else {
-                                tokenFactory.createMasterToken(ctx, entityToken, sessionKeys.encryptionKey, sessionKeys.hmacKey, {
+                                tokenFactory.createMasterToken(ctx, entityToken, sessionKeys.encryptionKey, sessionKeys.hmacKey, null, {
                                     result: function(masterToken) {
                                         AsyncExecutor(callback, function() {
                                             // Create crypto context.

--- a/core/src/main/javascript/keyx/JsonWebEncryptionLadderExchange.js
+++ b/core/src/main/javascript/keyx/JsonWebEncryptionLadderExchange.js
@@ -545,7 +545,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                     // Create the master token.
                     var tokenFactory = ctx.getTokenFactory();
                     if (entityToken instanceof MasterToken) {
-                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create session crypto context.
@@ -565,7 +565,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                             }
                         });
                     } else {
-                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create session crypto context.

--- a/core/src/main/javascript/keyx/JsonWebKeyLadderExchange.js
+++ b/core/src/main/javascript/keyx/JsonWebKeyLadderExchange.js
@@ -635,7 +635,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                     // Create the master token.
                     var tokenFactory = ctx.getTokenFactory();
                     if (entityToken instanceof MasterToken) {
-                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create session crypto context.
@@ -655,7 +655,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                             }
                         });
                     } else {
-                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create session crypto context.

--- a/core/src/main/javascript/keyx/SymmetricWrappedExchange.js
+++ b/core/src/main/javascript/keyx/SymmetricWrappedExchange.js
@@ -406,7 +406,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                     // Create the master token.
                     var tokenFactory = ctx.getTokenFactory();
                     if (entityToken instanceof MasterToken) {
-                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.renewMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create crypto context.
@@ -435,7 +435,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                             }
                         });
                     } else {
-                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, {
+                        tokenFactory.createMasterToken(ctx, entityToken, encryptionKey, hmacKey, null, {
                             result: function(masterToken) {
                                 AsyncExecutor(callback, function() {
                                     // Create crypto context.

--- a/core/src/main/javascript/tokens/ClientTokenFactory.js
+++ b/core/src/main/javascript/tokens/ClientTokenFactory.js
@@ -34,7 +34,7 @@ var ClientTokenFactory = TokenFactory.extend({
     },
     
     /** @inheritDoc */
-    createMasterToken: function createMasterToken(ctx, entityToken, encryptionKey, hmacKey, callback) {
+    createMasterToken: function createMasterToken(ctx, entityToken, encryptionKey, hmacKey, issuerData, callback) {
         callback.error(new MslInternalException("Creating master tokens is unsupported by the token factory."));
     },
 
@@ -44,7 +44,7 @@ var ClientTokenFactory = TokenFactory.extend({
     },
     
     /** @inheritDoc */
-    renewMasterToken: function renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, callback) {
+    renewMasterToken: function renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, issuerData, callback) {
         callback.error(new MslInternalException("Renewing master tokens is unsupported by the token factory."));
     },
 

--- a/core/src/main/javascript/tokens/TokenFactory.js
+++ b/core/src/main/javascript/tokens/TokenFactory.js
@@ -106,7 +106,7 @@ var TokenFactory = util.Class.create({
      * @param {CipherKey} encryptionKey the session encryption key.
      * @param {CipherKey} hmacKey the session HMAC key.
      * @param {Object} issuerData optional master token issuer data that should be
-     *        included in the master token.
+     *        included in the master token. May be {@code null}.
      * @param {{result: function(MasterToken), error: function(Error)}}
      *        callback the callback functions that will receive the new master
      *        token or any thrown exceptions.
@@ -150,7 +150,8 @@ var TokenFactory = util.Class.create({
      * @param {CipherKey} encryptionKey the session encryption key.
      * @param {CipherKey} hmacKey the session HMAC key.
      * @param {Object} issuerData optional master token issuer data that should be
-     *        merged into or overwrite any existing issuer data.
+     *        merged into or overwrite any existing issuer data. May be
+     *        {@code null}.
      * @param {{result: function(MasterToken), error: function(Error)}}
      *        callback the callback functions that will receive the new master
      *        token or any thrown exceptions.

--- a/core/src/main/javascript/tokens/TokenFactory.js
+++ b/core/src/main/javascript/tokens/TokenFactory.js
@@ -86,7 +86,7 @@ var TokenFactory = util.Class.create({
      * @throws MslMasterTokenException if the master token is not trusted.
      * @throws MslException if there is an error comparing or updating the non-
      *         replayable ID associated with this master token.
-     * @see #createMasterToken(MslContext, EntityAuthenticationData, SecretKey, SecretKey)
+     * @see #createMasterToken(MslContext, EntityAuthenticationData, SecretKey, SecretKey, JSONObject)
      * @see MslError.MESSAGE_REPLAYED
      * @see MslError.MESSAGE_REPLAYED_UNRECOVERABLE
      */
@@ -105,6 +105,8 @@ var TokenFactory = util.Class.create({
      * @param {EntityAuthenticationData} entityAuthData the entity authentication data.
      * @param {CipherKey} encryptionKey the session encryption key.
      * @param {CipherKey} hmacKey the session HMAC key.
+     * @param {Object} issuerData optional master token issuer data that should be
+     *        included in the master token.
      * @param {{result: function(MasterToken), error: function(Error)}}
      *        callback the callback functions that will receive the new master
      *        token or any thrown exceptions.
@@ -115,7 +117,7 @@ var TokenFactory = util.Class.create({
      * @throws MslException if there is an error creating the master token.
      * @see #acceptNonReplayableId(MslContext, MasterToken, long)
      */
-    createMasterToken: function(ctx, entityAuthData, encryptionKey, hmacKey, callback) {},
+    createMasterToken: function(ctx, entityAuthData, encryptionKey, hmacKey, issuerData, callback) {},
 
     /**
      * <p>Check if the master token would be renewed by a call to
@@ -133,7 +135,7 @@ var TokenFactory = util.Class.create({
      * @throws MslMasterTokenException if the master token is not trusted.
      * @throws MslException if there is an error checking the master token
      *         renewability.
-     * @see #renewMasterToken(MslContext, MasterToken, SecretKey, SecretKey)
+     * @see #renewMasterToken(MslContext, MasterToken, SecretKey, SecretKey, JSONObject)
      */
     isMasterTokenRenewable: function(ctx, masterToken, callback) {},
     
@@ -147,6 +149,8 @@ var TokenFactory = util.Class.create({
      * @param {MasterToken} masterToken the master token to renew.
      * @param {CipherKey} encryptionKey the session encryption key.
      * @param {CipherKey} hmacKey the session HMAC key.
+     * @param {Object} issuerData optional master token issuer data that should be
+     *        merged into or overwrite any existing issuer data.
      * @param {{result: function(MasterToken), error: function(Error)}}
      *        callback the callback functions that will receive the new master
      *        token or any thrown exceptions.
@@ -159,7 +163,7 @@ var TokenFactory = util.Class.create({
      * @throws MslException if there is an error renewing the master token.
      * @see #isMasterTokenRenewable(MslContext, MasterToken)
      */
-    renewMasterToken: function(ctx, masterToken, encryptionKey, hmacKey, callback) {},
+    renewMasterToken: function(ctx, masterToken, encryptionKey, hmacKey, issuerData, callback) {},
 
     /**
      * <p>Return false if the user ID token has been revoked.</p>

--- a/core/src/main/javascript/util/JsonUtils.js
+++ b/core/src/main/javascript/util/JsonUtils.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var JsonUtils$merge;
+
+(function() {
+    "use strict";
+    
+    /**
+     * Merge two JSON objects into a single JSON object. If the same key is
+     * found in both objects, the second object's value is used. The values are
+     * copied by reference so this is a shallow copy.
+     * 
+     * @param {?Object} jo1 first JSON object. May be null.
+     * @param {?Object} jo2 second JSON object. May be null.
+     * @return {?Object} the merged JSON object or null if both arguments are null.
+     */
+    JsonUtils$merge = function JsonUtils$merge(jo1, jo2) {
+        // Return null if both objects are null.
+        if (!jo1 && !jo2)
+            return null;
+        
+        // Create the final object.
+        var jo = {};
+
+        // Copy the contents of the first object into the final object.
+        if (jo1) {
+            for (var key in jo1)
+                jo[key] = jo1[key];
+        }
+        
+        // Copy the contents of the second object into the final object.
+        if (jo2) {
+            for (var key in jo2)
+                jo[key] = jo2[key];
+        }
+        
+        // Return the final object.
+        return jo;
+    };
+})();

--- a/examples/burp/src/main/java/burp/msl/tokens/EchoingTokenFactory.java
+++ b/examples/burp/src/main/java/burp/msl/tokens/EchoingTokenFactory.java
@@ -19,6 +19,8 @@ import java.util.Date;
 
 import javax.crypto.SecretKey;
 
+import org.json.JSONObject;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
@@ -58,14 +60,14 @@ public class EchoingTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException {
         final Date renewalWindow = new Date();
         final Date expiration = renewalWindow;
         final String identity = entityAuthData.getIdentity();
-        return new MasterToken(ctx, renewalWindow, expiration, 0, 0, null, identity, hmacKey, hmacKey);
+        return new MasterToken(ctx, renewalWindow, expiration, 0, 0, issuerData, identity, hmacKey, hmacKey);
     }
 
     /* (non-Javadoc)
@@ -77,10 +79,10 @@ public class EchoingTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) {
         return masterToken;
     }
 

--- a/examples/kancolle/src/main/java/kancolle/tokens/KanColleTokenFactory.java
+++ b/examples/kancolle/src/main/java/kancolle/tokens/KanColleTokenFactory.java
@@ -39,6 +39,7 @@ import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.MslUser;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.tokens.UserIdToken;
+import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -205,17 +206,11 @@ public class KanColleTokenFactory implements TokenFactory {
             throw new MslMasterTokenException(MslError.MASTERTOKEN_SEQUENCE_NUMBER_OUT_OF_SYNC, masterToken);
         final long sequenceNumber = (oldSequenceNumber == MslConstants.MAX_LONG_VALUE) ? 0 : oldSequenceNumber + 1;
         
-        // Merge issuer data.
-        final JSONObject mergedIssuerData = masterToken.getIssuerData();
-        for (final Object key : issuerData.keySet()) {
-            final String k = (String)key;
-            mergedIssuerData.put(k, issuerData.get(k));
-        }
-        
         // Renew master token.
         final Date renewal = new Date(ctx.getTime() + mtRenewalOffset);
         final Date expiration = new Date(ctx.getTime() + mtExpirationOffset);
         final long serialNumber = masterToken.getSerialNumber();
+        final JSONObject mergedIssuerData = JsonUtils.merge(masterToken.getIssuerData(), issuerData);
         return new MasterToken(ctx, renewal, expiration, sequenceNumber, serialNumber, mergedIssuerData, identity, encryptionKey, hmacKey);
     }
 

--- a/examples/proxy/src/main/java/com/netflix/msl/tokens/FailoverTokenFactory.java
+++ b/examples/proxy/src/main/java/com/netflix/msl/tokens/FailoverTokenFactory.java
@@ -5,6 +5,8 @@ package com.netflix.msl.tokens;
 
 import javax.crypto.SecretKey;
 
+import org.json.JSONObject;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
@@ -38,10 +40,10 @@ public class FailoverTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken createMasterToken(MslContext ctx, EntityAuthenticationData entityAuthData, SecretKey encryptionKey, SecretKey hmacKey) throws MslEncodingException, MslCryptoException, MslException {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException, MslException {
         // This method should not get called. If it does then throw an
         // exception to trigger processing by the proxied MSL service.
         throw new MslException(ProxyMslError.MASTERTOKEN_CREATION_REQUIRED);
@@ -56,10 +58,10 @@ public class FailoverTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslException {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslException {
         return masterToken;
     }
 

--- a/examples/proxy/src/main/java/com/netflix/msl/tokens/ProxyTokenFactory.java
+++ b/examples/proxy/src/main/java/com/netflix/msl/tokens/ProxyTokenFactory.java
@@ -5,6 +5,8 @@ package com.netflix.msl.tokens;
 
 import javax.crypto.SecretKey;
 
+import org.json.JSONObject;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
@@ -43,10 +45,10 @@ public class ProxyTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken createMasterToken(MslContext ctx, EntityAuthenticationData entityAuthData, SecretKey encryptionKey, SecretKey hmacKey) throws MslEncodingException, MslCryptoException, MslException {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException, MslException {
         // This method should not get called. If it does then throw an
         // exception to trigger processing by the proxied MSL service.
         throw new MslException(ProxyMslError.MASTERTOKEN_CREATION_REQUIRED);
@@ -64,10 +66,10 @@ public class ProxyTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslException {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslException {
         throw new MslException(ProxyMslError.MASTERTOKEN_RENEWAL_REQUIRED);
     }
 

--- a/examples/simple/src/main/java/server/userauth/SimpleTokenFactory.java
+++ b/examples/simple/src/main/java/server/userauth/SimpleTokenFactory.java
@@ -125,10 +125,10 @@ public class SimpleTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#createMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.entityauth.EntityAuthenticationData, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException {
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long sequenceNumber = 0;
@@ -136,7 +136,6 @@ public class SimpleTokenFactory implements TokenFactory {
         do {
             serialNumber = ctx.getRandom().nextLong();
         } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
-        final JSONObject issuerData = null;
         final String identity = entityAuthData.getIdentity();
         final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
         
@@ -161,22 +160,30 @@ public class SimpleTokenFactory implements TokenFactory {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey)
+     * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, javax.crypto.SecretKey, javax.crypto.SecretKey, org.json.JSONObject)
      */
     @Override
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException, MslMasterTokenException {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException, MslMasterTokenException {
         if (!isNewestMasterToken(masterToken))
             throw new MslMasterTokenException(MslError.MASTERTOKEN_SEQUENCE_NUMBER_OUT_OF_SYNC, masterToken);
         
         // Renew master token.
-        final JSONObject issuerData = null;
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long oldSequenceNumber = masterToken.getSequenceNumber();
         final long sequenceNumber = (oldSequenceNumber == MslConstants.MAX_LONG_VALUE) ? 0 : oldSequenceNumber + 1;
         final long serialNumber = masterToken.getSerialNumber();
         final String identity = masterToken.getIdentity();
-        final MasterToken newMasterToken = new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
+
+        // Merge issuer data.
+        final JSONObject mergedIssuerData = masterToken.getIssuerData();
+        for (final Object key : issuerData.keySet()) {
+            final String k = (String)key;
+            mergedIssuerData.put(k, issuerData.get(k));
+        }
+        
+        // Create the new master token.
+        final MasterToken newMasterToken = new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, mergedIssuerData, identity, encryptionKey, hmacKey);
         
         // Remember the sequence number.
         //

--- a/examples/simple/src/main/javascript/client/SimpleClient.html
+++ b/examples/simple/src/main/javascript/client/SimpleClient.html
@@ -35,6 +35,7 @@
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/AsyncExecutor.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/BlockingQueue.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/JsonUtils.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Random.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslError.js"></script>

--- a/integ-tests/src/main/java/com/netflix/msl/server/configuration/tokens/ServerTokenFactory.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/configuration/tokens/ServerTokenFactory.java
@@ -19,6 +19,8 @@ import java.sql.Date;
 
 import javax.crypto.SecretKey;
 
+import org.json.JSONObject;
+
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
@@ -35,12 +37,12 @@ import com.netflix.msl.util.MslContext;
  * Date: 7/24/14
  */
 public class ServerTokenFactory extends MockTokenFactory {
-    public ServerTokenFactory(TokenFactoryType tokenFactoryType) {
+    public ServerTokenFactory(final TokenFactoryType tokenFactoryType) {
         this.tokenFactoryType = tokenFactoryType;
     }
 
     @Override
-    public MslError acceptNonReplayableId(MslContext mslContext, MasterToken masterToken, long nonReplayableId) throws MslMasterTokenException, MslException {
+    public MslError acceptNonReplayableId(final MslContext mslContext, final MasterToken masterToken, final long nonReplayableId) throws MslMasterTokenException, MslException {
         if (!masterToken.isDecrypted())
             throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
         if (nonReplayableId < 0 || nonReplayableId > MslConstants.MAX_LONG_VALUE)
@@ -54,7 +56,7 @@ public class ServerTokenFactory extends MockTokenFactory {
 
     }
 
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslMasterTokenException, MslCryptoException, MslEncodingException {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslMasterTokenException, MslCryptoException, MslEncodingException {
         if (!masterToken.isDecrypted())
             throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
 
@@ -65,11 +67,11 @@ public class ServerTokenFactory extends MockTokenFactory {
 
         this.sequenceNumber++;
 
-        return super.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey);
+        return super.renewMasterToken(ctx, masterToken, encryptionKey, hmacKey, issuerData);
     }
 
     @Override
-    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException {
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         this.sequenceNumber++;

--- a/tests/src/main/java/com/netflix/msl/tokens/MockTokenFactory.java
+++ b/tests/src/main/java/com/netflix/msl/tokens/MockTokenFactory.java
@@ -29,6 +29,7 @@ import com.netflix.msl.MslException;
 import com.netflix.msl.MslMasterTokenException;
 import com.netflix.msl.MslUserIdTokenException;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
+import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -151,13 +152,6 @@ public class MockTokenFactory implements TokenFactory {
         if (!masterToken.isDecrypted())
             throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
         
-        // Merge issuer data.
-        final JSONObject mergedIssuerData = masterToken.getIssuerData();
-        for (final Object key : issuerData.keySet()) {
-            final String k = (String)key;
-            mergedIssuerData.put(k, issuerData.get(k));
-        }
-        
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long oldSequenceNumber = masterToken.getSequenceNumber();
@@ -169,6 +163,7 @@ public class MockTokenFactory implements TokenFactory {
             sequenceNumber = this.sequenceNumber;
         }
         final long serialNumber = masterToken.getSerialNumber();
+        final JSONObject mergedIssuerData = JsonUtils.merge(masterToken.getIssuerData(), issuerData);
         final String identity = masterToken.getIdentity();
         return new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, mergedIssuerData, identity, encryptionKey, hmacKey);
     }

--- a/tests/src/main/java/com/netflix/msl/tokens/MockTokenFactory.java
+++ b/tests/src/main/java/com/netflix/msl/tokens/MockTokenFactory.java
@@ -15,6 +15,12 @@
  */
 package com.netflix.msl.tokens;
 
+import java.sql.Date;
+
+import javax.crypto.SecretKey;
+
+import org.json.JSONObject;
+
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
@@ -24,12 +30,6 @@ import com.netflix.msl.MslMasterTokenException;
 import com.netflix.msl.MslUserIdTokenException;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.util.MslContext;
-
-import org.json.JSONObject;
-
-import javax.crypto.SecretKey;
-
-import java.sql.Date;
 
 /**
  * Token factory for unit tests.
@@ -119,7 +119,7 @@ public class MockTokenFactory implements TokenFactory {
     }
     
     @Override
-    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException {
+    public MasterToken createMasterToken(final MslContext ctx, final EntityAuthenticationData entityAuthData, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException {
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long sequenceNumber = 0;
@@ -127,7 +127,6 @@ public class MockTokenFactory implements TokenFactory {
         do {
             serialNumber = ctx.getRandom().nextLong();
         } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
-        final JSONObject issuerData = null;
         final String identity = entityAuthData.getIdentity();
         return new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
     }
@@ -148,11 +147,17 @@ public class MockTokenFactory implements TokenFactory {
      * @see com.netflix.msl.tokens.TokenFactory#renewMasterToken(com.netflix.msl.util.MslContext, com.netflix.msl.tokens.MasterToken, com.netflix.crypto.common.SecretKey, com.netflix.crypto.common.SecretKey)
      */
     @Override
-    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey) throws MslEncodingException, MslCryptoException, MslMasterTokenException {
+    public MasterToken renewMasterToken(final MslContext ctx, final MasterToken masterToken, final SecretKey encryptionKey, final SecretKey hmacKey, final JSONObject issuerData) throws MslEncodingException, MslCryptoException, MslMasterTokenException {
         if (!masterToken.isDecrypted())
             throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
         
-        final JSONObject issuerData = null;
+        // Merge issuer data.
+        final JSONObject mergedIssuerData = masterToken.getIssuerData();
+        for (final Object key : issuerData.keySet()) {
+            final String k = (String)key;
+            mergedIssuerData.put(k, issuerData.get(k));
+        }
+        
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long oldSequenceNumber = masterToken.getSequenceNumber();
@@ -165,7 +170,7 @@ public class MockTokenFactory implements TokenFactory {
         }
         final long serialNumber = masterToken.getSerialNumber();
         final String identity = masterToken.getIdentity();
-        return new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
+        return new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, mergedIssuerData, identity, encryptionKey, hmacKey);
     }
 
     /**

--- a/tests/src/main/javascript/tokens/MockTokenFactory.js
+++ b/tests/src/main/javascript/tokens/MockTokenFactory.js
@@ -29,6 +29,38 @@ var MockTokenFactory;
     var EXPIRATION_OFFSET = 120000;
     /** Non-replayable ID acceptance window. */
     var NON_REPLAYABLE_ID_WINDOW = 65536;
+    
+    /**
+     * Merge two JSON objects into a single JSON object. If the same key is
+     * found in both objects, the second object's value is used. The values are
+     * copied by reference so this is a shallow copy.
+     * 
+     * @param {Object} jo1 first JSON object. May be null.
+     * @param {Object} jo2 second JSON object. May be null.
+     * @return {Object} the merged JSON object or null if both arguments are null.
+     */
+    function merge(jo1, jo2) {
+        // Return null if both objects are null.
+        if (!jo1 && !jo2);
+        
+        // Create the final object.
+        var jo = {};
+        
+        // Copy the contents of the first object into the final object.
+        if (jo1) {
+            for (var key in jo1)
+                jo[key] = jo1[key];
+        }
+        
+        // Copy the contents of the second object into the final object.
+        if (jo2) {
+            for (var key in jo2)
+                jo[key] = jo2[key];
+        }
+        
+        // Return the final object.
+        return jo;
+    }
 
     MockTokenFactory = TokenFactory.extend({
         /**
@@ -143,12 +175,7 @@ var MockTokenFactory;
                 if (!masterToken.isDecrypted())
                     throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
                 
-                // Merge issuer data.
-                var mergedIssuerData = masterToken.issuerData;
-                for (var key in issuerData) {
-                    mergedIssuerData[key] = issuerData[key];
-                }
-
+                var mergedIssuerData = merge(masterToken.issuerData, issuerData);
                 var renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
                 var expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
                 var oldSequenceNumber = masterToken.sequenceNumber;

--- a/tests/src/main/javascript/tokens/MockTokenFactory.js
+++ b/tests/src/main/javascript/tokens/MockTokenFactory.js
@@ -29,38 +29,6 @@ var MockTokenFactory;
     var EXPIRATION_OFFSET = 120000;
     /** Non-replayable ID acceptance window. */
     var NON_REPLAYABLE_ID_WINDOW = 65536;
-    
-    /**
-     * Merge two JSON objects into a single JSON object. If the same key is
-     * found in both objects, the second object's value is used. The values are
-     * copied by reference so this is a shallow copy.
-     * 
-     * @param {Object} jo1 first JSON object. May be null.
-     * @param {Object} jo2 second JSON object. May be null.
-     * @return {Object} the merged JSON object or null if both arguments are null.
-     */
-    function merge(jo1, jo2) {
-        // Return null if both objects are null.
-        if (!jo1 && !jo2);
-        
-        // Create the final object.
-        var jo = {};
-        
-        // Copy the contents of the first object into the final object.
-        if (jo1) {
-            for (var key in jo1)
-                jo[key] = jo1[key];
-        }
-        
-        // Copy the contents of the second object into the final object.
-        if (jo2) {
-            for (var key in jo2)
-                jo[key] = jo2[key];
-        }
-        
-        // Return the final object.
-        return jo;
-    }
 
     MockTokenFactory = TokenFactory.extend({
         /**
@@ -175,7 +143,7 @@ var MockTokenFactory;
                 if (!masterToken.isDecrypted())
                     throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
                 
-                var mergedIssuerData = merge(masterToken.issuerData, issuerData);
+                var mergedIssuerData = JsonUtils$merge(masterToken.issuerData, issuerData);
                 var renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
                 var expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
                 var oldSequenceNumber = masterToken.sequenceNumber;

--- a/tests/src/main/javascript/tokens/MockTokenFactory.js
+++ b/tests/src/main/javascript/tokens/MockTokenFactory.js
@@ -123,7 +123,7 @@ var MockTokenFactory;
         },
 
         /** @inheritDoc */
-        createMasterToken: function(ctx, entityAuthData, encryptionKey, hmacKey, callback) {
+        createMasterToken: function(ctx, entityAuthData, encryptionKey, hmacKey, issuerData, callback) {
             AsyncExecutor(callback, function() {
                 var renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
                 var expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
@@ -132,19 +132,23 @@ var MockTokenFactory;
                 do {
                     serialNumber = ctx.getRandom().nextLong();
                 } while (serialNumber < 0 || serialNumber > MslConstants$MAX_LONG_VALUE);
-                var issuerData = null;
                 var identity = entityAuthData.getIdentity();
                 MasterToken$create(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey, callback);
             }, this);
         },
 
         /** @inheritDoc */
-        renewMasterToken: function(ctx, masterToken, encryptionKey, hmacKey, callback) {
+        renewMasterToken: function(ctx, masterToken, encryptionKey, hmacKey, issuerData, callback) {
             AsyncExecutor(callback, function() {
                 if (!masterToken.isDecrypted())
                     throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);
+                
+                // Merge issuer data.
+                var mergedIssuerData = masterToken.issuerData;
+                for (var key in issuerData) {
+                    mergedIssuerData[key] = issuerData[key];
+                }
 
-                var issuerData = null;
                 var renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
                 var expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
                 var oldSequenceNumber = masterToken.sequenceNumber;
@@ -157,7 +161,7 @@ var MockTokenFactory;
                 }
                 var serialNumber = masterToken.serialNumber;
                 var identity = masterToken.identity;
-                MasterToken$create(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey, callback);
+                MasterToken$create(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, mergedIssuerData, identity, encryptionKey, hmacKey, callback);
             }, this);
         },
 

--- a/tests/src/test/java/com/netflix/msl/util/NullMslStoreTest.java
+++ b/tests/src/test/java/com/netflix/msl/util/NullMslStoreTest.java
@@ -15,7 +15,8 @@
  */
 package com.netflix.msl.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -82,7 +83,7 @@ public class NullMslStoreTest {
     
     @Test
     public void cryptoContexts() throws MslException {
-        final MasterToken masterToken = factory.createMasterToken(ctx, entityAuthData, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
+        final MasterToken masterToken = factory.createMasterToken(ctx, entityAuthData, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, null);
         assertNull(store.getCryptoContext(masterToken));
         
         final ICryptoContext cryptoContext = new NullCryptoContext();
@@ -93,7 +94,7 @@ public class NullMslStoreTest {
     
     @Test
     public void nonReplayableId() throws MslEncodingException, MslCryptoException, MslException {
-        final MasterToken masterToken = factory.createMasterToken(ctx, entityAuthData, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
+        final MasterToken masterToken = factory.createMasterToken(ctx, entityAuthData, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, null);
         for (int i = 0; i < 10; ++i)
             assertEquals(1, store.getNonReplayableId(masterToken));
     }

--- a/tests/src/test/javascript/msltests.html
+++ b/tests/src/test/javascript/msltests.html
@@ -28,6 +28,7 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/AsyncExecutor.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/BlockingQueue.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/JsonUtils.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/Random.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslError.js"></script>
@@ -182,6 +183,7 @@
 <script type="text/javascript" src="util/ArraysTest.js"></script>
 <script type="text/javascript" src="util/ClassTest.js"></script>
 <script type="text/javascript" src="util/RandomTest.js"></script>
+<script type="text/javascript" src="util/JsonUtilsTest.js"></script>
 <script type="text/javascript" src="MslConstantsTest.js"></script>
 <script type="text/javascript" src="MslErrorTest.js"></script>
 <script type="text/javascript" src="MslExceptionTest.js"></script>

--- a/tests/src/test/javascript/util/JsonUtilsTest.js
+++ b/tests/src/test/javascript/util/JsonUtilsTest.js
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe("JsonUtils", function() {
+    var KEY_BOOLEAN = "boolean";
+    var KEY_NUMBER = "number";
+    var KEY_STRING = "string";
+    var KEY_NULL = "null";
+    var KEY_OBJECT = "object";
+    var KEY_ARRAY = "array";
+    
+    var MAX_ELEMENTS = 12;
+    var MAX_DEPTH = 3;
+    var MAX_STRING_CHARS = 25;
+    
+    /**
+     * @param {Random} random random source.
+     * @return {string} a random string of random length.
+     */
+    function randomString(random) {
+        var raw = new Uint8Array(random.nextInt(MAX_STRING_CHARS) + 1);
+        random.nextBytes(raw);
+        return base64$encode(raw);
+    }
+    
+    /**
+     * @param {Random} random source.
+     * @return {Object} a JSON object containing no JSON objects or JSON arrays.
+     */
+    function createFlatJSONObject(random) {
+        var jo = {};
+        for (var i = random.nextInt(MAX_ELEMENTS); i > 0; --i) {
+            switch (random.nextInt(4)) {
+                case 0:
+                    jo[KEY_BOOLEAN + i] = random.nextBoolean();
+                    break;
+                case 1:
+                    jo[KEY_NUMBER + i] = random.nextInt();
+                    break;
+                case 2:
+                    jo[KEY_STRING + i] = randomString(random);
+                    break;
+                case 3:
+                    jo[KEY_NULL + i] = null;
+                    break;
+            }
+        }
+        return jo;
+    }
+
+    /**
+     * @param {Random} random random source.
+     * @param {number} depth maximum depth. A depth of 1 indicates no children may have
+     *        more children.
+     * @return {Object} a JSON object that may contain JSON objects or JSON arrays.
+     */
+    function createDeepJSONObject(random, depth) {
+        var jo = {};
+        for (var i = random.nextInt(MAX_ELEMENTS); i > 0; --i) {
+            switch (random.nextInt(6)) {
+                case 0:
+                    jo[KEY_BOOLEAN + i] = random.nextBoolean();
+                    break;
+                case 1:
+                    jo[KEY_NUMBER + i] = random.nextInt();
+                    break;
+                case 2:
+                    jo[KEY_STRING + i] = randomString(random);
+                    break;
+                case 3:
+                    jo[KEY_NULL + i] = null;
+                    break;
+                case 4:
+                    jo[KEY_OBJECT + i] = (depth > 1) ? createDeepJSONObject(random, depth - 1) : createFlatJSONObject(random);
+                    break;
+                case 5:
+                    jo[KEY_ARRAY + i] = (depth > 1) ? createDeepJSONObject(random, depth - 1) : createFlatJSONArray(random);
+            }
+        }
+    }
+    
+    /**
+     * @param {Random} random random source.
+     * @return {Array} a JSON array containing no JSON objects or JSON arrays.
+     */
+    function createFlatJSONArray(random) {
+        var ja = [];
+        for (var i = random.nextInt(MAX_ELEMENTS); i > 0; --i) {
+            switch (random.nextInt(4)) {
+                case 0:
+                    ja.push(random.nextBoolean());
+                    break;
+                case 1:
+                    ja.push(random.nextInt());
+                    break;
+                case 2:
+                    ja.push(randomString(random));
+                    break;
+                case 3:
+                    ja.push(null);
+                    break;
+            }
+        }
+        return ja;
+    }
+    
+    /**
+     * @param {Random} random random source.
+     * @param {number} depth maximum depth. A depth of 1 indicates no children may have
+     *        more children.
+     * @return {Object} a JSON array that may contain JSON objects or JSON arrays.
+     */
+    function createDeepJSONArray(random, depth) {
+        var ja = [];
+        for (var i = random.nextInt(MAX_ELEMENTS); i > 0; --i) {
+            switch (random.nextInt(6)) {
+                case 0:
+                    ja.push(random.nextBoolean());
+                    break;
+                case 1:
+                    ja.push(random.nextInt());
+                    break;
+                case 2:
+                    ja.push(randomString(random));
+                    break;
+                case 3:
+                    ja.push(null);
+                    break;
+                case 4:
+                    ja.push((depth > 1) ? createDeepJSONObject(random, depth - 1) : createFlatJSONObject(random));
+                    break;
+                case 5:
+                    ja.push((depth > 1) ? createDeepJSONArray(random, depth - 1) : createFlatJSONArray(random));
+                    break;
+            }
+        }
+        return ja;
+    }
+    
+    var random;
+    var flatJo, deepJo;
+    
+    beforeEach(function() {
+        if (!random) {
+            random = new Random();
+            flatJo = createFlatJSONObject(random);
+            deepJo = createDeepJSONObject(random, MAX_DEPTH);
+        }
+    });
+    
+    it("merge nulls", function() {
+        var jo1 = null;
+        var jo2 = null;
+        var merged = JsonUtils$merge(jo1, jo2);
+        expect(merged).toBeNull();
+    });
+    
+    it("merge first null", function() {
+        var jo1 = null;
+        var jo2 = deepJo;
+        var merged = JsonUtils$merge(jo1, jo2);
+        expect(merged).toEqual(jo2);
+    });
+    
+    it("merge second null", function() {
+        var jo1 = deepJo;
+        var jo2 = null;
+        var merged = JsonUtils$merge(jo1, jo2);
+        expect(merged).toEqual(jo1);
+    });
+    
+    it("merge overwriting", function() {
+        var jo1 = createFlatJSONObject(random);
+        var jo2 = createFlatJSONObject(random);
+        
+        // Insert some shared keys.
+        jo1["key1"] = true;
+        jo2["key1"] = "value1";
+        jo1["key2"] = 17;
+        jo2["key2"] = 34;
+        
+        // Ensure second overwites first.
+        var merged = JsonUtils$merge(jo1, jo2);
+        for (var key in merged) {
+            var value = merged[key];
+            if (key == "key1" || key == "key2") {
+                expect(value).toEqual(jo2[key]);
+            } else if (jo2[key]) {
+                expect(value).toEqual(jo2[key]);
+            } else {
+                expect(value).toEqual(jo1[key]);
+            }
+        }
+    });
+});


### PR DESCRIPTION
Add issuer data parameter to TokenFactory.createMasterToken() and .renewMasterToken(). This can be used by a key exchange factory to provide data that will be carried in the master token issuer data. The Javadoc description on renewMasterToken() indicates the issuer data argument may be merged into or overwrite the existing master token issuer data.