### PR TITLE
Remove circular requires

### DIFF
--- a/core/src/main/javascript/MslException.js
+++ b/core/src/main/javascript/MslException.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2015 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -100,11 +100,11 @@ var MslException;
             };
             Object.defineProperties(this, props);
         },
-        
+
         /**
          * Set the entity associated with the exception. This does nothing if the
          * entity is already set.
-         * 
+         *
          * @param {?MasterToken|?EntityAuthenticationData} entity entity associated with the error. May be null.
          * @return {MslException} this.
          */
@@ -117,21 +117,48 @@ var MslException;
             }
             return this;
         },
-        
+
         /**
-         * Set the user associated with the exception. This does nothing if the
-         * user is already set.
-         * 
-         * @param {?UserIdToken|?UserAuthenticationData} user user associated with the error. May be null.
+         * Set the master token associated with the exception.
+         *
+         * @param {MasterToken} entity masterToken associated with the error. May be null.
          * @return {MslException} this.
          */
-        setUser: function setUser(user) {
-            if (user && !this.userIdToken && !this.userAuthenticationData) {
-                if (user instanceof UserIdToken)
-                    this.userIdToken = user;
-                else if (user instanceof UserAuthenticationData)
-                    this.userAuthenticationData = user;
-            }
+        setMasterToken: function setMasterToken(entity) {
+            this.masterToken = entity;
+            return this;
+        },
+
+        /**
+         * Set the entity associated with the exception.
+         *
+         * @param {EntityAuthenticationData} entity entity auth data associated with the error. May be null.
+         * @return {MslException} this.
+         */
+        setEntityAuthenticationData: function setEntityAuthenticationData(entity) {
+            this.entityAuthenticationData = entity;
+            return this;
+        },
+
+        /**
+         * Set the userAuthenticationData associated with the exception.
+         *
+         * @param {UserAuthenticationData} user user associated with the error. May be null.
+         * @return {MslException} this.
+         */
+        setUserAuthenticationData: function setUserAuthenticationData(user) {
+            this.userAuthenticationData = user;
+            return this;
+        },
+
+        /**
+         * Set the userIdToken associated with the exception.
+         *
+         * @param {UserIdToken} user userIdToken associated with the error. May be null.
+         * @return {MslException} this.
+         */
+        setUserIdToken: function setUserIdToken(user) {
+            this.userIdToken = user;
             return this;
         },
 

--- a/core/src/main/javascript/MslException.js
+++ b/core/src/main/javascript/MslException.js
@@ -102,23 +102,6 @@ var MslException;
         },
 
         /**
-         * Set the entity associated with the exception. This does nothing if the
-         * entity is already set.
-         *
-         * @param {?MasterToken|?EntityAuthenticationData} entity entity associated with the error. May be null.
-         * @return {MslException} this.
-         */
-        setEntity: function setEntity(entity) {
-            if (entity && !this.masterToken && !this.entityAuthenticationData) {
-                if (entity instanceof MasterToken)
-                    this.masterToken = entity;
-                else if (entity instanceof EntityAuthenticationData)
-                    this.entityAuthenticationData = entity;
-            }
-            return this;
-        },
-
-        /**
          * Set the master token associated with the exception.
          *
          * @param {MasterToken} entity masterToken associated with the error. May be null.

--- a/core/src/main/javascript/entityauth/MasterTokenProtectedAuthenticationFactory.js
+++ b/core/src/main/javascript/entityauth/MasterTokenProtectedAuthenticationFactory.js
@@ -51,18 +51,18 @@ var MasterTokenProtectedAuthenticationFactory = EntityAuthenticationFactory.exte
         // Check for revocation.
         var identity = mtpad.getIdentity();
         if (this.authutils.isEntityRevoked(identity))
-            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "mt protected " + identity).setEntity(mtpad);
+            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "mt protected " + identity).setEntityAuthenticationData(mtpad);
 
         // Verify the scheme is permitted.
         if (!this.authutils.isSchemePermitted(identity, this.scheme))
-            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication scheme for entity " + identity + " not supported:" + this.scheme).setEntity(mtpad);
+            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication scheme for entity " + identity + " not supported:" + this.scheme).setEntityAuthenticationData(mtpad);
         
         // Authenticate using the encapsulated authentication data.
         var ead = mtpad.encapsulatedAuthdata;
         var scheme = ead.scheme;
         var factory = ctx.getEntityAuthenticationFactory(scheme);
         if (!factory)
-            throw new MslEntityAuthException(MslError.ENTITYAUTH_FACTORY_NOT_FOUND, scheme.name).setEntity(mtpad);
+            throw new MslEntityAuthException(MslError.ENTITYAUTH_FACTORY_NOT_FOUND, scheme.name).setEntityAuthenticationData(mtpad);
         return factory.getCryptoContext(ctx, ead);
     },
 });

--- a/core/src/main/javascript/entityauth/PresharedAuthenticationFactory.js
+++ b/core/src/main/javascript/entityauth/PresharedAuthenticationFactory.js
@@ -55,16 +55,16 @@ PresharedAuthenticationFactory = EntityAuthenticationFactory.extend({
         // Check for revocation.
         var identity = pad.getIdentity();
         if (this.authutils.isEntityRevoked(identity))
-            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "psk " + identity).setEntity(pad);
+            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "psk " + identity).setEntityAuthenticationData(pad);
         
         // Verify the scheme is permitted.
         if (!this.authutils.isSchemePermitted(identity, this.scheme))
-            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication scheme for entity " + identity + " not supported:" + this.scheme).setEntity(pad);
+            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication scheme for entity " + identity + " not supported:" + this.scheme).setEntityAuthenticationData(pad);
         
         // Load preshared keys authentication data.
         var keys = this.store.getKeys(identity);
         if (!keys)
-            throw new MslEntityAuthException(MslError.ENTITY_NOT_FOUND, "psk " + identity).setEntity(pad);
+            throw new MslEntityAuthException(MslError.ENTITY_NOT_FOUND, "psk " + identity).setEntityAuthenticationData(pad);
         
         // Return the crypto context.
         return new SymmetricCryptoContext(ctx, identity, keys.encryptionKey, keys.hmacKey, keys.wrappingKey);

--- a/core/src/main/javascript/entityauth/PresharedProfileAuthenticationFactory.js
+++ b/core/src/main/javascript/entityauth/PresharedProfileAuthenticationFactory.js
@@ -55,16 +55,16 @@ var PresharedProfileAuthenticationFactory = EntityAuthenticationFactory.extend({
         // Check for revocation.
         var pskId = ppad.presharedKeysId;
         if (this.authutils.isEntityRevoked(pskId))
-            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "psk profile " + pskId).setEntity(ppad);
+            throw new MslEntityAuthException(MslError.ENTITY_REVOKED, "psk profile " + pskId).setEntityAuthenticationData(ppad);
         
         // Verify the scheme is permitted.
         if (!this.authutils.isSchemePermitted(pskId, this.scheme))
-            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication scheme for entity " + pskId + " not supported:" + this.scheme).setEntity(ppad);
+            throw new MslEntityAuthException(MslError.INCORRECT_ENTITYAUTH_DATA, "Authentication scheme for entity " + pskId + " not supported:" + this.scheme).setEntityAuthenticationData(ppad);
         
         // Load preshared keys authentication data.
         var keys = this.store.getKeys(pskId);
         if (!keys)
-            throw new MslEntityAuthException(MslError.ENTITY_NOT_FOUND, "psk profile " + pskId).setEntity(ppad);
+            throw new MslEntityAuthException(MslError.ENTITY_NOT_FOUND, "psk profile " + pskId).setEntityAuthenticationData(ppad);
         
         // Return the crypto context.
         var identity = ppad.getIdentity();

--- a/core/src/main/javascript/entityauth/RsaAuthenticationFactory.js
+++ b/core/src/main/javascript/entityauth/RsaAuthenticationFactory.js
@@ -64,11 +64,11 @@ var RsaAuthenticationFactory = EntityAuthenticationFactory.extend({
         
         // The local entity must have a private key.
         if (pubkeyid == this.keyPairId && !privateKey)
-            throw new MslEntityAuthException(MslError.RSA_PRIVATEKEY_NOT_FOUND, pubkeyid).setEntity(authdata);
+            throw new MslEntityAuthException(MslError.RSA_PRIVATEKEY_NOT_FOUND, pubkeyid).setEntityAuthenticationData(authdata);
         
         // Remote entities must have a public key.
         else if (pubkeyid != this.keyPairId && !publicKey)
-            throw new MslEntityAuthException(MslError.RSA_PUBLICKEY_NOT_FOUND, pubkeyid).setEntity(authdata);
+            throw new MslEntityAuthException(MslError.RSA_PUBLICKEY_NOT_FOUND, pubkeyid).setEntityAuthenticationData(authdata);
 
         // Return the crypto context.
         return new RsaCryptoContext(ctx, identity, privateKey, publicKey, RsaCryptoContext$Mode.SIGN_VERIFY);

--- a/core/src/main/javascript/entityauth/X509AuthenticationFactory.js
+++ b/core/src/main/javascript/entityauth/X509AuthenticationFactory.js
@@ -59,12 +59,12 @@ var X509AuthenticationFactory = EntityAuthenticationFactory.extend({
         // Verify entity certificate.
         try {
             if (!this.store.verify(cert))
-                throw new MslEntityAuthException(MslError.X509CERT_VERIFICATION_FAILED, cert.hex).setEntity(authdata);
+                throw new MslEntityAuthException(MslError.X509CERT_VERIFICATION_FAILED, cert.hex).setEntityAuthenticationData(authdata);
         } catch (e) {
             if (!(e instanceof MslException))
-                throw new MslEntityAuthException(MslError.X509CERT_PARSE_ERROR, cert.hex, e).setEntity(authdata);
+                throw new MslEntityAuthException(MslError.X509CERT_PARSE_ERROR, cert.hex, e).setEntityAuthenticationData(authdata);
             else
-                e.setEntity(authdata);
+                e.setEntityAuthenticationData(authdata);
             throw e;
         }
 

--- a/core/src/main/javascript/keyx/AsymmetricWrappedExchange.js
+++ b/core/src/main/javascript/keyx/AsymmetricWrappedExchange.js
@@ -402,7 +402,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException)
-                                e.setEntity(entityToken);
+                                e.setMasterToken(entityToken);
                             throw e;
                         }, self);
                     }
@@ -428,7 +428,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                                     error: function(e) {
                                         AsyncExecutor(callback, function() {
                                             if (e instanceof MslException)
-                                                e.setEntity(entityToken);
+                                                e.setMasterToken(entityToken);
                                             throw e;
                                         }, self);
                                     }
@@ -438,7 +438,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityToken);
+                                    e.setMasterToken(entityToken);
                                 throw e;
                             }, self);
                         }
@@ -467,7 +467,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 }, self);
                             }
@@ -487,7 +487,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 }, self);
                             }
@@ -512,12 +512,12 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                 var requestKeyPairId = request.keyPairId;
                 var responseKeyPairId = response.keyPairId;
                 if (requestKeyPairId != responseKeyPairId)
-                    throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, "request " + requestKeyPairId + "; response " + responseKeyPairId).setEntity(masterToken);
+                    throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, "request " + requestKeyPairId + "; response " + responseKeyPairId).setMasterToken(masterToken);
 
                 // Unwrap session keys with identified key.
                 var privateKey = request.privateKey;
                 if (!privateKey)
-                    throw new MslKeyExchangeException(MslError.KEYX_PRIVATE_KEY_MISSING, "request Asymmetric private key").setEntity(masterToken);
+                    throw new MslKeyExchangeException(MslError.KEYX_PRIVATE_KEY_MISSING, "request Asymmetric private key").setMasterToken(masterToken);
                 var mechanism = request.mechanism;
                 var unwrapCryptoContext = createCryptoContext(ctx, requestKeyPairId, mechanism, privateKey, null);
                 unwrapCryptoContext.unwrap(response.encryptionKey, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {
@@ -536,7 +536,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                                     error: function(e) {
                                         AsyncExecutor(callback, function() {
                                             if (e instanceof MslException)
-                                                e.setEntity(masterToken);
+                                                e.setMasterToken(masterToken);
                                             throw e;
                                         }, self);
                                     }
@@ -545,7 +545,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(masterToken);
+                                        e.setMasterToken(masterToken);
                                     throw e;
                                 }, self);
                             }
@@ -554,7 +554,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException)
-                                e.setEntity(masterToken);
+                                e.setMasterToken(masterToken);
                             throw e;
                         }, self);
                     }

--- a/core/src/main/javascript/keyx/DiffieHellmanExchange.js
+++ b/core/src/main/javascript/keyx/DiffieHellmanExchange.js
@@ -386,7 +386,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                 var parametersId = request.parametersId;
                 var params = this.paramSpecs.getParameterSpec(parametersId);
                 if (!params)
-                    throw new MslKeyExchangeException(MslError.UNKNOWN_KEYX_PARAMETERS_ID, parametersId).setEntity(entityToken);
+                    throw new MslKeyExchangeException(MslError.UNKNOWN_KEYX_PARAMETERS_ID, parametersId).setMasterToken(entityToken);
                 
                 // Reconstitute request public key.
                 var requestPublicKey = request.publicKey;
@@ -396,7 +396,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                     constructKeys(parametersId, params, requestPublicKey, keyPair.publicKey, keyPair.privateKey);
                 };
                 var onerror = function(e) {
-                    callback.error(new MslCryptoException(MslError.GENERATEKEY_ERROR, "Error generating Diffie-Hellman key pair.", e).setEntity(entityToken));
+                    callback.error(new MslCryptoException(MslError.GENERATEKEY_ERROR, "Error generating Diffie-Hellman key pair.", e).setMasterToken(entityToken));
                 };
                 mslCrypto['generateKey']({
                     'name': WebCryptoAlgorithm.DIFFIE_HELLMAN,
@@ -427,7 +427,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                                     error: function(e) {
                                         AsyncExecutor(callback, function() {
                                             if (e instanceof MslException)
-                                                e.setEntity(entityToken);
+                                                e.setMasterToken(entityToken);
                                             throw e;
                                         }, self);
                                     }
@@ -447,7 +447,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                                     error: function(e) {
                                         AsyncExecutor(callback, function() {
                                             if (e instanceof MslException)
-                                                e.setEntity(entityToken);
+                                                e.setMasterToken(entityToken);
                                             throw e;
                                         }, self);
                                     }
@@ -457,7 +457,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                     },
                     error: function(e) {
                         AsyncExecutor(callback, function() {
-                            throw new MslCryptoException(MslError.SESSION_KEY_CREATION_FAILURE, e).setEntity(entityToken);
+                            throw new MslCryptoException(MslError.SESSION_KEY_CREATION_FAILURE, e).setMasterToken(entityToken);
                         }, self);
                     }
                 });
@@ -479,15 +479,15 @@ var DiffieHellmanExchange$ResponseData$parse;
                 var requestParametersId = request.parametersId;
                 var responseParametersId = response.parametersId;
                 if (requestParametersId != responseParametersId)
-                    throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, "request " + requestParametersId + "; response " + responseParametersId).setEntity(masterToken);
+                    throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, "request " + requestParametersId + "; response " + responseParametersId).setMasterToken(masterToken);
 
                 // Reconstitute response public key.
                 var privateKey = request.privateKey;
                 if (!privateKey)
-                    throw new MslKeyExchangeException(MslError.KEYX_PRIVATE_KEY_MISSING, "request Diffie-Hellman private key").setEntity(masterToken);
+                    throw new MslKeyExchangeException(MslError.KEYX_PRIVATE_KEY_MISSING, "request Diffie-Hellman private key").setMasterToken(masterToken);
                 var params = this.paramSpecs.getParameterSpec(requestParametersId);
                 if (!params)
-                     throw new MslKeyExchangeException(MslError.UNKNOWN_KEYX_PARAMETERS_ID, requestParametersId).setEntity(masterToken);
+                     throw new MslKeyExchangeException(MslError.UNKNOWN_KEYX_PARAMETERS_ID, requestParametersId).setMasterToken(masterToken);
                 var publicKey = response.publicKey;
 
                 // Create crypto context.
@@ -505,9 +505,9 @@ var DiffieHellmanExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (!(e instanceof MslException))
-                                            e = new MslCryptoException(MslError.SESSION_KEY_CREATION_FAILURE, null, e).setEntity(masterToken);
+                                            e = new MslCryptoException(MslError.SESSION_KEY_CREATION_FAILURE, null, e).setMasterToken(masterToken);
                                         else
-                                            e.setEntity(masterToken);
+                                            e.setMasterToken(masterToken);
                                         throw e;
                                     }, self);
                                 }
@@ -517,7 +517,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException)
-                                e.setEntity(masterToken);
+                                e.setMasterToken(masterToken);
                             throw e;
                         }, self);
                     }

--- a/core/src/main/javascript/keyx/JsonWebEncryptionLadderExchange.js
+++ b/core/src/main/javascript/keyx/JsonWebEncryptionLadderExchange.js
@@ -442,7 +442,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     }, self);
                                 }
@@ -451,7 +451,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                     },
                     error: function(e) {
                         AsyncExecutor(callback, function() {
-                            throw new MslCryptoException(MslError.WRAP_KEY_CREATION_FAILURE, null, e).setEntity(entityToken);
+                            throw new MslCryptoException(MslError.WRAP_KEY_CREATION_FAILURE, null, e).setMasterToken(entityToken);
                         }, self);
                     }
                 });
@@ -469,7 +469,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException)
-                                e.setEntity(entityToken);
+                                e.setMasterToken(entityToken);
                             throw e;
                         });
                     }
@@ -494,7 +494,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     });
                                 }
@@ -503,7 +503,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityToken);
+                                    e.setMasterToken(entityToken);
                                 throw e;
                             });
                         }
@@ -523,7 +523,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     });
                                 }
@@ -532,7 +532,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityToken);
+                                    e.setMasterToken(entityToken);
                                 throw e;
                             });
                         }
@@ -559,7 +559,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 });
                             }
@@ -579,7 +579,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 });
                             }
@@ -615,7 +615,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                     var authdata = new PresharedAuthenticationData(identity);
                                     var factory = ctx.getEntityAuthenticationFactory(EntityAuthenticationScheme.PSK);
                                     if (!factory)
-                                        throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntity(entityAuthData);
+                                        throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntityAuthenticationData(entityAuthData);
                                     var cryptoContext = factory.getCryptoContext(ctx, authdata);
                                     // FIXME: Get a handle to KPE.
                                     var kpe = undefined;
@@ -626,11 +626,11 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                 {
                                     wrapKeyCryptoContext = this.repository.getCryptoContext(requestWrapdata);
                                     if (!wrapKeyCryptoContext)
-                                        throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, base64$encode(requestWrapdata)).setEntity(entityAuthData);
+                                        throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, base64$encode(requestWrapdata)).setEntityAuthenticationData(entityAuthData);
                                     break;
                                 }
                                 default:
-                                    throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntity(entityAuthData);
+                                    throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntityAuthenticationData(entityAuthData);
                             }
 
                             // Unwrap wrapping key.
@@ -641,7 +641,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityAuthData);
+                                            e.setEntityAuthenticationData(entityAuthData);
                                         throw e;
                                     });
                                 }
@@ -673,7 +673,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityAuthData);
+                                            e.setEntityAuthenticationData(entityAuthData);
                                         throw e;
                                     });
                                 }
@@ -682,7 +682,7 @@ var JsonWebEncryptionLadderExchange$ResponseData$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityAuthData);
+                                    e.setEntityAuthenticationData(entityAuthData);
                                 throw e;
                             });
                         }

--- a/core/src/main/javascript/keyx/JsonWebKeyLadderExchange.js
+++ b/core/src/main/javascript/keyx/JsonWebKeyLadderExchange.js
@@ -532,7 +532,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     }, self);
                                 }
@@ -541,7 +541,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                     },
                     error: function(e) {
                         AsyncExecutor(callback, function() {
-                            throw new MslCryptoException(MslError.WRAP_KEY_CREATION_FAILURE, null, e).setEntity(entityToken);
+                            throw new MslCryptoException(MslError.WRAP_KEY_CREATION_FAILURE, null, e).setMasterToken(entityToken);
                         }, self);
                     }
                 });
@@ -559,7 +559,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException)
-                                e.setEntity(entityToken);
+                                e.setMasterToken(entityToken);
                             throw e;
                         });
                     }
@@ -584,7 +584,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     });
                                 }
@@ -593,7 +593,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityToken);
+                                    e.setMasterToken(entityToken);
                                 throw e;
                             });
                         }
@@ -613,7 +613,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     });
                                 }
@@ -622,7 +622,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityToken);
+                                    e.setMasterToken(entityToken);
                                 throw e;
                             });
                         }
@@ -649,7 +649,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 });
                             }
@@ -669,7 +669,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 });
                             }
@@ -705,7 +705,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                     var authdata = new PresharedAuthenticationData(identity);
                                     var factory = ctx.getEntityAuthenticationFactory(EntityAuthenticationScheme.PSK);
                                     if (!factory)
-                                        throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntity(entityAuthData);
+                                        throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntityAuthenticationData(entityAuthData);
                                     var cryptoContext = factory.getCryptoContext(ctx, authdata);
                                     // FIXME: Get a handle to KPW.
                                     var kpw = undefined;
@@ -716,11 +716,11 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                 {
                                     wrapKeyCryptoContext = this.repository.getCryptoContext(requestWrapdata);
                                     if (!wrapKeyCryptoContext)
-                                        throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, base64$encode(requestWrapdata)).setEntity(entityAuthData);
+                                        throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, base64$encode(requestWrapdata)).setEntityAuthenticationData(entityAuthData);
                                     break;
                                 }
                                 default:
-                                    throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntity(entityAuthData);
+                                    throw new MslKeyExchangeException(MslError.UNSUPPORTED_KEYX_MECHANISM, mechanism).setEntityAuthenticationData(entityAuthData);
                             }
 
                             // Unwrap wrapping key.
@@ -731,7 +731,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityAuthData);
+                                            e.setEntityAuthenticationData(entityAuthData);
                                         throw e;
                                     });
                                 }
@@ -763,7 +763,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityAuthData);
+                                            e.setEntityAuthenticationData(entityAuthData);
                                         throw e;
                                     });
                                 }
@@ -772,7 +772,7 @@ var JsonWebKeyLadderExchange$AesKwJwkCryptoContext;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityAuthData);
+                                    e.setEntityAuthenticationData(entityAuthData);
                                 throw e;
                             });
                         }

--- a/core/src/main/javascript/keyx/SymmetricWrappedExchange.js
+++ b/core/src/main/javascript/keyx/SymmetricWrappedExchange.js
@@ -332,7 +332,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException)
-                                e.setEntity(entityToken);
+                                e.setMasterToken(entityToken);
                             throw e;
                         }, self);
                     }
@@ -373,7 +373,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                                         error: function(e) {
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException)
-                                                    e.setEntity(entityToken);
+                                                    e.setMasterToken(entityToken);
                                                 throw e;
                                             }, self);
                                         }
@@ -382,7 +382,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     }, self);
                                 }
@@ -391,7 +391,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(entityToken);
+                                    e.setMasterToken(entityToken);
                                 throw e;
                             }, self);
                         }
@@ -417,7 +417,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                                         if (e instanceof MslMasterTokenException)
                                             throw new MslInternalException("Master token constructed by token factory is not trusted.", e);
                                         if (e instanceof MslException)
-                                            e.setEntity(entityToken);
+                                            e.setMasterToken(entityToken);
                                         throw e;
                                     }
 
@@ -429,7 +429,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 }, self);
                             }
@@ -456,7 +456,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityToken);
+                                        e.setMasterToken(entityToken);
                                     throw e;
                                 }, self);
                             }
@@ -483,7 +483,7 @@ var SymmetricWrappedExchange$ResponseData$parse;
                 var requestKeyId = request.keyId;
                 var responseKeyId = response.keyId;
                 if (requestKeyId != responseKeyId)
-                    throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, "request " + requestKeyId + "; response " + responseKeyId).setEntity(masterToken);
+                    throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, "request " + requestKeyId + "; response " + responseKeyId).setMasterToken(masterToken);
 
                 // Unwrap session keys with identified key.
                 ctx.getEntityAuthenticationData(null, {
@@ -526,8 +526,8 @@ var SymmetricWrappedExchange$ResponseData$parse;
             function handleError(e) {
                 AsyncExecutor(callback, function() {
                     if (e instanceof MslException) {
-                        e.setEntity(masterToken);
-                        e.setEntity(entityAuthData);
+                        e.setMasterToken(masterToken);
+                        e.setEntityAuthenticationData(entityAuthData);
                     }
                     throw e;
                 }, self);

--- a/core/src/main/javascript/msg/ErrorHeader.js
+++ b/core/src/main/javascript/msg/ErrorHeader.js
@@ -170,7 +170,7 @@ var ErrorHeader$parse;
                         cryptoContext = factory.getCryptoContext(ctx, entityAuthData);
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(entityAuthData);
+                            e.setEntityAuthenticationData(entityAuthData);
                             e.setMessageId(messageId);
                         }
                         throw e;
@@ -204,7 +204,7 @@ var ErrorHeader$parse;
                                     error: function(e) {
                                         AsyncExecutor(callback, function() {
                                             if (e instanceof MslException) {
-                                                e.setEntity(entityAuthData);
+                                                e.setEntityAuthenticationData(entityAuthData);
                                                 e.setMessageId(messageId);
                                             }
                                             throw e;
@@ -216,7 +216,7 @@ var ErrorHeader$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException) {
-                                    e.setEntity(entityAuthData);
+                                    e.setEntityAuthenticationData(entityAuthData);
                                     e.setMessageId(messageId);
                                 }
                                 throw e;
@@ -328,7 +328,7 @@ var ErrorHeader$parse;
                 cryptoContext = factory.getCryptoContext(ctx, entityAuthData);
             } catch (e) {
                 if (e instanceof MslException)
-                    e.setEntity(entityAuthData);
+                    e.setEntityAuthenticationData(entityAuthData);
                 throw e;
             }
 
@@ -336,15 +336,15 @@ var ErrorHeader$parse;
             try {
                 errordata = base64$decode(errordata);
             } catch (e) {
-                throw new MslMessageException(MslError.HEADER_DATA_INVALID, errordata, e).setEntity(entityAuthData);
+                throw new MslMessageException(MslError.HEADER_DATA_INVALID, errordata, e).setEntityAuthenticationData(entityAuthData);
             }
             if (!errordata || errordata.length == 0)
-                throw new MslMessageException(MslError.HEADER_DATA_MISSING, errordata).setEntity(entityAuthData);
+                throw new MslMessageException(MslError.HEADER_DATA_MISSING, errordata).setEntityAuthenticationData(entityAuthData);
             cryptoContext.verify(errordata, signature, {
                 result: function(verified) {
                     AsyncExecutor(callback, function() {
                         if (!verified)
-                            throw new MslCryptoException(MslError.MESSAGE_VERIFICATION_FAILED).setEntity(entityAuthData);
+                            throw new MslCryptoException(MslError.MESSAGE_VERIFICATION_FAILED).setEntityAuthenticationData(entityAuthData);
                         cryptoContext.decrypt(errordata, {
                             result: function(plaintext) {
                                 AsyncExecutor(callback, function() {
@@ -355,7 +355,7 @@ var ErrorHeader$parse;
                                         errordataJO = JSON.parse(errordataJson);
                                     } catch (e) {
                                         if (e instanceof SyntaxError)
-                                            throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "errordata " + errordataJson, e).setEntity(entityAuthData);
+                                            throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "errordata " + errordataJson, e).setEntityAuthenticationData(entityAuthData);
                                         throw e;
                                     }
 
@@ -377,12 +377,12 @@ var ErrorHeader$parse;
                                         (errorMsg && typeof errorMsg !== 'string') ||
                                         (userMsg && typeof userMsg !== 'string'))
                                     {
-                                        throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "errordata " + errordataJson).setEntity(entityAuthData);
+                                        throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "errordata " + errordataJson).setEntityAuthenticationData(entityAuthData);
                                     }
 
                                     // The message ID must be within range.
                                     if (messageId < 0 || messageId > MslConstants$MAX_LONG_VALUE)
-                                        throw new MslMessageException(MslError.MESSAGE_ID_OUT_OF_RANGE, "errordata " + errordataJson).setEntity(entityAuthData);
+                                        throw new MslMessageException(MslError.MESSAGE_ID_OUT_OF_RANGE, "errordata " + errordataJson).setEntityAuthenticationData(entityAuthData);
 
                                     // If we do not recognize the error code then default to fail.
                                     var recognized = false;
@@ -398,7 +398,7 @@ var ErrorHeader$parse;
                                     // The parsed internal code cannot be negative.
                                     if (internalCode) {
                                         if (internalCode < 0)
-                                            throw new MslMessageException(MslError.INTERNAL_CODE_NEGATIVE, "errordata " + errordataJson).setEntity(entityAuthData).setMessageId(messageId);
+                                            throw new MslMessageException(MslError.INTERNAL_CODE_NEGATIVE, "errordata " + errordataJson).setEntityAuthenticationData(entityAuthData).setMessageId(messageId);
                                     } else {
                                         internalCode = -1;
                                     }
@@ -411,7 +411,7 @@ var ErrorHeader$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(entityAuthData);
+                                        e.setEntityAuthenticationData(entityAuthData);
                                     throw e;
                                 });
                             }
@@ -421,7 +421,7 @@ var ErrorHeader$parse;
                 error: function(e) {
                     AsyncExecutor(callback, function() {
                         if (e instanceof MslException)
-                            e.setEntity(entityAuthData);
+                            e.setEntityAuthenticationData(entityAuthData);
                         throw e;
                     });
                 }

--- a/core/src/main/javascript/msg/Header.js
+++ b/core/src/main/javascript/msg/Header.js
@@ -176,7 +176,7 @@ var Header$parseHeader;
                                         AsyncExecutor(callback, function() {
                                             // Make sure the header was verified and decrypted.
                                             if (!messageHeader.isDecrypted())
-                                                throw new MslCryptoException(MslError.MESSAGE_MASTERTOKENBASED_VERIFICATION_FAILED).setEntity(masterToken);
+                                                throw new MslCryptoException(MslError.MESSAGE_MASTERTOKENBASED_VERIFICATION_FAILED).setMasterToken(masterToken);
                                             
                                             // Return the header.
                                             return messageHeader;
@@ -194,7 +194,7 @@ var Header$parseHeader;
                                 AsyncExecutor(callback, function() {
                                     // Make sure the header was verified and decrypted.
                                     if (!messageHeader.isDecrypted())
-                                        throw new MslCryptoException(MslError.MESSAGE_ENTITYDATABASED_VERIFICATION_FAILED).setEntity(entityAuthData);
+                                        throw new MslCryptoException(MslError.MESSAGE_ENTITYDATABASED_VERIFICATION_FAILED).setEntityAuthenticationData(entityAuthData);
                                     
                                     // Return the header.
                                     return messageHeader;

--- a/core/src/main/javascript/msg/Header.js
+++ b/core/src/main/javascript/msg/Header.js
@@ -53,11 +53,6 @@
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 var Header$parseHeader;
-var Header$KEY_ENTITY_AUTHENTICATION_DATA;
-var Header$KEY_MASTER_TOKEN;
-var Header$KEY_HEADERDATA;
-var Header$KEY_ERRORDATA;
-var Header$KEY_SIGNATURE;
 
 (function() {
     /**
@@ -65,31 +60,31 @@ var Header$KEY_SIGNATURE;
      * @const
      * @type {string}
      */
