### PR TITLE
Clarify MslControl Future exceptions documentation.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -3493,9 +3493,9 @@ public class MslControl {
      * automatically sent (for example in response to a handshake request) or
      * if the operation was cancelled or interrupted. The returned message may
      * be an error message if the maximum number of messages is hit without
-     * successfully receiving the final message. It may throw a
-     * {@code MslException}, {@code MslErrorResponseException}, or
-     * {@code IOException}.</p>
+     * successfully receiving the final message. The {@code Future} may throw
+     * an {@code ExecutionException} whose cause is a {@code MslException},
+     * {@code MslErrorResponseException}, or {@code IOException}.</p>
      * 
      * <p>The remote entity input and output streams will not be closed in case
      * the caller wishes to reuse them.</p>
@@ -3547,8 +3547,9 @@ public class MslControl {
      * entity's next message can be received by another call to
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
      * 
-     * <p>It may throw a {@code MslException},
-     * {@code MslErrorResponseException}, or {@code IOException}.</p>
+     * <p>The {@code Future} may throw an {@code ExecutionException} whose
+     * cause is a {@code MslException}, {@code MslErrorResponseException}, or
+     * {@code IOException}.</p>
      * 
      * <p>The remote entity input and output streams will not be closed in case
      * the caller wishes to reuse them.</p>
@@ -3582,7 +3583,8 @@ public class MslControl {
      * {@link #request(MslContext, MessageContext, URL, int)}.</p>
      * 
      * <p>The returned {@code Future} will return true on success or false if
-     * cancelled or interrupted. It may throw a {@code MslException} or
+     * cancelled or interrupted. The {@code Future} may throw an
+     * {@code ExecutionException} whose cause is a {@code MslException} or
      * {@code IOException}.</p>
      * 
      * <p>The remote entity input and output streams will not be closed in case
@@ -3624,7 +3626,8 @@ public class MslControl {
      * <p>The returned {@code Future} will return {@code null} if cancelled or
      * interrupted. The returned message may be an error message if the maximum
      * number of messages is hit without successfully sending the request and
-     * receiving the response. It may throw a {@code MslException} or
+     * receiving the response. The {@code Future} may throw an
+     * {@code ExecutionException} whose cause is a {@code MslException} or
      * {@code IOException}.</p>
      * 
      * <p>The caller must close the returned message input stream and message
@@ -3666,7 +3669,8 @@ public class MslControl {
      * <p>The returned {@code Future} will return {@code null} if cancelled or
      * interrupted. The returned message may be an error message if the maximum
      * number of messages is hit without successfully sending the request and
-     * receiving the response. It may throw a {@code MslException} or
+     * receiving the response. The {@code Future} may throw an
+     * {@code ExecutionException} whose cause is a {@code MslException} or
      * {@code IOException}.</p>
      * 
      * <p>The caller must close the returned message input stream and message

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -2467,9 +2467,9 @@ var MslControl$MslChannel;
          * automatically sent (for example in response to a handshake request) or
          * if the operation was cancelled or interrupted. The returned message may
          * be an error message if the maximum number of messages is hit without
-         * successfully receiving the final message. It may throw a
-         * {@code MslException}, {@code MslErrorResponseException}, or
-         * {@code IOException}.</p>
+         * successfully receiving the final message. The {@code Future} may throw
+         * an {@code ExecutionException} whose cause is a {@code MslException},
+         * {@code MslErrorResponseException}, or {@code IOException}.</p>
          *
          * <p>The remote entity input and output streams will not be closed in case
          * the caller wishes to reuse them.</p>
@@ -2529,9 +2529,10 @@ var MslControl$MslChannel;
          * messages is hit without sending the message. In these cases the remote
          * entity's next message can be received by another call to
          * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
-         *
-         * <p>It may throw a {@code MslException},
-         * {@code MslErrorResponseException}, or {@code IOException}.</p>
+         * 
+         * <p>The {@code Future} may throw an {@code ExecutionException} whose
+         * cause is a {@code MslException}, {@code MslErrorResponseException}, or
+         * {@code IOException}.</p>
          *
          * <p>The remote entity input and output streams will not be closed in case
          * the caller wishes to reuse them.</p>
@@ -2569,7 +2570,8 @@ var MslControl$MslChannel;
          * {@link #request(MslContext, MessageContext, URL, int)}.</p>
          *
          * <p>The returned {@code Future} will return true on success or false if
-         * cancelled or interrupted. It may throw a {@code MslException} or
+         * cancelled or interrupted. The {@code Future} may throw an
+         * {@code ExecutionException} whose cause is a {@code MslException} or
          * {@code IOException}.</p>
          *
          * <p>The remote entity input and output streams will not be closed in case
@@ -2668,7 +2670,8 @@ var MslControl$MslChannel;
          * <p>The returned {@code Future} will return {@code null} if cancelled or
          * interrupted. The returned message may be an error message if the maximum
          * number of messages is hit without successfully sending the request and
-         * receiving the response. It may throw a {@code MslException} or
+         * receiving the response. The {@code Future} may throw an
+         * {@code ExecutionException} whose cause is a {@code MslException} or
          * {@code IOException}.</p>
          */
         request: function request(ctx, msgCtx /* variable arguments */) {


### PR DESCRIPTION
Addresses #89: Correct documentation to indicate the Future's thrown exceptions will be carried inside an ExecutionException.