-    var KEY_ENTITY_AUTHENTICATION_DATA = Header$KEY_ENTITY_AUTHENTICATION_DATA = "entityauthdata";
+    var KEY_ENTITY_AUTHENTICATION_DATA = Header$KEY_ENTITY_AUTHENTICATION_DATA;
     /**
      * JSON key master token.
      * @const
      * @type {string}
      */
-    var KEY_MASTER_TOKEN = Header$KEY_MASTER_TOKEN = "mastertoken";
+    var KEY_MASTER_TOKEN = Header$KEY_MASTER_TOKEN;
     /**
      * JSON key header data.
      * @const
      * @type {string}
      */
-    var KEY_HEADERDATA = Header$KEY_HEADERDATA = "headerdata";
+    var KEY_HEADERDATA = Header$KEY_HEADERDATA;
     /**
      * JSON key error data.
      * @const
      * @type {string}
      */
-    var KEY_ERRORDATA = Header$KEY_ERRORDATA = "errordata";
+    var KEY_ERRORDATA = Header$KEY_ERRORDATA;
     /**
      * JSON key signature.
      * @const
      * @type {string}
      */
-    var KEY_SIGNATURE = Header$KEY_SIGNATURE = "signature";
+    var KEY_SIGNATURE = Header$KEY_SIGNATURE;
 
     /**
      * <p>Construct a new header from the provided JSON object.</p>

--- a/core/src/main/javascript/msg/HeaderKeys.js
+++ b/core/src/main/javascript/msg/HeaderKeys.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2012-2015 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Header$KEY_ENTITY_AUTHENTICATION_DATA = "entityauthdata";
+var Header$KEY_MASTER_TOKEN = "mastertoken";
+var Header$KEY_HEADERDATA = "headerdata";
+var Header$KEY_ERRORDATA = "errordata";
+var Header$KEY_SIGNATURE = "signature";

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -302,7 +302,7 @@ var MessageBuilder$createErrorResponse;
                     var factory = ctx.getUserAuthenticationFactory(scheme);
                     if (!factory) {
                         throw new MslUserAuthException(MslError.USERAUTH_FACTORY_NOT_FOUND, scheme)
-                        .setEntity(masterToken)
+                        .setMasterToken(masterToken)
                         .setUserAuthenticationData(userAuthData)
                         .setMessageId(requestMessageId);
                     }
@@ -407,8 +407,8 @@ var MessageBuilder$createErrorResponse;
             function handleError(e) {
                 AsyncExecutor(callback, function() {
                     if (e instanceof MslException) {
-                        e.setEntity(masterToken);
-                        e.setEntity(entityAuthData);
+                        e.setMasterToken(masterToken);
+                        e.setEntityAuthenticationData(entityAuthData);
                         e.setUserIdToken(userIdToken);
                         e.setUserAuthenticationData(userAuthData);
                         e.setMessageId(requestMessageId);
@@ -987,9 +987,9 @@ var MessageBuilder$createErrorResponse;
 
             // Make sure the service token is properly bound.
             if (serviceToken.isMasterTokenBound() && !serviceToken.isBoundTo(serviceMasterToken))
-                throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; mt " + JSON.stringify(serviceMasterToken)).setEntity(serviceMasterToken);
+                throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; mt " + JSON.stringify(serviceMasterToken)).setMasterToken(serviceMasterToken);
             if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(this._userIdToken))
-                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._userIdToken)).setEntity(serviceMasterToken).setUserIdToken(this._userIdToken);
+                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._userIdToken)).setMasterToken(serviceMasterToken).setUserIdToken(this._userIdToken);
 
             // Add the service token.
             this._serviceTokens[serviceToken.name] = serviceToken;
@@ -1113,7 +1113,7 @@ var MessageBuilder$createErrorResponse;
             if (userIdToken && !masterToken)
                 throw new MslInternalException("Peer master token cannot be null when setting peer user ID token.");
             if (userIdToken && !userIdToken.isBoundTo(masterToken))
-                throw new MslMessageException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit " + userIdToken + "; mt " + masterToken).setEntity(masterToken).setUserIdToken(userIdToken);
+                throw new MslMessageException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit " + userIdToken + "; mt " + masterToken).setMasterToken(masterToken).setUserIdToken(userIdToken);
 
             // Load the stored peer service tokens.
             var storedTokens;
@@ -1172,9 +1172,9 @@ var MessageBuilder$createErrorResponse;
             if (!this._ctx.isPeerToPeer())
                 throw new MslInternalException("Cannot set peer service tokens when not in peer-to-peer mode.");
             if (serviceToken.isMasterTokenBound() && !serviceToken.isBoundTo(this._peerMasterToken))
-                throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; mt " + JSON.stringify(this._peerMasterToken)).setEntity(this._peerMasterToken);
+                throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; mt " + JSON.stringify(this._peerMasterToken)).setMasterToken(this._peerMasterToken);
             if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(this._peerUserIdToken))
-                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._peerUserIdToken)).setEntity(this._peerMasterToken).setUserIdToken(this._peerUserIdToken);
+                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._peerUserIdToken)).setMasterToken(this._peerMasterToken).setUserIdToken(this._peerUserIdToken);
 
             // Add the peer service token.
             this._peerServiceTokens[serviceToken.name] = serviceToken;

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2015 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -303,7 +303,7 @@ var MessageBuilder$createErrorResponse;
                     if (!factory) {
                         throw new MslUserAuthException(MslError.USERAUTH_FACTORY_NOT_FOUND, scheme)
                         .setEntity(masterToken)
-                        .setUser(userAuthData)
+                        .setUserAuthenticationData(userAuthData)
                         .setMessageId(requestMessageId);
                     }
                     user = factory.authenticate(ctx, masterToken.identity, userAuthData, null);
@@ -345,7 +345,7 @@ var MessageBuilder$createErrorResponse;
             var entityAuthData = requestHeader.entityAuthenticationData;
             var userIdToken = requestHeader.userIdToken;
             var userAuthData = requestHeader.userAuthenticationData;
-            
+
             // The response recipient is the requesting entity.
             var recipient = (masterToken) ? masterToken.identity : entityAuthData.getIdentity();
 
@@ -372,11 +372,11 @@ var MessageBuilder$createErrorResponse;
                                         result: function(token) {
                                             AsyncExecutor(callback, function() {
                                                 userIdToken = token;
-                                                
+
                                                 // Compute the intersection of the request and response message
                                                 // capabilities.
                                                 var capabilities = MessageCapabilities$intersection(requestHeader.messageCapabilities, ctx.getMessageCapabilities());
-                                                
+
                                                 // Create the message builder.
                                                 //
                                                 // Peer-to-peer responses swap the tokens.
@@ -403,14 +403,14 @@ var MessageBuilder$createErrorResponse;
                 },
                 error: handleError,
             });
-            
+
             function handleError(e) {
                 AsyncExecutor(callback, function() {
                     if (e instanceof MslException) {
                         e.setEntity(masterToken);
                         e.setEntity(entityAuthData);
-                        e.setUser(userIdToken);
-                        e.setUser(userAuthData);
+                        e.setUserIdToken(userIdToken);
+                        e.setUserAuthenticationData(userAuthData);
                         e.setMessageId(requestMessageId);
                     }
                     throw e;
@@ -594,7 +594,7 @@ var MessageBuilder$createErrorResponse;
                 _nonReplayable: { value: _nonReplayable, writable: true, enumerable: false, configurable: false },
                 /** @type {boolean} */
                 _handshake: { value: _handshake, writable: true, enumerable: false, configurable: false },
-                
+
                 /** @type {boolean} */
                 _renewable: { value: _renewable, writable: true, enumerable: false, configurable: false },
                 /** @type {KeyRequestData} */
@@ -663,7 +663,7 @@ var MessageBuilder$createErrorResponse;
                     (!this._ctx.isPeerToPeer() && this._keyExchangeData) ||
                     this._entityAuthData.scheme.encrypts);
         },
-        
+
         /**
          * @return {boolean} true if the message builder will create a message capable of
          *         integrity protecting the header data.
@@ -671,7 +671,7 @@ var MessageBuilder$createErrorResponse;
         willIntegrityProtectHeader: function willIntegrityProtectHeader() {
             return (this._masterToken || this._entityAuthData.scheme.protectsIntegrity);
         },
-        
+
         /**
          * @return {boolean} true if the message builder will create a message capable of
          *         integrity protecting the payload data.
@@ -726,7 +726,7 @@ var MessageBuilder$createErrorResponse;
                 MessageHeader$create(this._ctx, this._entityAuthData, this._masterToken, headerData, peerData, callback);
             }, self);
         },
-        
+
         /**
          * @return {boolean} true if the message will be marked non-replayable.
          */
@@ -769,18 +769,18 @@ var MessageBuilder$createErrorResponse;
                 this._handshake = false;
             return this;
         },
-        
+
         /**
          * @return {boolean} true if the message will be marked as a handshake message.
          */
         isHandshake: function isHandshake() {
             return this._handshake;
         },
-        
+
         /**
          * Set the message handshake flag. If true this will also set the non-
          * replayable flag to false and the renewable flag to true.
-         * 
+         *
          * @param {boolean} handshake true if the message is a handshake message.
          * @return {MessageBuilder} this.
          * @see #setNonReplayable(boolean)
@@ -803,7 +803,7 @@ var MessageBuilder$createErrorResponse;
          * <p>Changing these tokens may result in invalidation of existing service
          * tokens. Those service tokens will be removed from the message being
          * built.</p>
-         * 
+         *
          * <p>This is a special method for the {@link MslControl} class that assumes
          * the builder does not have key response data in trusted network mode.</p>
          *
@@ -860,7 +860,7 @@ var MessageBuilder$createErrorResponse;
 
         /**
          * <p>Set the user authentication data of the message.</p>
-         * 
+         *
          * <p>This will overwrite any existing user authentication data.</p>
          *
          * @param {UserAuthenticationData} userAuthData user authentication data to set. May be null.
@@ -874,11 +874,11 @@ var MessageBuilder$createErrorResponse;
         /**
          * <p>Set the remote user of the message. This will create a user ID
          * token in trusted network mode or peer user ID token in peer-to-peer mode.</p>
-         * 
+         *
          * <p>Adding a new user ID token will not impact the service tokens; it is
          * assumed that no service tokens exist that are bound to the newly created
          * user ID token.</p>
-         * 
+         *
          * <p>This is a special method for the {@link MslControl} class that assumes
          * the builder does not already have a user ID token for the remote user
          * and does have a master token that the new user ID token can be bound
@@ -989,7 +989,7 @@ var MessageBuilder$createErrorResponse;
             if (serviceToken.isMasterTokenBound() && !serviceToken.isBoundTo(serviceMasterToken))
                 throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; mt " + JSON.stringify(serviceMasterToken)).setEntity(serviceMasterToken);
             if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(this._userIdToken))
-                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._userIdToken)).setEntity(serviceMasterToken).setUser(this._userIdToken);
+                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._userIdToken)).setEntity(serviceMasterToken).setUserIdToken(this._userIdToken);
 
             // Add the service token.
             this._serviceTokens[serviceToken.name] = serviceToken;
@@ -999,7 +999,7 @@ var MessageBuilder$createErrorResponse;
         /**
          * <p>Add a service token to the message if a service token with the same
          * name does not already exist.</p>
-         * 
+         *
          * <p>Adding a service token with empty data indicates the recipient should
          * delete the service token.</p>
          *
@@ -1096,7 +1096,7 @@ var MessageBuilder$createErrorResponse;
         /**
          * <p>Set the peer master token and peer user ID token of the message. This
          * will overwrite any existing peer master token or peer user ID token.</p>
-         * 
+         *
          * <p>Changing these tokens may result in invalidation of existing peer
          * service tokens. Those peer service tokens will be removed from the
          * message being built.</p>
@@ -1113,7 +1113,7 @@ var MessageBuilder$createErrorResponse;
             if (userIdToken && !masterToken)
                 throw new MslInternalException("Peer master token cannot be null when setting peer user ID token.");
             if (userIdToken && !userIdToken.isBoundTo(masterToken))
-                throw new MslMessageException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit " + userIdToken + "; mt " + masterToken).setEntity(masterToken).setUser(userIdToken);
+                throw new MslMessageException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit " + userIdToken + "; mt " + masterToken).setEntity(masterToken).setUserIdToken(userIdToken);
 
             // Load the stored peer service tokens.
             var storedTokens;
@@ -1174,7 +1174,7 @@ var MessageBuilder$createErrorResponse;
             if (serviceToken.isMasterTokenBound() && !serviceToken.isBoundTo(this._peerMasterToken))
                 throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; mt " + JSON.stringify(this._peerMasterToken)).setEntity(this._peerMasterToken);
             if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(this._peerUserIdToken))
-                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._peerUserIdToken)).setEntity(this._peerMasterToken).setUser(this._peerUserIdToken);
+                throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + JSON.stringify(serviceToken) + "; uit " + JSON.stringify(this._peerUserIdToken)).setEntity(this._peerMasterToken).setUserIdToken(this._peerUserIdToken);
 
             // Add the peer service token.
             this._peerServiceTokens[serviceToken.name] = serviceToken;
@@ -1184,7 +1184,7 @@ var MessageBuilder$createErrorResponse;
         /**
          * <p>Add a peer service token to the message if a peer service token with
          * the same name does not already exist.</p>
-         * 
+         *
          * <p>Adding a service token with empty data indicates the recipient should
          * delete the service token.</p>
          *

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -595,8 +595,8 @@ var MessageHeader$HeaderPeerData;
                             if (e instanceof MslException) {
                                 e.setEntity(masterToken);
                                 e.setEntity(entityAuthData);
-                                e.setUser(userIdToken);
-                                e.setUser(userAuthData);
+                                e.setUserIdToken(userIdToken);
+                                e.setUserAuthenticationData(userAuthData);
                                 e.setMessageId(messageId);
                             }
                             throw e;
@@ -626,8 +626,8 @@ var MessageHeader$HeaderPeerData;
                                                 if (e instanceof MslException) {
                                                     e.setEntity(masterToken);
                                                     e.setEntity(entityAuthData);
-                                                    e.setUser(userIdToken);
-                                                    e.setUser(userAuthData);
+                                                    e.setUserIdToken(userIdToken);
+                                                    e.setUserAuthenticationData(userAuthData);
                                                     e.setMessageId(messageId);
                                                 }
                                                 throw e;
@@ -641,8 +641,8 @@ var MessageHeader$HeaderPeerData;
                                     if (e instanceof MslException) {
                                         e.setEntity(masterToken);
                                         e.setEntity(entityAuthData);
-                                        e.setUser(userIdToken);
-                                        e.setUser(userAuthData);
+                                        e.setUserIdToken(userIdToken);
+                                        e.setUserAuthenticationData(userAuthData);
                                         e.setMessageId(messageId);
                                     }
                                     throw e;
@@ -948,7 +948,7 @@ var MessageHeader$HeaderPeerData;
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
                                                     e.setEntity(peerVerificationMasterToken);
-                                                    e.setUser(peerUserIdToken);
+                                                    e.setUserIdToken(peerUserIdToken);
                                                 }
                                                 throw e;
                                             });
@@ -1203,7 +1203,7 @@ var MessageHeader$HeaderPeerData;
                                                         var scheme = userAuthData.scheme;
                                                         var factory = ctx.getUserAuthenticationFactory(scheme);
                                                         if (!factory)
-                                                            throw new MslUserAuthException(MslError.USERAUTH_FACTORY_NOT_FOUND, scheme).setUser(userIdToken).setUser(userAuthData);
+                                                            throw new MslUserAuthException(MslError.USERAUTH_FACTORY_NOT_FOUND, scheme).setUserIdToken(userIdToken).setUserAuthenticationData(userAuthData);
                                                         var identity = (masterToken) ? masterToken.identity : entityAuthData.getIdentity();
                                                         user = factory.authenticate(ctx, identity, userAuthData, userIdToken);
                                                     } else if (userIdToken) {
@@ -1267,8 +1267,8 @@ var MessageHeader$HeaderPeerData;
                                                                     error: function(e) {
                                                                         AsyncExecutor(callback, function() {
                                                                             if (e instanceof MslException) {
-                                                                                e.setUser(userIdToken);
-                                                                                e.setUser(userAuthData);
+                                                                                e.setUserIdToken(userIdToken);
+                                                                                e.setUserAuthenticationData(userAuthData);
                                                                             }
                                                                             throw e;
                                                                         });
@@ -1280,8 +1280,8 @@ var MessageHeader$HeaderPeerData;
                                                             AsyncExecutor(callback, function() {
                                                                 if (e instanceof MslException) {
                                                                     e.setEntity(tokenVerificationMasterToken);
-                                                                    e.setUser(userIdToken);
-                                                                    e.setUser(userAuthData);
+                                                                    e.setUserIdToken(userIdToken);
+                                                                    e.setUserAuthenticationData(userAuthData);
                                                                 }
                                                                 throw e;
                                                             });

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -593,8 +593,8 @@ var MessageHeader$HeaderPeerData;
                             messageCryptoContext = getMessageCryptoContext(ctx, entityAuthData, masterToken);
                         } catch (e) {
                             if (e instanceof MslException) {
-                                e.setEntity(masterToken);
-                                e.setEntity(entityAuthData);
+                                e.setMasterToken(masterToken);
+                                e.setEntityAuthenticationData(entityAuthData);
                                 e.setUserIdToken(userIdToken);
                                 e.setUserAuthenticationData(userAuthData);
                                 e.setMessageId(messageId);
@@ -624,8 +624,8 @@ var MessageHeader$HeaderPeerData;
                                         error: function(e) {
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
-                                                    e.setEntity(masterToken);
-                                                    e.setEntity(entityAuthData);
+                                                    e.setMasterToken(masterToken);
+                                                    e.setEntityAuthenticationData(entityAuthData);
                                                     e.setUserIdToken(userIdToken);
                                                     e.setUserAuthenticationData(userAuthData);
                                                     e.setMessageId(messageId);
@@ -639,8 +639,8 @@ var MessageHeader$HeaderPeerData;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException) {
-                                        e.setEntity(masterToken);
-                                        e.setEntity(entityAuthData);
+                                        e.setMasterToken(masterToken);
+                                        e.setEntityAuthenticationData(entityAuthData);
                                         e.setUserIdToken(userIdToken);
                                         e.setUserAuthenticationData(userAuthData);
                                         e.setMessageId(messageId);
@@ -947,7 +947,7 @@ var MessageHeader$HeaderPeerData;
                                         error: function(e) {
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
-                                                    e.setEntity(peerVerificationMasterToken);
+                                                    e.setMasterToken(peerVerificationMasterToken);
                                                     e.setUserIdToken(peerUserIdToken);
                                                 }
                                                 throw e;
@@ -959,7 +959,7 @@ var MessageHeader$HeaderPeerData;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException)
-                                        e.setEntity(peerVerificationMasterToken);
+                                        e.setMasterToken(peerVerificationMasterToken);
                                     throw e;
                                 });
                             }
@@ -1080,8 +1080,8 @@ var MessageHeader$HeaderPeerData;
                 messageCryptoContext = getMessageCryptoContext(ctx, entityAuthData, masterToken);
             } catch (e) {
                 if (e instanceof MslException) {
-                    e.setEntity(masterToken);
-                    e.setEntity(entityAuthData);
+                    e.setMasterToken(masterToken);
+                    e.setEntityAuthenticationData(entityAuthData);
                 }
                 throw e;
             }
@@ -1126,7 +1126,7 @@ var MessageHeader$HeaderPeerData;
                     headerdataJO = JSON.parse(headerdataJson);
                 } catch (e) {
                     if (e instanceof SyntaxError)
-                        throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson, e).setEntity(masterToken).setEntity(entityAuthData);
+                        throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson, e).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData);
                     throw e;
                 }
 
@@ -1136,25 +1136,25 @@ var MessageHeader$HeaderPeerData;
 
                 // Verify message ID.
                 if (!messageId || messageId != messageId)
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setEntity(masterToken).setEntity(entityAuthData);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData);
                 if (messageId < 0 || messageId > MslConstants$MAX_LONG_VALUE)
-                    throw new MslMessageException(MslError.MESSAGE_ID_OUT_OF_RANGE, "headerdata " + headerdataJson).setEntity(masterToken).setEntity(entityAuthData);
+                    throw new MslMessageException(MslError.MESSAGE_ID_OUT_OF_RANGE, "headerdata " + headerdataJson).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData);
 
                 // If the message was sent with a master token pull the sender.
                 var sender = (masterToken) ? headerdataJO[KEY_SENDER] : null;
                 if (masterToken && (!sender || typeof sender !== 'string'))
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setEntity(masterToken).setEntity(entityAuthData).setMessageId(messageId);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData).setMessageId(messageId);
                 var recipient = (headerdataJO[KEY_RECIPIENT] !== 'undefined') ? headerdataJO[KEY_RECIPIENT] : null;
                 if (recipient && typeof recipient !== 'string')
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setEntity(masterToken).setEntity(entityAuthData).setMessageId(messageId);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData).setMessageId(messageId);
                 var timestampSeconds = (headerdataJO[KEY_TIMESTAMP] !== 'undefined') ? headerdataJO[KEY_TIMESTAMP] : null;
                 if (timestampSeconds && typeof timestampSeconds !== 'number')
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setEntity(masterToken).setEntity(entityAuthData).setMessageId(messageId);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData).setMessageId(messageId);
                 
                 // Pull and verify key response data.
                 var keyResponseDataJo = headerdataJO[KEY_KEY_RESPONSE_DATA];
                 if (keyResponseDataJo && typeof keyResponseDataJo !== 'object')
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setEntity(masterToken).setEntity(entityAuthData).setMessageId(messageId);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "headerdata " + headerdataJson).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData).setMessageId(messageId);
 
                 // Change the callback so we can add the message Id to
                 // any thrown exceptions.
@@ -1163,8 +1163,8 @@ var MessageHeader$HeaderPeerData;
                         result: function(ret) { originalCallback.result(ret); },
                         error: function(e) {
                             if (e instanceof MslException) {
-                                e.setEntity(masterToken);
-                                e.setEntity(entityAuthData);
+                                e.setMasterToken(masterToken);
+                                e.setEntityAuthenticationData(entityAuthData);
                                 e.setMessageId(messageId);
                             }
                             originalCallback.error(e);
@@ -1279,7 +1279,7 @@ var MessageHeader$HeaderPeerData;
                                                         error: function(e) {
                                                             AsyncExecutor(callback, function() {
                                                                 if (e instanceof MslException) {
-                                                                    e.setEntity(tokenVerificationMasterToken);
+                                                                    e.setMasterToken(tokenVerificationMasterToken);
                                                                     e.setUserIdToken(userIdToken);
                                                                     e.setUserAuthenticationData(userAuthData);
                                                                 }

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -66,7 +66,7 @@ var MessageInputStream$create;
             // If there is no key response data then return null.
             if (!keyResponse)
                 return null;
-            
+
             // If the key response data master token is decrypted then use the
             // master token keys to create the crypto context.
             var keyxMasterToken = keyResponse.masterToken;
@@ -254,8 +254,8 @@ var MessageInputStream$create;
                                         if (e instanceof MslException) {
                                             e.setEntity(messageHeader.masterToken);
                                             e.setEntity(messageHeader.entityAuthenticationData);
-                                            e.setUser(messageHeader.userIdToken);
-                                            e.setUser(messageHeader.userAuthenticationData);
+                                            e.setUserIdToken(messageHeader.userIdToken);
+                                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                             e.setMessageId(messageHeader.messageId);
                                         }
                                         self._errored = e;
@@ -299,15 +299,15 @@ var MessageInputStream$create;
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
                             e.setEntity(messageHeader.entityAuthenticationData);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
                         ready();
                     }
                 }
-                
+
                 function checkHandshakeProperties(ctx, messageHeader) {
                     try {
                         // If this is a handshake message but it is not renewable or does
@@ -317,14 +317,14 @@ var MessageInputStream$create;
                         {
                             throw new MslMessageException(MslError.HANDSHAKE_DATA_MISSING, JSON.stringify(messageHeader));
                         }
-                        
+
                         checkMasterToken(ctx, messageHeader);
                     } catch (e) {
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
                             e.setEntity(messageHeader.entityAuthenticationData);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
@@ -346,8 +346,8 @@ var MessageInputStream$create;
                     } catch (e) {
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
@@ -365,8 +365,8 @@ var MessageInputStream$create;
                             result: function(revoked) {
                                 if (revoked) {
                                     self._errored = new MslMasterTokenException(revoked, masterToken)
-                                    .setUser(messageHeader.userIdToken)
-                                    .setUser(messageHeader.userAuthenticationData)
+                                    .setUserIdToken(messageHeader.userIdToken)
+                                    .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                     .setMessageId(messageHeader.messageId);
                                     ready();
                                 } else {
@@ -376,8 +376,8 @@ var MessageInputStream$create;
                             error: function(e) {
                                 if (e instanceof MslException) {
                                     e.setEntity(messageHeader.masterToken);
-                                    e.setUser(messageHeader.userIdToken);
-                                    e.setUser(messageHeader.userAuthenticationData);
+                                    e.setUserIdToken(messageHeader.userIdToken);
+                                    e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                     e.setMessageId(messageHeader.messageId);
                                 }
                                 self._errored = e;
@@ -387,8 +387,8 @@ var MessageInputStream$create;
                     } catch (e) {
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
@@ -410,7 +410,7 @@ var MessageInputStream$create;
                                     if (revoked) {
                                         self._errored = new MslUserIdTokenException(revoked, userIdToken)
                                         .setEntity(masterToken)
-                                        .setUser(userIdToken)
+                                        .setUserIdToken(userIdToken)
                                         .setMessageId(messageHeader.messageId);
                                         ready();
                                     } else {
@@ -420,8 +420,8 @@ var MessageInputStream$create;
                                 error: function(e) {
                                     if (e instanceof MslException) {
                                         e.setEntity(messageHeader.masterToken);
-                                        e.setUser(messageHeader.userIdToken);
-                                        e.setUser(messageHeader.userAuthenticationData);
+                                        e.setUserIdToken(messageHeader.userIdToken);
+                                        e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                         e.setMessageId(messageHeader.messageId);
                                     }
                                     self._errored = e;
@@ -434,8 +434,8 @@ var MessageInputStream$create;
                     } catch (e) {
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
@@ -453,8 +453,8 @@ var MessageInputStream$create;
                             if (!messageHeader.isRenewable() || messageHeader.keyRequestData.length == 0) {
                                 self._errored = new MslMessageException(MslError.MESSAGE_EXPIRED, JSON.stringify(messageHeader))
                                 .setEntity(masterToken)
-                                .setUser(messageHeader.userIdToken)
-                                .setUser(messageHeader.userAuthenticationData)
+                                .setUserIdToken(messageHeader.userIdToken)
+                                .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                 .setMessageId(messageHeader.messageId);
                                 ready();
                                 return;
@@ -471,8 +471,8 @@ var MessageInputStream$create;
                                     if (notRenewable) {
                                         self._errored = new MslMessageException(notRenewable, "Master token is expired and not renewable.")
                                         .setEntity(masterToken)
-                                        .setUser(messageHeader.userIdToken)
-                                        .setUser(messageHeader.userAuthenticationData)
+                                        .setUserIdToken(messageHeader.userIdToken)
+                                        .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                         .setMessageId(messageHeader.messageId);;
                                         ready();
                                     } else {
@@ -482,8 +482,8 @@ var MessageInputStream$create;
                                 error: function(e) {
                                     if (e instanceof MslException) {
                                         e.setEntity(messageHeader.masterToken);
-                                        e.setUser(messageHeader.userIdToken);
-                                        e.setUser(messageHeader.userAuthenticationData);
+                                        e.setUserIdToken(messageHeader.userIdToken);
+                                        e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                         e.setMessageId(messageHeader.messageId);
                                     }
                                     self._errored = e;
@@ -496,8 +496,8 @@ var MessageInputStream$create;
                     } catch (e) {
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
@@ -517,8 +517,8 @@ var MessageInputStream$create;
                             if (!masterToken) {
                                 self._errored = new MslMessageException(MslError.INCOMPLETE_NONREPLAYABLE_MESSAGE, JSON.stringify(messageHeader))
                                 .setEntity(messageHeader.entityAuthenticationData)
-                                .setUser(messageHeader.userIdToken)
-                                .setUser(messageHeader.userAuthenticationData)
+                                .setUserIdToken(messageHeader.userIdToken)
+                                .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                 .setMessageId(messageHeader.messageId);
                                 ready();
                                 return;
@@ -532,8 +532,8 @@ var MessageInputStream$create;
                                     if (replayed) {
                                         self._errored = new MslMessageException(replayed, JSON.stringify(messageHeader))
                                         .setEntity(masterToken)
-                                        .setUser(messageHeader.userIdToken)
-                                        .setUser(messageHeader.userAuthenticationData)
+                                        .setUserIdToken(messageHeader.userIdToken)
+                                        .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                         .setMessageId(messageHeader.messageId);
                                     }
 
@@ -543,8 +543,8 @@ var MessageInputStream$create;
                                 error: function(e) {
                                     if (e instanceof MslException) {
                                         e.setEntity(masterToken);
-                                        e.setUser(messageHeader.userIdToken);
-                                        e.setUser(messageHeader.userAuthenticationData);
+                                        e.setUserIdToken(messageHeader.userIdToken);
+                                        e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                         e.setMessageId(messageHeader.messageId);
                                     }
                                     self._errored = e;
@@ -561,8 +561,8 @@ var MessageInputStream$create;
                         if (e instanceof MslException) {
                             e.setEntity(messageHeader.masterToken);
                             e.setEntity(messageHeader.entityAuthenticationData);
-                            e.setUser(messageHeader.userIdToken);
-                            e.setUser(messageHeader.userAuthenticationData);
+                            e.setUserIdToken(messageHeader.userIdToken);
+                            e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
                         }
                         self._errored = e;
@@ -578,7 +578,7 @@ var MessageInputStream$create;
 
         /**
          * Retrieve the next JSON object.
-         * 
+         *
          * @param {number} timeout read timeout in milliseconds.
          * @return {object} the next JSON object or null if none remaining.
          * @throws MslEncodingException if there is a problem parsing the JSON.
@@ -595,7 +595,7 @@ var MessageInputStream$create;
                 // read more.
                 if (this._eom)
                     return null;
-                
+
                 // Otherwise read the next JSON object.
                 function nextObject(callback) {
                     InterruptibleExecutor(callback, function() {
@@ -640,7 +640,7 @@ var MessageInputStream$create;
                     },
                     timeout: callback.timeout,
                     error: callback.error,
-                }); 
+                });
             }, self);
         },
 
@@ -694,18 +694,18 @@ var MessageInputStream$create;
                                             throw new MslMessageException(MslError.PAYLOAD_MESSAGE_ID_MISMATCH, "payload mid " + payload.messageId + " header mid " + messageHeader.messageId)
                                             .setEntity(masterToken)
                                             .setEntity(entityAuthData)
-                                            .setUser(userIdToken)
-                                            .setUser(userAuthData);
+                                            .setUserIdToken(userIdToken)
+                                            .setUserAuthenticationData(userAuthData);
                                         }
                                         if (payload.sequenceNumber != this._payloadSequenceNumber) {
                                             throw new MslMessageException(MslError.PAYLOAD_SEQUENCE_NUMBER_MISMATCH, "payload seqno " + payload.sequenceNumber + " expected seqno " + this._payloadSequenceNumber)
                                             .setEntity(masterToken)
                                             .setEntity(entityAuthData)
-                                            .setUser(userIdToken)
-                                            .setUser(userAuthData);
+                                            .setUserIdToken(userIdToken)
+                                            .setUserAuthenticationData(userAuthData);
                                         }
                                         ++this._payloadSequenceNumber;
-                                        
+
                                         // FIXME remove this logic once the old handshake inference logic
                                         // is no longer supported.
                                         // Check for a handshake if this is the first payload chunk.
@@ -713,7 +713,7 @@ var MessageInputStream$create;
                                             this._handshake = (messageHeader.isRenewable() && messageHeader.keyRequestData.length > 0 &&
                                                 payload.isEndOfMessage() && payload.data.length == 0);
                                         }
-                                        
+
                                         // Check for end of message.
                                         if (payload.isEndOfMessage())
                                             this._eom = true;
@@ -795,15 +795,15 @@ var MessageInputStream$create;
                 }, self);
             }
         },
-        
+
         /**
          * Returns true if the message is a handshake message.
-         * 
+         *
          * FIXME
          * This method should be removed by a direct query of the message header
          * once the old behavior of inferred handshake messages based on a single
          * empty payload chunk is no longer supported.
-         * 
+         *
          * @return {boolean} true if the message is a handshake message or
          *         undefined if aborted.
          * @throws MslCryptoException if there is a problem decrypting or verifying
@@ -816,16 +816,16 @@ var MessageInputStream$create;
          */
         isHandshake: function isHandshake(timeout, callback) {
             var self = this;
-            
+
             InterruptibleExecutor(callback, function() {
                 var messageHeader = this.getMessageHeader();
-                
+
                 // Error messages are not handshake messages.
                 if (!messageHeader) return false;
-                
+
                 // If the message header has its handshake flag set return true.
                 if (messageHeader.isHandshake()) return true;
-                
+
                 // If we haven't read a payload we don't know if this is a handshake
                 // message or not. This also implies the current payload is null.
                 if (this._handshake == null) {
@@ -956,7 +956,7 @@ var MessageInputStream$create;
         /** @inheritDoc */
         close: function close(timeout, callback) {
             var self = this;
-            
+
             InterruptibleExecutor(callback, function() {
                 // Only close the source if instructed to do so because we might want
                 // to reuse the connection.
@@ -1046,7 +1046,7 @@ var MessageInputStream$create;
                     initialChecks();
                 }
             }, self);
-            
+
             function initialChecks() {
                 InterruptibleExecutor(callback, function() {
                     // Check if already aborted, timedout, or errored.
@@ -1065,7 +1065,7 @@ var MessageInputStream$create;
                         this._readException = null;
                         throw e;
                     }
-                    
+
                     // Return end of stream immediately for handshake messages.
                     this.isHandshake(timeout, {
                         result: function(handshake) {

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -252,8 +252,8 @@ var MessageInputStream$create;
                                     },
                                     error: function(e) {
                                         if (e instanceof MslException) {
-                                            e.setEntity(messageHeader.masterToken);
-                                            e.setEntity(messageHeader.entityAuthenticationData);
+                                            e.setMasterToken(messageHeader.masterToken);
+                                            e.setEntityAuthenticationData(messageHeader.entityAuthenticationData);
                                             e.setUserIdToken(messageHeader.userIdToken);
                                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                             e.setMessageId(messageHeader.messageId);
@@ -297,8 +297,8 @@ var MessageInputStream$create;
                         checkHandshakeProperties(ctx, messageHeader);
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
-                            e.setEntity(messageHeader.entityAuthenticationData);
+                            e.setMasterToken(messageHeader.masterToken);
+                            e.setEntityAuthenticationData(messageHeader.entityAuthenticationData);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -321,8 +321,8 @@ var MessageInputStream$create;
                         checkMasterToken(ctx, messageHeader);
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
-                            e.setEntity(messageHeader.entityAuthenticationData);
+                            e.setMasterToken(messageHeader.masterToken);
+                            e.setEntityAuthenticationData(messageHeader.entityAuthenticationData);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -345,7 +345,7 @@ var MessageInputStream$create;
                         }
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
+                            e.setMasterToken(messageHeader.masterToken);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -375,7 +375,7 @@ var MessageInputStream$create;
                             },
                             error: function(e) {
                                 if (e instanceof MslException) {
-                                    e.setEntity(messageHeader.masterToken);
+                                    e.setMasterToken(messageHeader.masterToken);
                                     e.setUserIdToken(messageHeader.userIdToken);
                                     e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                     e.setMessageId(messageHeader.messageId);
@@ -386,7 +386,7 @@ var MessageInputStream$create;
                         });
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
+                            e.setMasterToken(messageHeader.masterToken);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -409,7 +409,7 @@ var MessageInputStream$create;
                                 result: function(revoked) {
                                     if (revoked) {
                                         self._errored = new MslUserIdTokenException(revoked, userIdToken)
-                                        .setEntity(masterToken)
+                                        .setMasterToken(masterToken)
                                         .setUserIdToken(userIdToken)
                                         .setMessageId(messageHeader.messageId);
                                         ready();
@@ -419,7 +419,7 @@ var MessageInputStream$create;
                                 },
                                 error: function(e) {
                                     if (e instanceof MslException) {
-                                        e.setEntity(messageHeader.masterToken);
+                                        e.setMasterToken(messageHeader.masterToken);
                                         e.setUserIdToken(messageHeader.userIdToken);
                                         e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                         e.setMessageId(messageHeader.messageId);
@@ -433,7 +433,7 @@ var MessageInputStream$create;
                         }
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
+                            e.setMasterToken(messageHeader.masterToken);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -452,7 +452,7 @@ var MessageInputStream$create;
                             // request data then reject the message.
                             if (!messageHeader.isRenewable() || messageHeader.keyRequestData.length == 0) {
                                 self._errored = new MslMessageException(MslError.MESSAGE_EXPIRED, JSON.stringify(messageHeader))
-                                .setEntity(masterToken)
+                                .setMasterToken(masterToken)
                                 .setUserIdToken(messageHeader.userIdToken)
                                 .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                 .setMessageId(messageHeader.messageId);
@@ -470,7 +470,7 @@ var MessageInputStream$create;
                                 result: function(notRenewable) {
                                     if (notRenewable) {
                                         self._errored = new MslMessageException(notRenewable, "Master token is expired and not renewable.")
-                                        .setEntity(masterToken)
+                                        .setMasterToken(masterToken)
                                         .setUserIdToken(messageHeader.userIdToken)
                                         .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                         .setMessageId(messageHeader.messageId);;
@@ -481,7 +481,7 @@ var MessageInputStream$create;
                                 },
                                 error: function(e) {
                                     if (e instanceof MslException) {
-                                        e.setEntity(messageHeader.masterToken);
+                                        e.setMasterToken(messageHeader.masterToken);
                                         e.setUserIdToken(messageHeader.userIdToken);
                                         e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                         e.setMessageId(messageHeader.messageId);
@@ -495,7 +495,7 @@ var MessageInputStream$create;
                         }
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
+                            e.setMasterToken(messageHeader.masterToken);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -516,7 +516,7 @@ var MessageInputStream$create;
                             // message.
                             if (!masterToken) {
                                 self._errored = new MslMessageException(MslError.INCOMPLETE_NONREPLAYABLE_MESSAGE, JSON.stringify(messageHeader))
-                                .setEntity(messageHeader.entityAuthenticationData)
+                                .setEntityAuthenticationData(messageHeader.entityAuthenticationData)
                                 .setUserIdToken(messageHeader.userIdToken)
                                 .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                 .setMessageId(messageHeader.messageId);
@@ -531,7 +531,7 @@ var MessageInputStream$create;
                                 result: function(replayed) {
                                     if (replayed) {
                                         self._errored = new MslMessageException(replayed, JSON.stringify(messageHeader))
-                                        .setEntity(masterToken)
+                                        .setMasterToken(masterToken)
                                         .setUserIdToken(messageHeader.userIdToken)
                                         .setUserAuthenticationData(messageHeader.userAuthenticationData)
                                         .setMessageId(messageHeader.messageId);
@@ -542,7 +542,7 @@ var MessageInputStream$create;
                                 },
                                 error: function(e) {
                                     if (e instanceof MslException) {
-                                        e.setEntity(masterToken);
+                                        e.setMasterToken(masterToken);
                                         e.setUserIdToken(messageHeader.userIdToken);
                                         e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                                         e.setMessageId(messageHeader.messageId);
@@ -559,8 +559,8 @@ var MessageInputStream$create;
                         }
                     } catch (e) {
                         if (e instanceof MslException) {
-                            e.setEntity(messageHeader.masterToken);
-                            e.setEntity(messageHeader.entityAuthenticationData);
+                            e.setMasterToken(messageHeader.masterToken);
+                            e.setEntityAuthenticationData(messageHeader.entityAuthenticationData);
                             e.setUserIdToken(messageHeader.userIdToken);
                             e.setUserAuthenticationData(messageHeader.userAuthenticationData);
                             e.setMessageId(messageHeader.messageId);
@@ -692,15 +692,15 @@ var MessageInputStream$create;
                                         var userAuthData = messageHeader.getUserAuthenticationData;
                                         if (payload.messageId != messageHeader.messageId) {
                                             throw new MslMessageException(MslError.PAYLOAD_MESSAGE_ID_MISMATCH, "payload mid " + payload.messageId + " header mid " + messageHeader.messageId)
-                                            .setEntity(masterToken)
-                                            .setEntity(entityAuthData)
+                                            .setMasterToken(masterToken)
+                                            .setEntityAuthenticationData(entityAuthData)
                                             .setUserIdToken(userIdToken)
                                             .setUserAuthenticationData(userAuthData);
                                         }
                                         if (payload.sequenceNumber != this._payloadSequenceNumber) {
                                             throw new MslMessageException(MslError.PAYLOAD_SEQUENCE_NUMBER_MISMATCH, "payload seqno " + payload.sequenceNumber + " expected seqno " + this._payloadSequenceNumber)
-                                            .setEntity(masterToken)
-                                            .setEntity(entityAuthData)
+                                            .setMasterToken(masterToken)
+                                            .setEntityAuthenticationData(entityAuthData)
                                             .setUserIdToken(userIdToken)
                                             .setUserAuthenticationData(userAuthData);
                                         }

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -1734,8 +1734,8 @@ var MslControl$MslChannel;
                                             var expectedMessageId = MessageBuilder$incrementMessageId(request.messageId);
                                             if (responseMessageId != expectedMessageId) {
                                                 throw new MslMessageException(MslError.UNEXPECTED_RESPONSE_MESSAGE_ID, "expected " + expectedMessageId + "; received " + responseMessageId)
-                                                    .setEntity(masterToken)
-                                                    .setEntity(entityAuthData)
+                                                    .setMasterToken(masterToken)
+                                                    .setEntityAuthenticationData(entityAuthData)
                                                     .setUserIdToken(userIdToken)
                                                     .setUserAuthenticationData(userAuthData);
                                             }
@@ -1811,8 +1811,8 @@ var MslControl$MslChannel;
                                                         ctx.updateRemoteTime(timestamp);
                                                 } catch (e) {
                                                     if (e instanceof MslException) {
-                                                        e.setEntity(masterToken);
-                                                        e.setEntity(entityAuthData);
+                                                        e.setMasterToken(masterToken);
+                                                        e.setEntityAuthenticationData(entityAuthData);
                                                         e.setUserIdToken(userIdToken);
                                                         e.setUserAuthenticationData(userAuthData);
                                                     }

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -139,20 +139,20 @@ var MslControl$MslChannel;
         Object.defineProperties(this, props);
         return this;
     };
-    
+
     /**
      * A map key based off a MSL context and master token pair.
      */
     var MslContextMasterTokenKey = util.Class.create({
         /**
          * Create a new MSL context and master token map key.
-         * 
+         *
          * @param {MslContext} ctx MSL context.
          * @param {MasterToken} masterToken master token.
          */
         init: function init(ctx, masterToken) {
             // The properties.
-            var props = { 
+            var props = {
                 _ctx: { value: ctx, writable: false, enumerable: false, configurable: false },
                 _masterToken: { value: masterToken, writable: false, enumerable: false, configurable: false },
             };
@@ -662,7 +662,7 @@ var MslControl$MslChannel;
                             // If aborted throw an exception.
                             if (ticket === undefined)
                                 throw new MslInterruptedException('getNewestMasterToken aborted.');
-                            
+
                             // Now we have to be tricky and make sure the master token we just
                             // acquired is still the newest master token. This is necessary
                             // just in case the master token was deleted between grabbing it
@@ -670,7 +670,7 @@ var MslControl$MslChannel;
                             var newestMasterToken = store.getMasterToken();
                             if (masterToken.equals(newestMasterToken))
                                 return new TokenTicket(masterToken, ticket);
-                            
+
                             // If the master tokens are not the same then release the read
                             // lock, acquire the write lock, and then delete the master token
                             // lock (it may already be deleted). Then try again.
@@ -681,7 +681,7 @@ var MslControl$MslChannel;
                                         // If aborted throw an exception.
                                         if (writeTicket === undefined)
                                             throw new MslInterruptedException('getNewestMasterToken aborted.');
-                                        
+
                                         delete this._masterTokenLocks[key];
                                         rwlock.unlock(writeTicket);
                                         return this.getNewestMasterToken(service, ctx, timeout, callback);
@@ -764,7 +764,7 @@ var MslControl$MslChannel;
                 var masterToken = tokenTicket.masterToken;
                 var key = new MslContextMasterTokenKey(ctx, masterToken).uniqueKey();
                 var rwlock = this._masterTokenLocks[key];
-                
+
                 // The lock may be null if the master token was deleted.
                 if (rwlock)
                     rwlock.unlock(tokenTicket.ticket);
@@ -1229,7 +1229,7 @@ var MslControl$MslChannel;
                                     } else {
                                         userIdToken = null;
                                     }
-                                    
+
                                     // Resend the request.
                                     var messageId = MessageBuilder$incrementMessageId(errorHeader.messageId);
                                     var resendMsgCtx = new ResendMessageContext(payloads, msgCtx);
@@ -1290,7 +1290,7 @@ var MslControl$MslChannel;
                                     } else {
                                         userIdToken = null;
                                     }
-                                    
+
                                     // Resend the request.
                                     var messageId = MessageBuilder$incrementMessageId(errorHeader.messageId);
                                     var resendMsgCtx = new ResendMessageContext(payloads, msgCtx);
@@ -1303,7 +1303,7 @@ var MslControl$MslChannel;
                                                     var peerUserIdToken = requestHeader.peerUserIdToken;
                                                     requestBuilder.setPeerAuthTokens(peerMasterToken, peerUserIdToken);
                                                 }
-                                                
+
                                                 // Mark the message as replayable or not as dictated by the
                                                 // message context.
                                                 requestBuilder.setNonReplayable(resendMsgCtx.isNonReplayable());
@@ -1736,8 +1736,8 @@ var MslControl$MslChannel;
                                                 throw new MslMessageException(MslError.UNEXPECTED_RESPONSE_MESSAGE_ID, "expected " + expectedMessageId + "; received " + responseMessageId)
                                                     .setEntity(masterToken)
                                                     .setEntity(entityAuthData)
-                                                    .setUser(userIdToken)
-                                                    .setUser(userAuthData);
+                                                    .setUserIdToken(userIdToken)
+                                                    .setUserAuthenticationData(userAuthData);
                                             }
                                         }
                                     }
@@ -1803,7 +1803,7 @@ var MslControl$MslChannel;
                                                         if (localIdentity == sender)
                                                             throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, sender);
                                                     }
-                                                    
+
                                                     // Update the synchronized clock if we are a trusted network client
                                                     // (there is a request) or peer-to-peer entity.
                                                     var timestamp = (responseHeader) ? responseHeader.timestamp : errorHeader.timestamp;
@@ -1813,8 +1813,8 @@ var MslControl$MslChannel;
                                                     if (e instanceof MslException) {
                                                         e.setEntity(masterToken);
                                                         e.setEntity(entityAuthData);
-                                                        e.setUser(userIdToken);
-                                                        e.setUser(userAuthData);
+                                                        e.setUserIdToken(userIdToken);
+                                                        e.setUserAuthenticationData(userAuthData);
                                                     }
                                                     throw e;
                                                 }
@@ -1898,7 +1898,7 @@ var MslControl$MslChannel;
          */
         sendReceive: function sendReceive(service, ctx, msgCtx, input, output, builderTokenTicket, receive, closeStreams, timeout, callback) {
             var self = this;
-            
+
             // Attempt to acquire the renewal lock.
             InterruptibleExecutor(callback, function() {
                 // acquireRenewalLock() may change the master token, and in
@@ -1937,7 +1937,7 @@ var MslControl$MslChannel;
                 InterruptibleExecutor(callback, function sendrecv_send() {
                     var builder = builderTokenTicket.builder;
                     var tokenTicket = builderTokenTicket.tokenTicket;
-                    
+
                     // Send the request.
                     builder.setRenewable(renewing);
                     this.send(service, ctx, msgCtx, output, builder, closeStreams, timeout, {
@@ -1958,11 +1958,11 @@ var MslControl$MslChannel;
                                                 var errorHeader = response.getErrorHeader();
                                                 if (errorHeader)
                                                     this.cleanupContext(ctx, requestHeader, errorHeader);
-                                                
+
                                                 // Release the renewal lock.
                                                 if (renewing)
                                                     this.releaseRenewalLock(ctx, renewalQueue, response);
-                                                
+
                                                 // Release the master token lock.
                                                 this.releaseMasterToken(ctx, tokenTicket);
 
@@ -1976,10 +1976,10 @@ var MslControl$MslChannel;
                                                 // Release the renewal lock.
                                                 if (renewing)
                                                     this.releaseRenewalLock(ctx, renewalQueue, null);
-                                                
+
                                                 // Release the master token lock.
                                                 this.releaseMasterToken(ctx, tokenTicket);
-                                                
+
                                                 callback.timeout();
                                             }, self);
                                         },
@@ -1988,10 +1988,10 @@ var MslControl$MslChannel;
                                                 // Release the renewal lock.
                                                 if (renewing)
                                                     this.releaseRenewalLock(ctx, renewalQueue, null);
-                                                
+
                                                 // Release the master token lock.
                                                 this.releaseMasterToken(ctx, tokenTicket);
-                                                
+
                                                 callback.error(e);
                                             }, self);
                                         }
@@ -1999,11 +1999,11 @@ var MslControl$MslChannel;
                                 } else {
                                     InterruptibleExecutor(callback, function() {
                                         var response = null;
-                                        
+
                                         // Release the renewal lock.
                                         if (renewing)
                                             this.releaseRenewalLock(ctx, renewalQueue, response);
-                                        
+
                                         // Release the master token lock.
                                         this.releaseMasterToken(ctx, tokenTicket);
 
@@ -2018,24 +2018,24 @@ var MslControl$MslChannel;
                                 // Release the renewal lock.
                                 if (renewing)
                                     this.releaseRenewalLock(ctx, renewalQueue, null);
-                                
+
                                 // Release the master token lock.
                                 this.releaseMasterToken(ctx, tokenTicket);
-                                
+
                                 callback.timeout();
                             }, self);
                         },
                         error: function(e) {
                             InterruptibleExecutor(callback, function() {
                                 var response = null;
-                                
+
                                 // Release the renewal lock.
                                 if (renewing)
                                     this.releaseRenewalLock(ctx, renewalQueue, response);
-                                
+
                                 // Release the master token lock.
                                 this.releaseMasterToken(ctx, tokenTicket);
-                                
+
                                 callback.error(e);
                             }, self);
                         }
@@ -2106,7 +2106,7 @@ var MslControl$MslChannel;
             InterruptibleExecutor(callback, function() {
                 var builder = builderTokenTicket.builder;
                 var tokenTicket = builderTokenTicket.tokenTicket;
-                
+
                 var masterToken = builder.getMasterToken();
                 var userIdToken = builder.getUserIdToken();
                 var userId = msgCtx.getUserId();
@@ -2178,14 +2178,14 @@ var MslControl$MslChannel;
                                 // Put the same master token back on the renewing queue so
                                 // anyone else waiting can also proceed.
                                 ctxRenewingQueue.add(newMasterToken);
-                                
+
                                 // If the renewing request did not acquire a master token then
                                 // try again to acquire renewal ownership.
                                 if (newMasterToken === NULL_MASTER_TOKEN) {
                                     blockingAcquisition(masterToken, userIdToken, userId, builder, tokenTicket);
                                     return;
                                 }
-                                
+
                                 // If the new master token is not equal to the previous master
                                 // token then release the previous master token and get the
                                 // newest master token.
@@ -2202,7 +2202,7 @@ var MslControl$MslChannel;
                                                 // right token ticket, now that we have potentially
                                                 // swapped master tokens.
                                                 builderTokenTicket.tokenTicket = tokenTicket;
-                                                
+
                                                 // If there is no newest master token (it could have been
                                                 // deleted despite just being delivered to us) then try
                                                 // again to acquire renewal ownership.
@@ -2211,7 +2211,7 @@ var MslControl$MslChannel;
                                                     blockingAcquisition(masterToken, userIdToken, userId, builder, tokenTicket);
                                                     return;
                                                 }
-                                                
+
                                                 // Otherwise continue with renewal lock acquisition.
                                                 continueAcquisition(previousMasterToken, masterToken, userIdToken, userId, builder, tokenTicket);
                                             }, self);
@@ -2238,7 +2238,7 @@ var MslControl$MslChannel;
                     });
                 }, self);
             }
-                        
+
             function continueAcquisition(previousMasterToken, masterToken, userIdToken, userId, builder, tokenTicket) {
                 InterruptibleExecutor(callback, function() {
                     // The renewing request may have acquired a new user ID token.
@@ -2258,7 +2258,7 @@ var MslControl$MslChannel;
 
                     // Update the message's master token and user ID token.
                     builder.setAuthTokens(masterToken, userIdToken);
-                    
+
                     // If the new master token is still expired then try again to
                     // acquire renewal ownership.
                     var updateTime = ctx.getRemoteTime();
@@ -3188,15 +3188,15 @@ var MslControl$MslChannel;
                 try {
                     var builder = builderTokenTicket.builder;
                     var tokenTicket = builderTokenTicket.tokenTicket;
-                    
+
                     // Do nothing if we cannot send one more message.
                     if (msgCount + 1 > MslConstants$MAX_MESSAGES) {
                         // Release the master token lock.
                         this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                        
+
                         return null;
                     }
-    
+
                     // If the response must be encrypted or integrity protected but
                     // cannot then send an error requesting it. The client must re-
                     // initiate the transaction.
@@ -3218,18 +3218,18 @@ var MslControl$MslChannel;
                                 InterruptibleExecutor(callback, function() {
                                     // If we were cancelled then return null.
                                     if (cancelled(re)) return null;
-    
+
                                     throw new MslErrorResponseException("Response requires encryption or integrity protection but cannot be protected: " + securityRequired, re, null);
                                 }, self);
                             }
                         });
-                        
+
                         // Release the master token lock.
                         this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                        
+
                         return;
                     }
-    
+
                     // If the response wishes to attach a user ID token but there is no
                     // master token then send an error requesting the master token. The
                     // client must re-initiate the transaction.
@@ -3244,7 +3244,7 @@ var MslControl$MslChannel;
                                 InterruptibleExecutor(callback, function() {
                                     // If we were cancelled then return null.
                                     if (cancelled(re)) return null;
-    
+
                                     throw new MslErrorResponseException("Response wishes to attach a user ID token but there is no master token.", re, null);
                                 }, self);
                             }
@@ -3252,10 +3252,10 @@ var MslControl$MslChannel;
 
                         // Release the master token lock.
                         this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                        
+
                         return;
                     }
-    
+
                     // Otherwise simply send the response.
                     builder.setRenewable(false);
                     this._ctrl.send(this._ctx, this._msgCtx, this._output, builder, false, this._timeout, {
@@ -3263,7 +3263,7 @@ var MslControl$MslChannel;
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
                                 this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                                
+
                                 return new MslChannel(this._request, result.request);
                             }, self);
                         },
@@ -3271,7 +3271,7 @@ var MslControl$MslChannel;
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
                                 this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                                
+
                                 callback.timeout();
                             }, self);
                         },
@@ -3279,7 +3279,7 @@ var MslControl$MslChannel;
                             InterruptibleExecutor(callback, function() {
                                 // Release the master token lock.
                                 this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                                
+
                                 callback.error(e);
                             }, self);
                         }
@@ -3287,7 +3287,7 @@ var MslControl$MslChannel;
                 } catch (e) {
                     // Release the master token lock.
                     this._ctrl.releaseMasterToken(this._ctx, tokenTicket);
-                    
+
                     throw e;
                 }
             }, self);
@@ -3321,7 +3321,7 @@ var MslControl$MslChannel;
             InterruptibleExecutor(callback, function() {
                 var builder = builderTokenTicket.builder;
                 var tokenTicket = builderTokenTicket.tokenTicket;
-                
+
                 // Do nothing if we cannot send and receive two more messages.
                 //
                 // Make sure to release the master token lock.
@@ -4105,7 +4105,7 @@ var MslControl$MslChannel;
                         // response then return the original error response.
                         if (this._maxMessagesHit || (newChannel && !newChannel.input))
                             return new MslChannel(result.response, null);
-                        
+
                         // Return the new channel, which may contain an error or be
                         // null if cancelled or interrupted.
                         return newChannel;

--- a/core/src/main/javascript/tokens/ServiceToken.js
+++ b/core/src/main/javascript/tokens/ServiceToken.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2015 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -126,7 +126,7 @@ var ServiceToken$parse;
     /**
      * <p>Select the appropriate crypto context for the service token
      * represented by the provided JSON object.</p>
-     * 
+     *
      * <p>If the service token name exists as a key in the map of crypto
      * contexts, the mapped crypto context will be returned. Otherwise the
      * default crypto context mapped from the empty string key will be
@@ -153,7 +153,7 @@ var ServiceToken$parse;
         }
         if (!tokendata || tokendata.length == 0)
             throw new MslEncodingException(MslError.SERVICETOKEN_TOKENDATA_MISSING, "servicetoken " + JSON.stringify(serviceTokenJO));
-        
+
         // Extract the service token name.
         var name;
         try {
@@ -193,7 +193,7 @@ var ServiceToken$parse;
          * master token is provided, the service token is bound to the master
          * token's serial number. If a user ID token is provided, the service token
          * is bound to the user ID token's serial number.</p>
-         * 
+         *
          * <p>For encrypted tokens, the token data is encrypted using the provided
          * crypto context. For verified tokens, the token data is signed using the
          * provided crypto context.</p>
@@ -234,7 +234,7 @@ var ServiceToken$parse;
                     var plaintext;
                     if (compressionAlgo) {
                         var compressed = MslUtils$compress(compressionAlgo, data);
-                        
+
                         // Only use compression if the compressed data is smaller than the
                         // uncompressed data.
                         if (compressed.length < data.length) {
@@ -247,7 +247,7 @@ var ServiceToken$parse;
                         compressionAlgo = null;
                         plaintext = data;
                     }
-                    
+
                     // Start constructing the token data.
                     var tokenDataJO = {};
                     tokenDataJO[KEY_NAME] = name;
@@ -296,7 +296,7 @@ var ServiceToken$parse;
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
                                                     e.setEntity(masterToken);
-                                                    e.setUser(userIdToken);
+                                                    e.setUserIdTokenIdToken(userIdToken);
                                                 }
                                                 throw e;
                                             });
@@ -308,7 +308,7 @@ var ServiceToken$parse;
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException) {
                                         e.setEntity(masterToken);
-                                        e.setUser(userIdToken);
+                                        e.setUserIdToken(userIdToken);
                                     }
                                     throw e;
                                 });
@@ -348,7 +348,7 @@ var ServiceToken$parse;
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException) {
                                         e.setEntity(masterToken);
-                                        e.setUser(userIdToken);
+                                        e.setUserIdToken(userIdToken);
                                     }
                                     throw e;
                                 });
@@ -481,7 +481,7 @@ var ServiceToken$parse;
      * master token is provided, the service token is bound to the master
      * token's serial number. If a user ID token is provided, the service token
      * is bound to the user ID token's serial number.</p>
-     * 
+     *
      * <p>For encrypted tokens, the token data is encrypted using the provided
      * crypto context. For verified tokens, the token data is signed using the
      * provided crypto context.</p>
@@ -629,7 +629,7 @@ var ServiceToken$parse;
 
             // Convert encrypted to the correct type.
             encrypted = (encrypted === true);
-            
+
             // Verify compression algorithm.
             var compressionAlgo;
             if (algoName) {
@@ -663,7 +663,7 @@ var ServiceToken$parse;
                                                 var servicedata = (compressionAlgo)
                                                     ? MslUtils$uncompress(compressionAlgo, compressedData)
                                                     : compressedData;
-                                                
+
                                                 // Return the new service token.
                                                 var creationData = new CreationData(tokendata, signature, verified);
                                                 new ServiceToken(ctx, name, servicedata, (mtSerialNumber != -1) ? masterToken : null, (uitSerialNumber != -1) ? userIdToken : null, encrypted, compressionAlgo, cryptoContext, creationData, callback);
@@ -673,7 +673,7 @@ var ServiceToken$parse;
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
                                                     e.setEntity(masterToken);
-                                                    e.setUser(userIdToken);
+                                                    e.setUserIdToken(userIdToken);
                                                 }
                                                 throw e;
                                             });
@@ -702,7 +702,7 @@ var ServiceToken$parse;
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException) {
                                 e.setEntity(masterToken);
-                                e.setUser(userIdToken);
+                                e.setUserIdToken(userIdToken);
                             }
                             throw e;
                         });

--- a/core/src/main/javascript/tokens/ServiceToken.js
+++ b/core/src/main/javascript/tokens/ServiceToken.js
@@ -295,7 +295,7 @@ var ServiceToken$parse;
                                         error: function(e) {
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
-                                                    e.setEntity(masterToken);
+                                                    e.setMasterToken(masterToken);
                                                     e.setUserIdTokenIdToken(userIdToken);
                                                 }
                                                 throw e;
@@ -307,7 +307,7 @@ var ServiceToken$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException) {
-                                        e.setEntity(masterToken);
+                                        e.setMasterToken(masterToken);
                                         e.setUserIdToken(userIdToken);
                                     }
                                     throw e;
@@ -347,7 +347,7 @@ var ServiceToken$parse;
                             error: function(e) {
                                 AsyncExecutor(callback, function() {
                                     if (e instanceof MslException) {
-                                        e.setEntity(masterToken);
+                                        e.setMasterToken(masterToken);
                                         e.setUserIdToken(userIdToken);
                                     }
                                     throw e;
@@ -560,19 +560,19 @@ var ServiceToken$parse;
             var tokendataB64 = serviceTokenJO[KEY_TOKENDATA];
             var signatureB64 = serviceTokenJO[KEY_SIGNATURE];
             if (typeof tokendataB64 !== 'string' || typeof signatureB64 !== 'string')
-                throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "servicetoken " + JSON.stringify(serviceTokenJO)).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "servicetoken " + JSON.stringify(serviceTokenJO)).setMasterToken(masterToken).setUserIdToken(userIdToken);
             var tokendata, signature;
             try {
                 tokendata = base64$decode(tokendataB64);
             } catch (e) {
-                throw new MslException(MslError.SERVICETOKEN_TOKENDATA_INVALID, "servicetoken " + JSON.stringify(serviceTokenJO), e).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslException(MslError.SERVICETOKEN_TOKENDATA_INVALID, "servicetoken " + JSON.stringify(serviceTokenJO), e).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
             if (!tokendata || tokendata.length == 0)
-                throw new MslEncodingException(MslError.SERVICETOKEN_TOKENDATA_MISSING, "servicetoken " + JSON.stringify(serviceTokenJO)).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslEncodingException(MslError.SERVICETOKEN_TOKENDATA_MISSING, "servicetoken " + JSON.stringify(serviceTokenJO)).setMasterToken(masterToken).setUserIdToken(userIdToken);
             try {
                 signature = base64$decode(signatureB64);
             } catch (e) {
-                throw new MslException(MslError.SERVICETOKEN_SIGNATURE_INVALID, "servicetoken " + JSON.stringify(serviceTokenJO), e).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslException(MslError.SERVICETOKEN_SIGNATURE_INVALID, "servicetoken " + JSON.stringify(serviceTokenJO), e).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
 
             // Pull the token data.
@@ -594,7 +594,7 @@ var ServiceToken$parse;
                 ciphertextB64 = tokenDataJO[KEY_SERVICEDATA];
             } catch (e) {
                 if (e instanceof SyntaxError)
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "servicetokendata " + tokenDataJson, e).setEntity(masterToken).setEntity(userIdToken);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "servicetokendata " + tokenDataJson, e).setMasterToken(masterToken).setUserIdToken(userIdToken);
                 throw e;
             }
 
@@ -606,26 +606,26 @@ var ServiceToken$parse;
                 (algoName && typeof algoName !== 'string') ||
                 typeof ciphertextB64 !== 'string')
             {
-                throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "servicetokendata " + tokenDataJson).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "servicetokendata " + tokenDataJson).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
 
             // Verify serial number values.
             if (tokenDataJO[KEY_MASTER_TOKEN_SERIAL_NUMBER] &&
                 mtSerialNumber < 0 || mtSerialNumber > MslConstants$MAX_LONG_VALUE)
             {
-                throw new MslException(MslError.SERVICETOKEN_MASTERTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "servicetokendata " + tokenDataJson).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslException(MslError.SERVICETOKEN_MASTERTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "servicetokendata " + tokenDataJson).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
             if (tokenDataJO[KEY_USER_ID_TOKEN_SERIAL_NUMBER] &&
                 uitSerialNumber < 0 || uitSerialNumber > MslConstants$MAX_LONG_VALUE)
             {
-                throw new MslException(MslError.SERVICETOKEN_USERIDTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "servicetokendata " + tokenDataJson).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslException(MslError.SERVICETOKEN_USERIDTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "servicetokendata " + tokenDataJson).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
 
             // Verify serial numbers match.
             if (mtSerialNumber != -1 && (!masterToken || mtSerialNumber != masterToken.serialNumber))
-                throw new MslException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st mtserialnumber " + mtSerialNumber + "; mt " + masterToken).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st mtserialnumber " + mtSerialNumber + "; mt " + masterToken).setMasterToken(masterToken).setUserIdToken(userIdToken);
             if (uitSerialNumber != -1 && (!userIdToken || uitSerialNumber != userIdToken.serialNumber))
-                throw new MslException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st uitserialnumber " + uitSerialNumber + "; uit " + userIdToken).setEntity(masterToken).setEntity(userIdToken);
+                throw new MslException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st uitserialnumber " + uitSerialNumber + "; uit " + userIdToken).setMasterToken(masterToken).setUserIdToken(userIdToken);
 
             // Convert encrypted to the correct type.
             encrypted = (encrypted === true);
@@ -652,10 +652,10 @@ var ServiceToken$parse;
                                 try {
                                     ciphertext = base64$decode(ciphertextB64);
                                 } catch (e) {
-                                    throw new MslException(MslError.SERVICETOKEN_SERVICEDATA_INVALID, "servicetokendata " + tokenDataJson, e).setEntity(masterToken).setEntity(userIdToken);
+                                    throw new MslException(MslError.SERVICETOKEN_SERVICEDATA_INVALID, "servicetokendata " + tokenDataJson, e).setMasterToken(masterToken).setUserIdToken(userIdToken);
                                 }
                                 if (!ciphertext || (ciphertextB64.length != 0 && ciphertext.length == 0))
-                                    throw new MslException(MslError.SERVICETOKEN_SERVICEDATA_INVALID, "servicetokendata " + tokenDataJson).setEntity(masterToken).setEntity(userIdToken);
+                                    throw new MslException(MslError.SERVICETOKEN_SERVICEDATA_INVALID, "servicetokendata " + tokenDataJson).setMasterToken(masterToken).setUserIdToken(userIdToken);
                                 if (encrypted && ciphertext.length > 0) {
                                     cryptoContext.decrypt(ciphertext, {
                                         result: function(compressedData) {
@@ -672,7 +672,7 @@ var ServiceToken$parse;
                                         error: function(e) {
                                             AsyncExecutor(callback, function() {
                                                 if (e instanceof MslException) {
-                                                    e.setEntity(masterToken);
+                                                    e.setMasterToken(masterToken);
                                                     e.setUserIdToken(userIdToken);
                                                 }
                                                 throw e;
@@ -701,7 +701,7 @@ var ServiceToken$parse;
                     error: function(e) {
                         AsyncExecutor(callback, function() {
                             if (e instanceof MslException) {
-                                e.setEntity(masterToken);
+                                e.setMasterToken(masterToken);
                                 e.setUserIdToken(userIdToken);
                             }
                             throw e;

--- a/core/src/main/javascript/tokens/UserIdToken.js
+++ b/core/src/main/javascript/tokens/UserIdToken.js
@@ -245,7 +245,7 @@ var UserIdToken$parse;
                                     error: function(e) {
                                         AsyncExecutor(callback, function() {
                                             if (e instanceof MslException)
-                                                e.setEntity(masterToken);
+                                                e.setMasterToken(masterToken);
                                             throw e;
                                         }, self);
                                     },
@@ -255,7 +255,7 @@ var UserIdToken$parse;
                         error: function(e) {
                             AsyncExecutor(callback, function() {
                                 if (e instanceof MslException)
-                                    e.setEntity(masterToken);
+                                    e.setMasterToken(masterToken);
                                 throw e;
                             }, self);
                         },
@@ -449,19 +449,19 @@ var UserIdToken$parse;
             var tokendataB64 = userIdTokenJO[KEY_TOKENDATA];
             var signatureB64 = userIdTokenJO[KEY_SIGNATURE];
             if (typeof tokendataB64 !== 'string' || typeof signatureB64 !== 'string')
-                throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "useridtoken " + JSON.stringify(userIdTokenJO)).setEntity(masterToken);
+                throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "useridtoken " + JSON.stringify(userIdTokenJO)).setMasterToken(masterToken);
             var tokendata, signature;
             try {
                 tokendata = base64$decode(tokendataB64);
             } catch (e) {
-                throw new MslException(MslError.USERIDTOKEN_TOKENDATA_INVALID, "useridtoken " + JSON.stringify(userIdTokenJO), e).setEntity(masterToken);
+                throw new MslException(MslError.USERIDTOKEN_TOKENDATA_INVALID, "useridtoken " + JSON.stringify(userIdTokenJO), e).setMasterToken(masterToken);
             }
             if (!tokendata || tokendata.length == 0)
-                throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_MISSING, "useridtoken " + JSON.stringify(userIdTokenJO)).setEntity(masterToken);
+                throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_MISSING, "useridtoken " + JSON.stringify(userIdTokenJO)).setMasterToken(masterToken);
             try {
                 signature = base64$decode(signatureB64);
             } catch (e) {
-                throw new MslException(MslError.USERIDTOKEN_TOKENDATA_INVALID, "useridtoken " + JSON.stringify(userIdTokenJO), e).setEntity(masterToken);
+                throw new MslException(MslError.USERIDTOKEN_TOKENDATA_INVALID, "useridtoken " + JSON.stringify(userIdTokenJO), e).setMasterToken(masterToken);
             }
             cryptoContext.verify(tokendata, signature, {
                 result: function(verified) {
@@ -478,7 +478,7 @@ var UserIdToken$parse;
                             ciphertextB64 = tokenDataJO[KEY_USERDATA];
                         } catch (e) {
                             if (e instanceof SyntaxError)
-                                throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_PARSE_ERROR, "usertokendata " + tokenDataJson, e).setEntity(masterToken);
+                                throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_PARSE_ERROR, "usertokendata " + tokenDataJson, e).setMasterToken(masterToken);
                             throw e;
                         }
 
@@ -489,16 +489,16 @@ var UserIdToken$parse;
                             typeof serialNumber !== 'number' || serialNumber != serialNumber ||
                             typeof ciphertextB64 !== 'string')
                         {
-                            throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_PARSE_ERROR, "usertokendata " + tokenDataJson).setEntity(masterToken);
+                            throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_PARSE_ERROR, "usertokendata " + tokenDataJson).setMasterToken(masterToken);
                         }
                         if (expirationSeconds < renewalWindowSeconds)
-                            throw new MslException(MslError.USERIDTOKEN_EXPIRES_BEFORE_RENEWAL, "mastertokendata " + tokenDataJson).setEntity(masterToken);
+                            throw new MslException(MslError.USERIDTOKEN_EXPIRES_BEFORE_RENEWAL, "mastertokendata " + tokenDataJson).setMasterToken(masterToken);
 
                         // Verify serial number values.
                         if (mtSerialNumber < 0 || mtSerialNumber > MslConstants$MAX_LONG_VALUE)
-                            throw new MslException(MslError.USERIDTOKEN_MASTERTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "usertokendata " + tokenDataJson).setEntity(masterToken);
+                            throw new MslException(MslError.USERIDTOKEN_MASTERTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "usertokendata " + tokenDataJson).setMasterToken(masterToken);
                         if (serialNumber < 0 || serialNumber > MslConstants$MAX_LONG_VALUE)
-                            throw new MslException(MslError.USERIDTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "usertokendata " + tokenDataJson).setEntity(masterToken);
+                            throw new MslException(MslError.USERIDTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "usertokendata " + tokenDataJson).setMasterToken(masterToken);
 
                         // Convert dates.
                         var renewalWindow = new Date(renewalWindowSeconds * MILLISECONDS_PER_SECOND);
@@ -506,17 +506,17 @@ var UserIdToken$parse;
 
                         // Verify serial numbers.
                         if (!masterToken || mtSerialNumber != masterToken.serialNumber)
-                            throw new MslException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit mtserialnumber " + mtSerialNumber + "; mt " + JSON.stringify(masterToken)).setEntity(masterToken);
+                            throw new MslException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit mtserialnumber " + mtSerialNumber + "; mt " + JSON.stringify(masterToken)).setMasterToken(masterToken);
 
                         // Construct user data.
                         var ciphertext;
                         try {
                             ciphertext = base64$decode(ciphertextB64);
                         } catch (e) {
-                            throw new MslException(MslError.USERIDTOKEN_USERDATA_INVALID, ciphertextB64, e).setEntity(masterToken);
+                            throw new MslException(MslError.USERIDTOKEN_USERDATA_INVALID, ciphertextB64, e).setMasterToken(masterToken);
                         }
                         if (!ciphertext || ciphertext.length == 0)
-                            throw new MslException(MslError.USERIDTOKEN_USERDATA_MISSING, ciphertextB64).setEntity(masterToken);
+                            throw new MslException(MslError.USERIDTOKEN_USERDATA_MISSING, ciphertextB64).setMasterToken(masterToken);
                         if (verified) {
                             cryptoContext.decrypt(ciphertext, {
                                 result: function(userdata) {
@@ -530,7 +530,7 @@ var UserIdToken$parse;
                                             identity = userdataJO[KEY_IDENTITY];
                                         } catch (e) {
                                             if (e instanceof SyntaxError)
-                                                throw new MslEncodingException(MslError.USERIDTOKEN_USERDATA_PARSE_ERROR, "userdata " + userdataJson).setEntity(masterToken);
+                                                throw new MslEncodingException(MslError.USERIDTOKEN_USERDATA_PARSE_ERROR, "userdata " + userdataJson).setMasterToken(masterToken);
                                             throw e;
                                         }
 
@@ -538,10 +538,10 @@ var UserIdToken$parse;
                                         if (issuerData && typeof issuerData !== 'object' ||
                                             typeof identity !== 'string')
                                         {
-                                            throw new MslEncodingException(MslError.USERIDTOKEN_USERDATA_PARSE_ERROR, "userdata " + userdataJson).setEntity(masterToken);
+                                            throw new MslEncodingException(MslError.USERIDTOKEN_USERDATA_PARSE_ERROR, "userdata " + userdataJson).setMasterToken(masterToken);
                                         }
                                         if (!identity || identity.length == 0)
-                                            throw new MslException(MslError.USERIDTOKEN_IDENTITY_INVALID, "userdata " + userdataJson).setEntity(masterToken);
+                                            throw new MslException(MslError.USERIDTOKEN_IDENTITY_INVALID, "userdata " + userdataJson).setMasterToken(masterToken);
                                         
                                         // Reconstruct the user.
                                         var factory = ctx.getTokenFactory();
@@ -559,7 +559,7 @@ var UserIdToken$parse;
                                             error: function(e) {
                                                 AsyncExecutor(callback, function() {
                                                     if (e instanceof MslException)
-                                                        e.setEntity(masterToken);
+                                                        e.setMasterToken(masterToken);
                                                     throw e;
                                                 });
                                             },
@@ -569,7 +569,7 @@ var UserIdToken$parse;
                                 error: function(e) {
                                     AsyncExecutor(callback, function() {
                                         if (e instanceof MslException)
-                                            e.setEntity(masterToken);
+                                            e.setMasterToken(masterToken);
                                         throw e;
                                     });
                                 },
@@ -587,7 +587,7 @@ var UserIdToken$parse;
                 error: function(e) {
                     AsyncExecutor(callback, function() {
                         if (e instanceof MslException)
-                            e.setEntity(masterToken);
+                            e.setMasterToken(masterToken);
                         throw e;
                     });
                 },

--- a/core/src/main/javascript/userauth/EmailPasswordAuthenticationFactory.js
+++ b/core/src/main/javascript/userauth/EmailPasswordAuthenticationFactory.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2015 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,13 +22,13 @@
 var EmailPasswordAuthenticationFactory = UserAuthenticationFactory.extend({
     /**
      * Construct a new email/password-based user authentication factory.
-     * 
+     *
      * @param {EmailPasswordStore} store email/password store.
      * @param {AuthenticationUtils} authutils authentication utilities.
      */
     init: function init(store, authutils) {
         init.base.call(this, UserAuthenticationScheme.EMAIL_PASSWORD);
-        
+
         // The properties.
         var props = {
             _store: { value: store, writable: false, enumerable: false, configurable: false },
@@ -53,7 +53,7 @@ var EmailPasswordAuthenticationFactory = UserAuthenticationFactory.extend({
 
         // Verify the scheme is permitted.
         if(!this._authutils.isSchemePermitted(identity, this.scheme))
-            throw new MslUserAuthException(MslError.USERAUTH_ENTITY_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUser(data);
+            throw new MslUserAuthException(MslError.USERAUTH_ENTITY_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUserAuthenticationData(data);
 
         // Extract and check email and password values.
         var email = epad.email;
@@ -61,25 +61,25 @@ var EmailPasswordAuthenticationFactory = UserAuthenticationFactory.extend({
         if (!email || email.trim().length == 0 ||
             !password || password.trim().length == 0)
         {
-            throw new MslUserAuthException(MslError.EMAILPASSWORD_BLANK).setUser(epad);
-        }
-        
+            throw new MslUserAuthException(MslError.EMAILPASSWORD_BLANK).setUserAuthenticationData(epad); 
+       }
+
         // Authenticate the user.
         var user = this._store.isUser(email, password);
         if (user == null)
-            throw new MslUserAuthException(MslError.EMAILPASSWORD_INCORRECT).setUser(epad);
-        
+            throw new MslUserAuthException(MslError.EMAILPASSWORD_INCORRECT).setUserAuthenticationData(epad);
+
         // Verify the scheme is still permitted.
         if (!this._authutils.isSchemePermitted(identity, user, this.scheme))
-            throw new MslUserAuthException(MslError.USERAUTH_ENTITYUSER_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUser(data);
-        
+            throw new MslUserAuthException(MslError.USERAUTH_ENTITYUSER_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUserAuthenticationData(data);
+
         // If a user ID token was provided validate the user identities.
         if (userIdToken) {
             var uitUser = userIdToken.user;
             if (!user.equals(uitUser))
-                throw new MslUserAuthException(MslError.USERIDTOKEN_USERAUTH_DATA_MISMATCH, "uad user " + user + "; uit user " + uitUser).setUser(epad);
+                throw new MslUserAuthException(MslError.USERIDTOKEN_USERAUTH_DATA_MISMATCH, "uad user " + user + "; uit user " + uitUser).setUserAuthenticationData(epad);
         }
-        
+
         // Return the user.
         return user;
     },

--- a/core/src/main/javascript/userauth/UserIdTokenAuthenticationFactory.js
+++ b/core/src/main/javascript/userauth/UserIdTokenAuthenticationFactory.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,18 +16,18 @@
 
 /**
  * User ID token-based user authentication factory.
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 var UserIdTokenAuthenticationFactory = UserAuthenticationFactory.extend({
     /**
      * Construct a new user ID token-based user authentication factory.
-     * 
+     *
      * @param {AuthenticationUtils} authutils authentication utilities.
      */
     init: function init(authutils) {
         init.base.call(this, UserAuthenticationScheme.USER_ID_TOKEN);
-        
+
         // The properties.
         var props = {
             _authutils: { value: authutils, writable: false, enumerable: false, configurable: false },
@@ -46,36 +46,36 @@ var UserIdTokenAuthenticationFactory = UserAuthenticationFactory.extend({
         if (!(data instanceof UserIdTokenAuthenticationData))
             throw new MslInternalException("Incorrect authentication data type " + data + ".");
         var uita = data;
-     
+
         // Verify the scheme is permitted.
         if(!this._authutils.isSchemePermitted(identity, this.scheme))
-            throw new MslUserAuthException(MslError.USERAUTH_ENTITY_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUser(data);
-        
+            throw new MslUserAuthException(MslError.USERAUTH_ENTITY_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUserIdToken(data);
+
         // Extract and check master token.
         var uitaMasterToken = uita.masterToken;
         var uitaIdentity = uitaMasterToken.identity;
         if (!uitaIdentity)
-            throw new MslUserAuthException(MslError.USERAUTH_MASTERTOKEN_NOT_DECRYPTED).setUser(uita);
+            throw new MslUserAuthException(MslError.USERAUTH_MASTERTOKEN_NOT_DECRYPTED).setUserIdToken(uita);
         if (identity != uitaIdentity)
-            throw new MslUserAuthException(MslError.USERAUTH_ENTITY_MISMATCH, "entity identity " + identity + "; uad identity " + uitaIdentity).setUser(uita);
-        
+            throw new MslUserAuthException(MslError.USERAUTH_ENTITY_MISMATCH, "entity identity " + identity + "; uad identity " + uitaIdentity).setUserIdToken(uita);
+
         // Authenticate the user.
         var uitaUserIdToken = uita.userIdToken;
         var user = uitaUserIdToken.user;
         if (!user)
-            throw new MslUserAuthException(MslError.USERAUTH_USERIDTOKEN_NOT_DECRYPTED).setUser(uita);
-        
+            throw new MslUserAuthException(MslError.USERAUTH_USERIDTOKEN_NOT_DECRYPTED).setUserIdToken(uita);
+
         // Verify the scheme is still permitted.
         if (!this._authutils.isSchemePermitted(identity, user, this.scheme))
-            throw new MslUserAuthException(MslError.USERAUTH_ENTITYUSER_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUser(data);
-        
+            throw new MslUserAuthException(MslError.USERAUTH_ENTITYUSER_INCORRECT_DATA, "Authentication scheme " + this.scheme + " not permitted for entity " + identity + ".").setUserIdToken(data);
+
         // If a user ID token was provided validate the user identities.
         if (userIdToken) {
             var uitUser = userIdToken.user;
             if (!user.equals(uitUser))
                 throw new MslUserAuthException(MslError.USERIDTOKEN_USERAUTH_DATA_MISMATCH, "uad user " + user + "; uit user " + uitUser);
         }
-        
+
         // Return the user.
         return user;
     },

--- a/examples/simple/src/main/javascript/client/SimpleClient.html
+++ b/examples/simple/src/main/javascript/client/SimpleClient.html
@@ -87,6 +87,7 @@
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/keyx/KeyExchangeFactory.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/msg/ClarinetParser.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/msg/HeaderKeys.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/msg/Header.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/msg/ErrorHeader.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/msg/MessageCapabilities.js"></script>

--- a/tests/src/main/javascript/entityauth/MockPresharedAuthenticationFactory.js
+++ b/tests/src/main/javascript/entityauth/MockPresharedAuthenticationFactory.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -53,7 +53,7 @@ var MockPresharedAuthenticationFactory$create;
      * @type {Uint8Array}
      */
     var PSK_KPH2 = "WhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=";
-    
+
     /**
      * Kpe/Kph/Kpw #1.
      * @type {CipherKey}
@@ -68,25 +68,25 @@ var MockPresharedAuthenticationFactory$create;
 
     /**
      * Test pre-shared keys authentication factory.
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
     MockPresharedAuthenticationFactory = PresharedAuthenticationFactory.extend({
 	    /**
 	     * Create a new test pre-shared keys authentication factory.
-	     * 
+	     *
          * @param {result: function(MockPresharedAuthenticationFactory), error: function(Error)}
          *        callback the callback functions that will receive the factory
          *        or any thrown exceptions.
 	     */
 		init: function init(callback) {
             init.base.call(this);
-            
+
             var self = this;
             AsyncExecutor(callback, function() {
                 // We have to block until keys exist.
                 if (KPE && KPH && KPW && KPE2 && KPH2 && KPW2) return this;
-                
+
                 function retry() {
                     keysDefined.wait(-1, {
                         result: function() {
@@ -106,14 +106,14 @@ var MockPresharedAuthenticationFactory$create;
                 retry();
             }, this);
 		},
-		
+
 		/** @inheritDoc */
 		getCryptoContext: function getCryptoContext(ctx, authdata) {
 	        // Make sure we have the right kind of entity authentication data.
 	        if (!(authdata instanceof PresharedAuthenticationData))
 	            throw new MslInternalException("Incorrect authentication data type " + JSON.stringify(authdata) + ".");
 	        var pad = authdata;
-	        
+
 	        // Try to return the test crypto context.
 	        var identity = pad.getIdentity();
 	        if (PSK_ESN == identity)
@@ -122,13 +122,13 @@ var MockPresharedAuthenticationFactory$create;
 	            return new SymmetricCryptoContext(ctx, identity, KPE2, KPH2, KPW2);
 
 	        // Entity not found.
-	        throw new MslEntityAuthException(MslError.ENTITY_NOT_FOUND, "psk " + identity).setEntity(pad);
+	        throw new MslEntityAuthException(MslError.ENTITY_NOT_FOUND, "psk " + identity).setEntityAuthenticationData(pad);
 	    },
     });
-    
+
     /**
      * Create a new test pre-shared keys authentication factory.
-     * 
+     *
      * @param {result: function(MockPresharedAuthenticationFactory), error: function(Error)}
      *        callback the callback functions that will receive the factory
      *        or any thrown exceptions.
@@ -136,7 +136,7 @@ var MockPresharedAuthenticationFactory$create;
     MockPresharedAuthenticationFactory$create = function MockPresharedAuthenticationFactory$create(callback) {
         new MockPresharedAuthenticationFactory(callback);
     };
-    
+
     // Expose public static properties.
     MockPresharedAuthenticationFactory.PSK_ESN = PSK_ESN;
     CipherKey$import(PSK_KPE, WebCryptoAlgorithm.AES_CBC, WebCryptoUsage.ENCRYPT_DECRYPT, {

--- a/tests/src/test/javascript/MslExceptionTest.js
+++ b/tests/src/test/javascript/MslExceptionTest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,10 +20,10 @@ describe("MslException", function() {
     function getUserAuthenticationData() {
         return new EmailPasswordAuthenticationData("email", "password");
     }
-    
+
     /** MSL context. */
     var ctx;
-    
+
     beforeEach(function() {
         if (!ctx) {
             runs(function() {
@@ -35,7 +35,7 @@ describe("MslException", function() {
             waitsFor(function() { return ctx; }, "static initialization", 300);
         }
     });
-    
+
 	it("error as expected", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR);
 		expect(e.error).toBe(MslError.JSON_PARSE_ERROR);
@@ -43,7 +43,7 @@ describe("MslException", function() {
 		expect(e.cause).toBeUndefined();
 		expect(e.messageId).toBeUndefined();
 	});
-	
+
 	it("error details as expected", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR, "details");
 		expect(e.error).toBe(MslError.JSON_PARSE_ERROR);
@@ -51,7 +51,7 @@ describe("MslException", function() {
 		expect(e.cause).toBeUndefined();
 		expect(e.messageId).toBeUndefined();
 	});
-	
+
 	it("error details and cause as expected", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR, "details", new Error("cause"));
 		expect(e.error).toBe(MslError.JSON_PARSE_ERROR);
@@ -59,31 +59,31 @@ describe("MslException", function() {
 		expect(e.cause).not.toBeNull();
 		expect(e.cause.message).toBe("cause");
 	});
-	
+
 	it("message ID can be set", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR);
 		expect(e.messageId).toBeUndefined();
 		e.messageId = 1;
 		expect(e.messageId).toEqual(1);
 	});
-	
+
 	it("message ID can be set via setMessageId()", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR);
 		expect(e.messageId).toBeUndefined();
 		e.setMessageId(1);
 		expect(e.messageId).toEqual(1);
 	});
-	
+
 	it("name is correct", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR);
 		expect(e.name).toEqual("MslException");
 	});
-	
+
 	it("toString() is correct", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR, "details", new Error("cause"));
 		expect(e.toString()).toEqual('MslException: ' + MslError.JSON_PARSE_ERROR.message + ' [details]');
 	});
-	
+
 	it("exception properties are not writable", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR, "details", new Error("cause"));
 		e.message = "x";
@@ -95,27 +95,27 @@ describe("MslException", function() {
 		expect(e.cause).not.toBeNull();
 		expect(e.cause.message).toBe("cause");
 	});
-	
+
 	it("instanceof MslException", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR);
 		expect(e instanceof MslException).toBeTruthy();
 	});
-	
+
 	it("instanceof Error", function() {
 		var e = new MslException(MslError.JSON_PARSE_ERROR);
-		expect(e instanceof Error).toBeTruthy(); 
+		expect(e instanceof Error).toBeTruthy();
 	});
-	
+
 	it("Error not instanceof MslException", function() {
 		var e = new Error("msg");
-		expect(e instanceof MslException).toBeFalsy();	
+		expect(e instanceof MslException).toBeFalsy();
 	});
-    
+
     it("set master token", function() {
         var e = new MslException(MslError.JSON_PARSE_ERROR);
         expect(e.masterToken).toBeNull();
         expect(e.entityAuthenticationData).toBeNull();
-        
+
         var masterToken;
         runs(function() {
             MslTestUtils.getMasterToken(ctx, 1, 1, {
@@ -124,7 +124,7 @@ describe("MslException", function() {
             });
         });
         waitsFor(function() { return masterToken; }, "masterToken", 100);
-        
+
         var entityAuthData;
         runs(function() {
             ctx.getEntityAuthenticationData(null, {
@@ -133,7 +133,7 @@ describe("MslException", function() {
             });
         });
         waitsFor(function() { return entityAuthData; }, "entityAuthData", 100);
-        
+
         runs(function() {
             e.setEntity(masterToken);
             e.setEntity(entityAuthData);
@@ -141,12 +141,12 @@ describe("MslException", function() {
             expect(e.entityAuthenticationData).toBeNull();
         });
     });
-    
+
     it("set entity authentication data", function() {
         var e = new MslException(MslError.JSON_PARSE_ERROR);
         expect(e.masterToken).toBeNull();
         expect(e.entityAuthenticationData).toBeNull();
-        
+
         var entityAuthData;
         runs(function() {
             ctx.getEntityAuthenticationData(null, {
@@ -155,19 +155,19 @@ describe("MslException", function() {
             });
         });
         waitsFor(function() { return entityAuthData; }, "entityAuthData", 100);
-        
+
         runs(function() {
             e.setEntity(entityAuthData);
             expect(e.masterToken).toBeNull();
             expect(e.entityAuthenticationData).toEqual(entityAuthData);
         });
     });
-    
+
     it("set user ID token", function() {
         var e = new MslException(MslError.JSON_PARSE_ERROR);
         expect(e.userIdToken).toBeNull();
         expect(e.userAuthenticationData).toBeNull();
-        
+
         var masterToken;
         runs(function() {
             MslTestUtils.getMasterToken(ctx, 1, 1, {
@@ -176,7 +176,7 @@ describe("MslException", function() {
             });
         });
         waitsFor(function() { return masterToken; }, "masterToken", 100);
-        
+
         var userIdToken;
         runs(function() {
             MslTestUtils.getUserIdToken(ctx, masterToken, 1, MockEmailPasswordAuthenticationFactory.USER, {
@@ -185,33 +185,35 @@ describe("MslException", function() {
             });
         });
         waitsFor(function() { return userIdToken; }, "userIdToken", 100);
-        
+
         runs(function() {
             var userAuthData = getUserAuthenticationData();
-            e.setUser(userIdToken);
-            e.setUser(userAuthData);
+            e.setUserIdToken(userIdToken);
+            e.setUserAuthenticationData(userAuthData);
             expect(e.userIdToken).toEqual(userIdToken);
-            expect(e.userAuthenticationData).toBeNull();
+            // XXX: this 'expect' should fail since the userIdToken
+            //      and the userAuthenticationData are set separately
+            // expect(e.userAuthenticationData).toBeNull();
         });
     });
-    
+
     it("set user authentication data", function() {
         var e = new MslException(MslError.JSON_PARSE_ERROR);
         expect(e.userIdToken).toBeNull();
         expect(e.userAuthenticationData).toBeNull();
         var userAuthData = getUserAuthenticationData();
-        e.setUser(userAuthData);
+        e.setUserAuthenticationData(userAuthData);
         expect(e.userIdToken).toBeNull();
         expect(e.userAuthenticationData).toEqual(userAuthData);
     });
-	
+
     it("set message ID", function() {
     	var e = new MslException(MslError.JSON_PARSE_ERROR);
         expect(e.messageId).toBeUndefined();
         e.messageId = 1;
         expect(e.messageId).toEqual(1);
     });
-    
+
     it("negative message ID", function() {
     	var f = function() {
     		var e = new MslException(MslError.JSON_PARSE_ERROR);

--- a/tests/src/test/javascript/MslExceptionTest.js
+++ b/tests/src/test/javascript/MslExceptionTest.js
@@ -135,10 +135,12 @@ describe("MslException", function() {
         waitsFor(function() { return entityAuthData; }, "entityAuthData", 100);
 
         runs(function() {
-            e.setEntity(masterToken);
-            e.setEntity(entityAuthData);
+            e.setMasterToken(masterToken);
+            e.setEntityAuthenticationData(entityAuthData);
             expect(e.masterToken).toEqual(masterToken);
-            expect(e.entityAuthenticationData).toBeNull();
+            // XXX: this 'expect' should fail since the master token
+            //      and the entity auth data are set separately
+            // expect(e.entityAuthenticationData).toBeNull();
         });
     });
 
@@ -157,7 +159,7 @@ describe("MslException", function() {
         waitsFor(function() { return entityAuthData; }, "entityAuthData", 100);
 
         runs(function() {
-            e.setEntity(entityAuthData);
+            e.setEntityAuthenticationData(entityAuthData);
             expect(e.masterToken).toBeNull();
             expect(e.entityAuthenticationData).toEqual(entityAuthData);
         });

--- a/tests/src/test/javascript/msltests.html
+++ b/tests/src/test/javascript/msltests.html
@@ -117,6 +117,7 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/keyx/JsonWebKeyLadderExchange.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/keyx/SymmetricWrappedExchange.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/msg/ClarinetParser.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/msg/HeaderKeys.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/msg/Header.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/msg/ErrorHeader.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/msg/MessageCapabilities.js"></script>


### PR DESCRIPTION
This removes the circular dependencies in msljs that are currently causing problems. Specifically:

1) I've created HeaderKeys.js which stores the key values that are used in multiple files. I've added the reference to HeaderKeys.js in the simple client example (SimpleClient.html).

2) I've split out setUser and setEntity into 4 methods in MslException: setUserIdToken, setUserAuthenticationData, setMasterToken, and setEntityAuthenticationData. I've fixed all old references to those methods in the tests.