### PR TITLE
Create Java Base64 abstraction.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,6 +26,7 @@ task javadoc_public(type: Javadoc) {
     ]
     source = sourceSets.main.allJava
     includes = [
+        "**/Base64.java",
         "**/EntityAuthenticationData.java",
         "**/EntityAuthenticationFactory.java",
         "**/EntityAuthenticationScheme.java",

--- a/core/src/main/java/com/netflix/msl/crypto/MslCiphertextEnvelope.java
+++ b/core/src/main/java/com/netflix/msl/crypto/MslCiphertextEnvelope.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.msl.crypto;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -26,6 +24,7 @@ import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.MslInternalException;
+import com.netflix.msl.util.Base64;
 
 /**
  * MSL ciphertext envelopes contain all of the information necessary for
@@ -200,12 +199,12 @@ public class MslCiphertextEnvelope implements JSONString {
                     this.keyId = jsonObj.getString(KEY_KEY_ID);
                     this.cipherSpec = null;
                     try {
-                        this.iv = (jsonObj.has(KEY_IV)) ? DatatypeConverter.parseBase64Binary(jsonObj.getString(KEY_IV)) : null;
+                        this.iv = (jsonObj.has(KEY_IV)) ? Base64.decode(jsonObj.getString(KEY_IV)) : null;
                     } catch (final IllegalArgumentException e) {
                         throw new MslCryptoException(MslError.INVALID_IV, "ciphertext envelope " + jsonObj.toString(), e);
                     }
                     try {
-                        this.ciphertext = DatatypeConverter.parseBase64Binary(jsonObj.getString(KEY_CIPHERTEXT));
+                        this.ciphertext = Base64.decode(jsonObj.getString(KEY_CIPHERTEXT));
                     } catch (final IllegalArgumentException e) {
                         throw new MslCryptoException(MslError.INVALID_CIPHERTEXT, "ciphertext envelope " + jsonObj.toString(), e);
                     }
@@ -223,12 +222,12 @@ public class MslCiphertextEnvelope implements JSONString {
                     this.keyId = null;
                     this.cipherSpec = CipherSpec.fromString(jsonObj.getString(KEY_CIPHERSPEC));
                     try {
-                        this.iv = (jsonObj.has(KEY_IV)) ? DatatypeConverter.parseBase64Binary(jsonObj.getString(KEY_IV)) : null;
+                        this.iv = (jsonObj.has(KEY_IV)) ? Base64.decode(jsonObj.getString(KEY_IV)) : null;
                     } catch (final IllegalArgumentException e) {
                         throw new MslCryptoException(MslError.INVALID_IV, "ciphertext envelope " + jsonObj.toString(), e);
                     }
                     try {
-                        this.ciphertext = DatatypeConverter.parseBase64Binary(jsonObj.getString(KEY_CIPHERTEXT));
+                        this.ciphertext = Base64.decode(jsonObj.getString(KEY_CIPHERTEXT));
                     } catch (final IllegalArgumentException e) {
                         throw new MslCryptoException(MslError.INVALID_CIPHERTEXT, "ciphertext envelope " + jsonObj.toString(), e);
                     }
@@ -292,15 +291,15 @@ public class MslCiphertextEnvelope implements JSONString {
             switch (version) {
                 case V1:
                     jsonObj.put(KEY_KEY_ID, keyId);
-                    if (iv != null) jsonObj.put(KEY_IV, DatatypeConverter.printBase64Binary(iv));
-                    jsonObj.put(KEY_CIPHERTEXT, DatatypeConverter.printBase64Binary(ciphertext));
+                    if (iv != null) jsonObj.put(KEY_IV, Base64.encode(iv));
+                    jsonObj.put(KEY_CIPHERTEXT, Base64.encode(ciphertext));
                     jsonObj.put(KEY_SHA256, "AA==");
                     break;
                 case V2:
                     jsonObj.put(KEY_VERSION, version.intValue());
                     jsonObj.put(KEY_CIPHERSPEC, cipherSpec.toString());
-                    if (iv != null) jsonObj.put(KEY_IV, DatatypeConverter.printBase64Binary(iv));
-                    jsonObj.put(KEY_CIPHERTEXT, DatatypeConverter.printBase64Binary(ciphertext));
+                    if (iv != null) jsonObj.put(KEY_IV, Base64.encode(iv));
+                    jsonObj.put(KEY_CIPHERTEXT, Base64.encode(ciphertext));
                     break;
                 default:
                     throw new MslInternalException("Ciphertext envelope version " + version + " encoding unsupported.");

--- a/core/src/main/java/com/netflix/msl/crypto/MslSignatureEnvelope.java
+++ b/core/src/main/java/com/netflix/msl/crypto/MslSignatureEnvelope.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.msl.crypto;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -26,6 +24,7 @@ import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.MslInternalException;
+import com.netflix.msl.util.Base64;
 
 /**
  * <p>MSL signature envelopes contain all of the information necessary for
@@ -151,9 +150,9 @@ public class MslSignatureEnvelope {
                     try {
                         final Version v = Version.valueOf(envelopeJo.getInt(KEY_VERSION));
                         if (!Version.V2.equals(v))
-                            throw new MslCryptoException(MslError.UNSUPPORTED_SIGNATURE_ENVELOPE, "signature envelope " + DatatypeConverter.printBase64Binary(envelope));
+                            throw new MslCryptoException(MslError.UNSUPPORTED_SIGNATURE_ENVELOPE, "signature envelope " + Base64.encode(envelope));
                     } catch (final IllegalArgumentException e) {
-                        throw new MslCryptoException(MslError.UNIDENTIFIED_SIGNATURE_ENVELOPE, "signature envelope " + DatatypeConverter.printBase64Binary(envelope), e);
+                        throw new MslCryptoException(MslError.UNIDENTIFIED_SIGNATURE_ENVELOPE, "signature envelope " + Base64.encode(envelope), e);
                     }
                     
                     // Grab algorithm.
@@ -161,26 +160,26 @@ public class MslSignatureEnvelope {
                     try {
                         algorithm = SignatureAlgo.fromString(envelopeJo.getString(KEY_ALGORITHM));
                     } catch (final IllegalArgumentException e) {
-                        throw new MslCryptoException(MslError.UNIDENTIFIED_ALGORITHM, "signature envelope " + DatatypeConverter.printBase64Binary(envelope), e);
+                        throw new MslCryptoException(MslError.UNIDENTIFIED_ALGORITHM, "signature envelope " + Base64.encode(envelope), e);
                     }
                     
                     // Grab signature.
                     final byte[] signature;
                     try {
-                        signature = DatatypeConverter.parseBase64Binary(envelopeJo.getString(KEY_SIGNATURE));
+                        signature = Base64.decode(envelopeJo.getString(KEY_SIGNATURE));
                     } catch (final IllegalArgumentException e) {
-                        throw new MslCryptoException(MslError.INVALID_SIGNATURE, "signature envelope " + DatatypeConverter.printBase64Binary(envelope));
+                        throw new MslCryptoException(MslError.INVALID_SIGNATURE, "signature envelope " + Base64.encode(envelope));
                     }
                     if (signature == null)
-                        throw new MslCryptoException(MslError.INVALID_SIGNATURE, "signature envelope " + DatatypeConverter.printBase64Binary(envelope));
+                        throw new MslCryptoException(MslError.INVALID_SIGNATURE, "signature envelope " + Base64.encode(envelope));
                     
                     // Return the envelope.
                     return new MslSignatureEnvelope(algorithm, signature);
                 } catch (final JSONException e) {
-                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "signature envelope " + DatatypeConverter.printBase64Binary(envelope), e);
+                    throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "signature envelope " + Base64.encode(envelope), e);
                 }
             default:
-                throw new MslCryptoException(MslError.UNSUPPORTED_SIGNATURE_ENVELOPE, "signature envelope " + DatatypeConverter.printBase64Binary(envelope));
+                throw new MslCryptoException(MslError.UNSUPPORTED_SIGNATURE_ENVELOPE, "signature envelope " + Base64.encode(envelope));
         }
     }
     
@@ -235,7 +234,7 @@ public class MslSignatureEnvelope {
                 final byte[] signature;
                 try {
                     algorithm = SignatureAlgo.fromString(envelopeJo.getString(KEY_ALGORITHM));
-                    signature = DatatypeConverter.parseBase64Binary(envelopeJo.getString(KEY_SIGNATURE));
+                    signature = Base64.decode(envelopeJo.getString(KEY_SIGNATURE));
                     
                     // If the signature fails to decode then it is extremely
                     // unlikely but possible that this is a version 1 envelope.
@@ -255,7 +254,7 @@ public class MslSignatureEnvelope {
                 }
                 return new MslSignatureEnvelope(algorithm, signature);
             default:
-                throw new MslCryptoException(MslError.UNSUPPORTED_SIGNATURE_ENVELOPE, "signature envelope " + DatatypeConverter.printBase64Binary(envelope));
+                throw new MslCryptoException(MslError.UNSUPPORTED_SIGNATURE_ENVELOPE, "signature envelope " + Base64.encode(envelope));
         }
     }
     
@@ -294,7 +293,7 @@ public class MslSignatureEnvelope {
                     final JSONObject jsonObj = new JSONObject();
                     jsonObj.put(KEY_VERSION, version.intValue());
                     jsonObj.put(KEY_ALGORITHM, algorithm.toString());
-                    jsonObj.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+                    jsonObj.put(KEY_SIGNATURE, Base64.encode(signature));
                     return jsonObj.toString().getBytes(MslConstants.DEFAULT_CHARSET);
                 } catch (final JSONException e) {
                     throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);

--- a/core/src/main/java/com/netflix/msl/entityauth/MasterTokenProtectedAuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/MasterTokenProtectedAuthenticationData.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.msl.entityauth;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -30,6 +28,7 @@ import com.netflix.msl.MslMasterTokenException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.crypto.SessionCryptoContext;
 import com.netflix.msl.tokens.MasterToken;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -121,12 +120,12 @@ public class MasterTokenProtectedAuthenticationData extends EntityAuthentication
                 throw new MslEntityAuthException(MslError.ENTITYAUTH_MASTERTOKEN_INVALID, "master token protected authdata " + authdataJO.toString(), e);
             }
             try {
-                this.ciphertext = DatatypeConverter.parseBase64Binary(authdataJO.getString(KEY_AUTHENTICATION_DATA));
+                this.ciphertext = Base64.decode(authdataJO.getString(KEY_AUTHENTICATION_DATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEntityAuthException(MslError.ENTITYAUTH_CIPHERTEXT_INVALID, "master token protected authdata " + authdataJO.toString(), e);
             }
             try {
-                this.signature = DatatypeConverter.parseBase64Binary(authdataJO.getString(KEY_SIGNATURE));
+                this.signature = Base64.decode(authdataJO.getString(KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslEntityAuthException(MslError.ENTITYAUTH_SIGNATURE_INVALID, "master token protected authdata " + authdataJO.toString(), e);
             }
@@ -183,8 +182,8 @@ public class MasterTokenProtectedAuthenticationData extends EntityAuthentication
         try {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_MASTER_TOKEN, masterToken);
-            jsonObj.put(KEY_AUTHENTICATION_DATA, DatatypeConverter.printBase64Binary(ciphertext));
-            jsonObj.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(KEY_AUTHENTICATION_DATA, Base64.encode(ciphertext));
+            jsonObj.put(KEY_SIGNATURE, Base64.encode(signature));
             return new JSONObject(jsonObj.toString());
         } catch (final JSONException e) {
             throw new MslEncodingException(MslError.JSON_ENCODE_ERROR, "master token protected authdata", e);

--- a/core/src/main/java/com/netflix/msl/entityauth/X509AuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/X509AuthenticationData.java
@@ -21,8 +21,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -30,6 +28,7 @@ import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.MslInternalException;
+import com.netflix.msl.util.Base64;
 
 /**
  * <p>X.509 asymmetric keys entity authentication data.</p>
@@ -99,7 +98,7 @@ public class X509AuthenticationData extends EntityAuthenticationData {
         // Create X.509 cert.
         final byte[] x509bytes;
         try {
-            x509bytes = DatatypeConverter.parseBase64Binary(x509);
+            x509bytes = Base64.decode(x509);
         } catch (final IllegalArgumentException e) {
             throw new MslCryptoException(MslError.X509CERT_INVALID, x509, e);
         }
@@ -134,7 +133,7 @@ public class X509AuthenticationData extends EntityAuthenticationData {
     public JSONObject getAuthData() throws MslEncodingException {
         final JSONObject jsonObj = new JSONObject();
         try {
-            jsonObj.put(KEY_X509_CERT, DatatypeConverter.printBase64Binary(x509cert.getEncoded()));
+            jsonObj.put(KEY_X509_CERT, Base64.encode(x509cert.getEncoded()));
         } catch (final JSONException e) {
             throw new MslEncodingException(MslError.JSON_ENCODE_ERROR, "X.509 authdata", e);
         } catch (final CertificateEncodingException e) {

--- a/core/src/main/java/com/netflix/msl/entityauth/X509Store.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/X509Store.java
@@ -33,7 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
-import javax.xml.bind.DatatypeConverter;
+
+import com.netflix.msl.util.Base64;
 
 /**
  * <p>An X.509 certificate store.</p>
@@ -86,7 +87,7 @@ public class X509Store {
         do {
             final X509Certificate issuer = getIssuer(current);
             if (issuer == null)
-                throw new CertificateException("No issuer found for certificate: " + DatatypeConverter.printBase64Binary(current.getEncoded()));
+                throw new CertificateException("No issuer found for certificate: " + Base64.encode(current.getEncoded()));
             chain.add(0, issuer);
             current = issuer;
         } while (!isSelfSigned(current));
@@ -242,7 +243,7 @@ public class X509Store {
         // Verify that the root certificate is self-signed and add it.
         X509Certificate issuer = chain.get(0);
         if(!isSelfSigned(issuer))
-            throw new CertificateException("First certificate is not self-signed: " + DatatypeConverter.printBase64Binary(issuer.getEncoded()));
+            throw new CertificateException("First certificate is not self-signed: " + Base64.encode(issuer.getEncoded()));
         addTrusted(issuer);
         
         // Add subordinate certificates.
@@ -288,18 +289,18 @@ public class X509Store {
         // Verify this is a CA certificate.
         final int pathlen = cert.getBasicConstraints();
         if (pathlen < 0)
-            throw new CertificateException("Certificate is not a CA certificate: " + DatatypeConverter.printBase64Binary(cert.getEncoded()));
+            throw new CertificateException("Certificate is not a CA certificate: " + Base64.encode(cert.getEncoded()));
 
         // Verify the certificate signature.
         if (isSelfSigned(cert)) {
             cert.verify(cert.getPublicKey());
         } else {
             if (!isVerified(cert))
-                throw new CertificateException("Certificate is not self-signed and not trusted by any known CA certificate: " + DatatypeConverter.printBase64Binary(cert.getEncoded()));
+                throw new CertificateException("Certificate is not self-signed and not trusted by any known CA certificate: " + Base64.encode(cert.getEncoded()));
             
             // Subordinate certificates must have their path length validated.
             if (!isPermittedByIssuer(cert))
-                throw new CertificateException("Certificate appears too far from its issuing CA certificate: " + DatatypeConverter.printBase64Binary(cert.getEncoded()));
+                throw new CertificateException("Certificate appears too far from its issuing CA certificate: " + Base64.encode(cert.getEncoded()));
         }
 
         // Add the certificate.

--- a/core/src/main/java/com/netflix/msl/keyx/AsymmetricWrappedExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/AsymmetricWrappedExchange.java
@@ -35,7 +35,6 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -63,6 +62,7 @@ import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -290,7 +290,7 @@ public class AsymmetricWrappedExchange extends KeyExchangeFactory {
                     throw new MslKeyExchangeException(MslError.UNIDENTIFIED_KEYX_MECHANISM, mechanismName, e);
                 }
                 try {
-                    encodedKey = DatatypeConverter.parseBase64Binary(keyRequestJO.getString(KEY_PUBLIC_KEY));
+                    encodedKey = Base64.decode(keyRequestJO.getString(KEY_PUBLIC_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslCryptoException(MslError.KEYX_INVALID_PUBLIC_KEY, "keydata " + keyRequestJO.toString(), e);
                 }
@@ -369,7 +369,7 @@ public class AsymmetricWrappedExchange extends KeyExchangeFactory {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_KEY_PAIR_ID, keyPairId);
             jsonObj.put(KEY_MECHANISM, mechanism.name());
-            jsonObj.put(KEY_PUBLIC_KEY, DatatypeConverter.printBase64Binary(publicKey.getEncoded()));
+            jsonObj.put(KEY_PUBLIC_KEY, Base64.encode(publicKey.getEncoded()));
             return jsonObj;
         }
 
@@ -473,12 +473,12 @@ public class AsymmetricWrappedExchange extends KeyExchangeFactory {
             try {
                 keyPairId = keyDataJO.getString(KEY_KEY_PAIR_ID);
                 try {
-                    encryptionKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_ENCRYPTION_KEY));
+                    encryptionKey = Base64.decode(keyDataJO.getString(KEY_ENCRYPTION_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_ENCRYPTION_KEY, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    hmacKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_HMAC_KEY));
+                    hmacKey = Base64.decode(keyDataJO.getString(KEY_HMAC_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_HMAC_KEY, "keydata " + keyDataJO.toString(), e);
                 }
@@ -512,8 +512,8 @@ public class AsymmetricWrappedExchange extends KeyExchangeFactory {
         protected JSONObject getKeydata() throws JSONException {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_KEY_PAIR_ID, keyPairId);
-            jsonObj.put(KEY_ENCRYPTION_KEY, DatatypeConverter.printBase64Binary(encryptionKey));
-            jsonObj.put(KEY_HMAC_KEY, DatatypeConverter.printBase64Binary(hmacKey));
+            jsonObj.put(KEY_ENCRYPTION_KEY, Base64.encode(encryptionKey));
+            jsonObj.put(KEY_HMAC_KEY, Base64.encode(hmacKey));
             return jsonObj;
         }
         

--- a/core/src/main/java/com/netflix/msl/keyx/DiffieHellmanExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/DiffieHellmanExchange.java
@@ -35,7 +35,6 @@ import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.DHPublicKeySpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -55,6 +54,7 @@ import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -143,7 +143,7 @@ public class DiffieHellmanExchange extends KeyExchangeFactory {
             super(KeyExchangeScheme.DIFFIE_HELLMAN);
             try {
                 parametersId = keyDataJO.getString(KEY_PARAMETERS_ID);
-                final byte[] publicKeyY = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_PUBLIC_KEY));
+                final byte[] publicKeyY = Base64.decode(keyDataJO.getString(KEY_PUBLIC_KEY));
                 publicKey = new BigInteger(correctNullBytes(publicKeyY));
             } catch (final JSONException e) {
                 throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "keydata " + keyDataJO.toString(), e);
@@ -162,7 +162,7 @@ public class DiffieHellmanExchange extends KeyExchangeFactory {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_PARAMETERS_ID, parametersId);
             final byte[] publicKeyY = publicKey.toByteArray();
-            jsonObj.put(KEY_PUBLIC_KEY, DatatypeConverter.printBase64Binary(correctNullBytes(publicKeyY)));
+            jsonObj.put(KEY_PUBLIC_KEY, Base64.encode(correctNullBytes(publicKeyY)));
             return jsonObj;
         }
 
@@ -272,7 +272,7 @@ public class DiffieHellmanExchange extends KeyExchangeFactory {
             super(masterToken, KeyExchangeScheme.DIFFIE_HELLMAN);
             try {
                 parametersId = keyDataJO.getString(KEY_PARAMETERS_ID);
-                final byte[] publicKeyY = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_PUBLIC_KEY));
+                final byte[] publicKeyY = Base64.decode(keyDataJO.getString(KEY_PUBLIC_KEY));
                 publicKey = new BigInteger(correctNullBytes(publicKeyY));
             } catch (final JSONException e) {
                 throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "keydata " + keyDataJO.toString(), e);
@@ -304,7 +304,7 @@ public class DiffieHellmanExchange extends KeyExchangeFactory {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_PARAMETERS_ID, parametersId);
             final byte[] publicKeyY = publicKey.toByteArray();
-            jsonObj.put(KEY_PUBLIC_KEY, DatatypeConverter.printBase64Binary(correctNullBytes(publicKeyY)));
+            jsonObj.put(KEY_PUBLIC_KEY, Base64.encode(correctNullBytes(publicKeyY)));
             return jsonObj;
         }
 

--- a/core/src/main/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchange.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -51,6 +50,7 @@ import com.netflix.msl.entityauth.PresharedAuthenticationData;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -169,7 +169,7 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
                     case WRAP:
                     {
                         try {
-                            wrapdata = DatatypeConverter.parseBase64Binary(keyRequestJO.getString(KEY_WRAPDATA));
+                            wrapdata = Base64.decode(keyRequestJO.getString(KEY_WRAPDATA));
                         } catch (final IllegalArgumentException e) {
                             throw new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPPING_KEY, "keydata " + keyRequestJO.toString());
                         }
@@ -206,7 +206,7 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
         protected JSONObject getKeydata() throws JSONException {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_MECHANISM, mechanism.name());
-            if (wrapdata != null) jsonObj.put(KEY_WRAPDATA, DatatypeConverter.printBase64Binary(wrapdata));
+            if (wrapdata != null) jsonObj.put(KEY_WRAPDATA, Base64.encode(wrapdata));
             return jsonObj;
         }
         
@@ -301,22 +301,22 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
             super(masterToken, KeyExchangeScheme.JWE_LADDER);
             try {
                 try {
-                    wrapKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_WRAP_KEY));
+                    wrapKey = Base64.decode(keyDataJO.getString(KEY_WRAP_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPPING_KEY, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    wrapdata = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_WRAPDATA));
+                    wrapdata = Base64.decode(keyDataJO.getString(KEY_WRAPDATA));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPDATA, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    encryptionKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_ENCRYPTION_KEY));
+                    encryptionKey = Base64.decode(keyDataJO.getString(KEY_ENCRYPTION_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_ENCRYPTION_KEY, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    hmacKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_HMAC_KEY));
+                    hmacKey = Base64.decode(keyDataJO.getString(KEY_HMAC_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_HMAC_KEY, "keydata " + keyDataJO.toString(), e);
                 }
@@ -359,10 +359,10 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
         @Override
         protected JSONObject getKeydata() throws JSONException {
             final JSONObject jsonObj = new JSONObject();
-            jsonObj.put(KEY_WRAP_KEY, DatatypeConverter.printBase64Binary(wrapKey));
-            jsonObj.put(KEY_WRAPDATA, DatatypeConverter.printBase64Binary(wrapdata));
-            jsonObj.put(KEY_ENCRYPTION_KEY, DatatypeConverter.printBase64Binary(encryptionKey));
-            jsonObj.put(KEY_HMAC_KEY, DatatypeConverter.printBase64Binary(hmacKey));
+            jsonObj.put(KEY_WRAP_KEY, Base64.encode(wrapKey));
+            jsonObj.put(KEY_WRAPDATA, Base64.encode(wrapdata));
+            jsonObj.put(KEY_ENCRYPTION_KEY, Base64.encode(encryptionKey));
+            jsonObj.put(KEY_HMAC_KEY, Base64.encode(hmacKey));
             return jsonObj;
         }
         
@@ -632,7 +632,7 @@ public class JsonWebEncryptionLadderExchange extends KeyExchangeFactory {
             {
                 wrapKeyCryptoContext = repository.getCryptoContext(requestWrapdata);
                 if (wrapKeyCryptoContext == null)
-                    throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, DatatypeConverter.printBase64Binary(requestWrapdata)).setEntityAuthenticationData(entityAuthData);
+                    throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, Base64.encode(requestWrapdata)).setEntityAuthenticationData(entityAuthData);
                 break;
             }
             default:

--- a/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
@@ -28,7 +28,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -55,6 +54,7 @@ import com.netflix.msl.entityauth.PresharedAuthenticationData;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -183,7 +183,7 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
                     case WRAP:
                     {
                         try {
-                            wrapdata = DatatypeConverter.parseBase64Binary(keyRequestJO.getString(KEY_WRAPDATA));
+                            wrapdata = Base64.decode(keyRequestJO.getString(KEY_WRAPDATA));
                         } catch (final IllegalArgumentException e) {
                             throw new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPDATA, "keydata " + keyRequestJO.toString(), e);
                         }
@@ -220,7 +220,7 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
         protected JSONObject getKeydata() throws JSONException {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_MECHANISM, mechanism.name());
-            if (wrapdata != null) jsonObj.put(KEY_WRAPDATA, DatatypeConverter.printBase64Binary(wrapdata));
+            if (wrapdata != null) jsonObj.put(KEY_WRAPDATA, Base64.encode(wrapdata));
             return jsonObj;
         }
         
@@ -314,22 +314,22 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
             super(masterToken, KeyExchangeScheme.JWK_LADDER);
             try {
                 try {
-                    wrapKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_WRAP_KEY));
+                    wrapKey = Base64.decode(keyDataJO.getString(KEY_WRAP_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPPING_KEY, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    wrapdata = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_WRAPDATA));
+                    wrapdata = Base64.decode(keyDataJO.getString(KEY_WRAPDATA));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPDATA, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    encryptionKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_ENCRYPTION_KEY));
+                    encryptionKey = Base64.decode(keyDataJO.getString(KEY_ENCRYPTION_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_ENCRYPTION_KEY, "keydata " + keyDataJO.toString(), e);
                 }
                 try {
-                    hmacKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_HMAC_KEY));
+                    hmacKey = Base64.decode(keyDataJO.getString(KEY_HMAC_KEY));
                 } catch (final IllegalArgumentException e) {
                     throw new MslKeyExchangeException(MslError.KEYX_INVALID_HMAC_KEY, "keydata " + keyDataJO.toString(), e);
                 }
@@ -372,10 +372,10 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
         @Override
         protected JSONObject getKeydata() throws JSONException {
             final JSONObject jsonObj = new JSONObject();
-            jsonObj.put(KEY_WRAP_KEY, DatatypeConverter.printBase64Binary(wrapKey));
-            jsonObj.put(KEY_WRAPDATA, DatatypeConverter.printBase64Binary(wrapdata));
-            jsonObj.put(KEY_ENCRYPTION_KEY, DatatypeConverter.printBase64Binary(encryptionKey));
-            jsonObj.put(KEY_HMAC_KEY, DatatypeConverter.printBase64Binary(hmacKey));
+            jsonObj.put(KEY_WRAP_KEY, Base64.encode(wrapKey));
+            jsonObj.put(KEY_WRAPDATA, Base64.encode(wrapdata));
+            jsonObj.put(KEY_ENCRYPTION_KEY, Base64.encode(encryptionKey));
+            jsonObj.put(KEY_HMAC_KEY, Base64.encode(hmacKey));
             return jsonObj;
         }
         
@@ -801,7 +801,7 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
             {
                 wrapKeyCryptoContext = repository.getCryptoContext(requestWrapdata);
                 if (wrapKeyCryptoContext == null)
-                    throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, DatatypeConverter.printBase64Binary(requestWrapdata)).setEntityAuthenticationData(entityAuthData);
+                    throw new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING, Base64.encode(requestWrapdata)).setEntityAuthenticationData(entityAuthData);
                 break;
             }
             default:

--- a/core/src/main/java/com/netflix/msl/keyx/SymmetricWrappedExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/SymmetricWrappedExchange.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -42,6 +41,7 @@ import com.netflix.msl.entityauth.PresharedAuthenticationData;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -203,12 +203,12 @@ public class SymmetricWrappedExchange extends KeyExchangeFactory {
                 try {
                     keyId = KeyId.valueOf(keyIdName);
                     try {
-                        encryptionKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_ENCRYPTION_KEY));
+                        encryptionKey = Base64.decode(keyDataJO.getString(KEY_ENCRYPTION_KEY));
                     } catch (final IllegalArgumentException e) {
                         throw new MslKeyExchangeException(MslError.KEYX_INVALID_ENCRYPTION_KEY, "keydata " + keyDataJO.toString(), e);
                     }
                     try {
-                        hmacKey = DatatypeConverter.parseBase64Binary(keyDataJO.getString(KEY_HMAC_KEY));
+                        hmacKey = Base64.decode(keyDataJO.getString(KEY_HMAC_KEY));
                     } catch (final IllegalArgumentException e) {
                         throw new MslKeyExchangeException(MslError.KEYX_INVALID_HMAC_KEY, "keydata " + keyDataJO.toString(), e);
                     }
@@ -248,8 +248,8 @@ public class SymmetricWrappedExchange extends KeyExchangeFactory {
         protected JSONObject getKeydata() throws JSONException {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_KEY_ID, keyId.name());
-            jsonObj.put(KEY_ENCRYPTION_KEY, DatatypeConverter.printBase64Binary(encryptionKey));
-            jsonObj.put(KEY_HMAC_KEY, DatatypeConverter.printBase64Binary(hmacKey));
+            jsonObj.put(KEY_ENCRYPTION_KEY, Base64.encode(encryptionKey));
+            jsonObj.put(KEY_HMAC_KEY, Base64.encode(hmacKey));
             return jsonObj;
         }
         

--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -17,8 +17,6 @@ package com.netflix.msl.msg;
 
 import java.util.Date;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -34,6 +32,7 @@ import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.entityauth.EntityAuthenticationFactory;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -197,7 +196,7 @@ public class ErrorHeader extends Header {
             
             // Verify and decrypt the error data.
             try {
-                this.errordata = DatatypeConverter.parseBase64Binary(errordata);
+                this.errordata = Base64.decode(errordata);
             } catch (final IllegalArgumentException e) {
                 throw new MslMessageException(MslError.HEADER_DATA_INVALID, errordata, e).setEntityAuthenticationData(entityAuthData);
             }
@@ -321,8 +320,8 @@ public class ErrorHeader extends Header {
         try {
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(HeaderKeys.KEY_ENTITY_AUTHENTICATION_DATA, entityAuthData);
-            jsonObj.put(HeaderKeys.KEY_ERRORDATA, DatatypeConverter.printBase64Binary(errordata));
-            jsonObj.put(HeaderKeys.KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(HeaderKeys.KEY_ERRORDATA, Base64.encode(errordata));
+            jsonObj.put(HeaderKeys.KEY_SIGNATURE, Base64.encode(signature));
             return jsonObj.toString();
         } catch (final JSONException e) {
             throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);

--- a/core/src/main/java/com/netflix/msl/msg/Header.java
+++ b/core/src/main/java/com/netflix/msl/msg/Header.java
@@ -17,8 +17,6 @@ package com.netflix.msl.msg;
 
 import java.util.Map;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -34,6 +32,7 @@ import com.netflix.msl.MslUserAuthException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.tokens.MasterToken;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -125,7 +124,7 @@ public abstract class Header implements JSONString {
                 ? new MasterToken(ctx, headerJO.getJSONObject(HeaderKeys.KEY_MASTER_TOKEN))
                 : null;
             try {
-                signature = DatatypeConverter.parseBase64Binary(headerJO.getString(HeaderKeys.KEY_SIGNATURE));
+                signature = Base64.decode(headerJO.getString(HeaderKeys.KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslMessageException(MslError.HEADER_SIGNATURE_INVALID, "header/errormsg " + headerJO.toString());
             }

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -21,8 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -52,6 +50,7 @@ import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.userauth.UserAuthenticationData;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MslContext;
 
@@ -517,7 +516,7 @@ public class MessageHeader extends Header {
             
             // Verify and decrypt the header data.
             try {
-                this.headerdata = DatatypeConverter.parseBase64Binary(headerdata);
+                this.headerdata = Base64.decode(headerdata);
             } catch (final IllegalArgumentException e) {
                 throw new MslMessageException(MslError.HEADER_DATA_INVALID, headerdata, e).setMasterToken(masterToken).setEntityAuthenticationData(entityAuthData);
             }
@@ -953,8 +952,8 @@ public class MessageHeader extends Header {
                 jsonObj.put(HeaderKeys.KEY_MASTER_TOKEN, masterToken);
             else
                 jsonObj.put(HeaderKeys.KEY_ENTITY_AUTHENTICATION_DATA, entityAuthData);
-            jsonObj.put(HeaderKeys.KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
-            jsonObj.put(HeaderKeys.KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(HeaderKeys.KEY_HEADERDATA, Base64.encode(headerdata));
+            jsonObj.put(HeaderKeys.KEY_SIGNATURE, Base64.encode(signature));
             return jsonObj.toString();
         } catch (final JSONException e) {
             throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);

--- a/core/src/main/java/com/netflix/msl/tokens/ServiceToken.java
+++ b/core/src/main/java/com/netflix/msl/tokens/ServiceToken.java
@@ -17,8 +17,6 @@ package com.netflix.msl.tokens;
 
 import java.util.Map;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -31,6 +29,7 @@ import com.netflix.msl.MslError;
 import com.netflix.msl.MslException;
 import com.netflix.msl.MslInternalException;
 import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslUtils;
 
@@ -127,7 +126,7 @@ public class ServiceToken implements JSONString {
         try {
             final byte[] tokendata;
             try {
-                tokendata = DatatypeConverter.parseBase64Binary(serviceTokenJO.getString(KEY_TOKENDATA));
+                tokendata = Base64.decode(serviceTokenJO.getString(KEY_TOKENDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.SERVICETOKEN_TOKENDATA_INVALID, "servicetoken " + serviceTokenJO.toString(), e);
             }
@@ -212,7 +211,7 @@ public class ServiceToken implements JSONString {
                 if (this.uitSerialNumber != -1) tokenDataJO.put(KEY_USER_ID_TOKEN_SERIAL_NUMBER, this.uitSerialNumber);
                 tokenDataJO.put(KEY_ENCRYPTED, this.encrypted);
                 if (this.compressionAlgo != null) tokenDataJO.put(KEY_COMPRESSION_ALGORITHM, this.compressionAlgo.name());
-                tokenDataJO.put(KEY_SERVICEDATA, DatatypeConverter.printBase64Binary(ciphertext));
+                tokenDataJO.put(KEY_SERVICEDATA, Base64.encode(ciphertext));
                 this.tokendata = tokenDataJO.toString().getBytes(MslConstants.DEFAULT_CHARSET);
             } catch (final JSONException e) {
                 throw new MslEncodingException(MslError.JSON_ENCODE_ERROR, "servicetoken", e).setMasterToken(masterToken).setUserIdToken(userIdToken);
@@ -297,14 +296,14 @@ public class ServiceToken implements JSONString {
         // Verify the JSON representation.
         try {
             try {
-                tokendata = DatatypeConverter.parseBase64Binary(serviceTokenJO.getString(KEY_TOKENDATA));
+                tokendata = Base64.decode(serviceTokenJO.getString(KEY_TOKENDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.SERVICETOKEN_TOKENDATA_INVALID, "servicetoken " + serviceTokenJO.toString(), e).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
             if (tokendata == null || tokendata.length == 0)
                 throw new MslEncodingException(MslError.SERVICETOKEN_TOKENDATA_MISSING, "servicetoken " + serviceTokenJO.toString()).setMasterToken(masterToken).setUserIdToken(userIdToken);
             try {
-                signature = DatatypeConverter.parseBase64Binary(serviceTokenJO.getString(KEY_SIGNATURE));
+                signature = Base64.decode(serviceTokenJO.getString(KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.SERVICETOKEN_SIGNATURE_INVALID, "servicetoken " + serviceTokenJO.toString(), e).setMasterToken(masterToken).setUserIdToken(userIdToken);
             }
@@ -357,7 +356,7 @@ public class ServiceToken implements JSONString {
             if (verified) {
                 final byte[] ciphertext;
                 try {
-                    ciphertext = DatatypeConverter.parseBase64Binary(data);
+                    ciphertext = Base64.decode(data);
                 } catch (final IllegalArgumentException e) {
                     throw new MslException(MslError.SERVICETOKEN_SERVICEDATA_INVALID, "servicetokendata " + tokenDataJson).setMasterToken(masterToken).setUserIdToken(userIdToken);
                 }
@@ -533,8 +532,8 @@ public class ServiceToken implements JSONString {
     public String toJSONString() {
         try {
             final JSONObject jsonObj = new JSONObject();
-            jsonObj.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendata));
-            jsonObj.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(KEY_TOKENDATA, Base64.encode(tokendata));
+            jsonObj.put(KEY_SIGNATURE, Base64.encode(signature));
             return jsonObj.toString();
         } catch (final JSONException e) {
             throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);
@@ -551,11 +550,11 @@ public class ServiceToken implements JSONString {
             tokendataJO.put(KEY_NAME, name);
             tokendataJO.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, mtSerialNumber);
             tokendataJO.put(KEY_USER_ID_TOKEN_SERIAL_NUMBER, uitSerialNumber);
-            tokendataJO.put(KEY_SERVICEDATA, DatatypeConverter.printBase64Binary(servicedata));
+            tokendataJO.put(KEY_SERVICEDATA, Base64.encode(servicedata));
             
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_TOKENDATA, tokendataJO);
-            jsonObj.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(KEY_SIGNATURE, Base64.encode(signature));
             return jsonObj.toString();
         } catch (final JSONException e) {
             throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);

--- a/core/src/main/java/com/netflix/msl/tokens/UserIdToken.java
+++ b/core/src/main/java/com/netflix/msl/tokens/UserIdToken.java
@@ -17,8 +17,6 @@ package com.netflix.msl.tokens;
 
 import java.util.Date;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONString;
@@ -30,6 +28,7 @@ import com.netflix.msl.MslError;
 import com.netflix.msl.MslException;
 import com.netflix.msl.MslInternalException;
 import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -173,7 +172,7 @@ public class UserIdToken implements JSONString {
                 tokenDataJO.put(KEY_EXPIRATION, this.expiration);
                 tokenDataJO.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, this.mtSerialNumber);
                 tokenDataJO.put(KEY_SERIAL_NUMBER, this.serialNumber);
-                tokenDataJO.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(ciphertext));
+                tokenDataJO.put(KEY_USERDATA, Base64.encode(ciphertext));
                 this.tokendata = tokenDataJO.toString().getBytes(MslConstants.DEFAULT_CHARSET);
             } catch (final JSONException e) {
                 throw new MslEncodingException(MslError.JSON_ENCODE_ERROR, "usertokendata", e).setMasterToken(masterToken);
@@ -215,14 +214,14 @@ public class UserIdToken implements JSONString {
         // Verify the JSON representation.
         try {
             try {
-                tokendata = DatatypeConverter.parseBase64Binary(userIdTokenJO.getString(KEY_TOKENDATA));
+                tokendata = Base64.decode(userIdTokenJO.getString(KEY_TOKENDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_INVALID, "useridtoken " + userIdTokenJO.toString(), e).setMasterToken(masterToken);
             }
             if (tokendata == null || tokendata.length == 0)
                 throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_MISSING, "useridtoken " + userIdTokenJO.toString()).setMasterToken(masterToken);
             try {
-                signature = DatatypeConverter.parseBase64Binary(userIdTokenJO.getString(KEY_SIGNATURE));
+                signature = Base64.decode(userIdTokenJO.getString(KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.USERIDTOKEN_SIGNATURE_INVALID, "useridtoken " + userIdTokenJO.toString(), e).setMasterToken(masterToken);
             }
@@ -247,7 +246,7 @@ public class UserIdToken implements JSONString {
                 throw new MslException(MslError.USERIDTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "usertokendata " + tokenDataJson).setMasterToken(masterToken);
             final byte[] ciphertext;
             try {
-                ciphertext = DatatypeConverter.parseBase64Binary(tokenDataJO.getString(KEY_USERDATA));
+                ciphertext = Base64.decode(tokenDataJO.getString(KEY_USERDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslException(MslError.USERIDTOKEN_USERDATA_INVALID, tokenDataJO.getString(KEY_USERDATA)).setMasterToken(masterToken);
             }
@@ -440,8 +439,8 @@ public class UserIdToken implements JSONString {
     public final String toJSONString() {
         try {
             final JSONObject jsonObj = new JSONObject();
-            jsonObj.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendata));
-            jsonObj.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(KEY_TOKENDATA, Base64.encode(tokendata));
+            jsonObj.put(KEY_SIGNATURE, Base64.encode(signature));
             return jsonObj.toString();
         } catch (final JSONException e) {
             throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);
@@ -473,7 +472,7 @@ public class UserIdToken implements JSONString {
             
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_TOKENDATA, tokendataJO);
-            jsonObj.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+            jsonObj.put(KEY_SIGNATURE, Base64.encode(signature));
             return jsonObj.toString();
         } catch (final JSONException e) {
             throw new MslInternalException("Error encoding " + this.getClass().getName() + " JSON.", e);

--- a/core/src/main/java/com/netflix/msl/util/Base64.java
+++ b/core/src/main/java/com/netflix/msl/util/Base64.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.util;
+
+/**
+ * <p>Base64 encoder/decoder. Can be configured with a backing
+ * implementation.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class Base64 {
+    /** Base64 validation regular expression. */
+    private static final String VALID_REGEXP = "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$";
+    
+    /**
+     * <p>Validates that a string is a valid Base64 encoding. This uses a
+     * regular expression to perform the check. The empty string is also
+     * considered valid.</p>
+     * 
+     * @param s the string to validate.
+     * @return true if the string is a valid Base64 encoding.
+     */
+    public static boolean isValidBase64(final String s) {
+        return s.matches(VALID_REGEXP);
+    }
+    
+    /**
+     * <p>A Base64 encoder/decoder implementation. Implementations must be
+     * thread-safe.</p>
+     */
+    public static interface Base64Impl {
+        /**
+         * <p>Base64 encodes binary data.</p>
+         * 
+         * @param b the binary data.
+         * @return the Base64-encoded binary data.
+         */
+        public String encode(final byte[] b);
+        
+        /**
+         * <p>Decodes a Base64-encoded string into its binary form.</p>
+         * 
+         * @param s the Base64-encoded string.
+         * @return the binary data.
+         * @throws IllegalArgumentException if the argument is not a valid
+         *         Base64-encoded string. The empty string is considered valid.
+         * @see Base64#isValidBase64(String)
+         */
+        public byte[] decode(final String s);
+    }
+    
+    /**
+     * Set the backing implementation.
+     * 
+     * @param provider the backing implementation.
+     * @throws NullPointerException if the provider is {@code null}.
+     */
+    public static void setImpl(final Base64Impl impl) {
+        if (impl == null)
+            throw new NullPointerException("Base64 implementation cannot be null.");
+        Base64.impl = impl;
+    }
+    
+    /**
+     * <p>Base64 encodes binary data.</p>
+     * 
+     * @param b the binary data.
+     * @return the Base64-encoded binary data.
+     */
+    public static String encode(final byte[] b) {
+        return impl.encode(b);
+    }
+    
+    /**
+     * <p>Decodes a Base64-encoded string into its binary form.</p>
+     * 
+     * @param s the Base64-encoded string.
+     * @return the binary data.
+     * @throws IllegalArgumentException if the argument is not a valid Base64-
+     *         encoded string.
+     */
+    public static byte[] decode(final String s) {
+        // Delegate validation of the argument to the implementation.
+        return impl.decode(s);
+    }
+    
+    /** The backing implementation. */
+    private static Base64Impl impl = new Base64Jaxb();
+}

--- a/core/src/main/java/com/netflix/msl/util/Base64Jaxb.java
+++ b/core/src/main/java/com/netflix/msl/util/Base64Jaxb.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.util;
+
+import javax.xml.bind.DatatypeConverter;
+
+import com.netflix.msl.util.Base64.Base64Impl;
+
+/**
+ * <p>Base64 encoder/decoder implementation that uses the JAXB {@link DatatypConverter}
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class Base64Jaxb implements Base64Impl {
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.Base64.Base64Impl#encode(byte[])
+     */
+    @Override
+    public String encode(final byte[] b) {
+        return DatatypeConverter.printBase64Binary(b);
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.util.Base64.Base64Impl#decode(java.lang.String)
+     */
+    @Override
+    public byte[] decode(final String s) {
+        if (!Base64.isValidBase64(s))
+            throw new IllegalArgumentException("Invalid Base64 encoded string: " + s);
+        return DatatypeConverter.parseBase64Binary(s);
+    }
+}

--- a/core/src/main/java/com/netflix/msl/util/JsonUtils.java
+++ b/core/src/main/java/com/netflix/msl/util/JsonUtils.java
@@ -62,7 +62,7 @@ public class JsonUtils {
      */
     public static String b64urlEncode(final byte[] data) {
         // Perform a standard Base64 encode.
-        final String padded = DatatypeConverter.printBase64Binary(data);
+        final String padded = Base64.encode(data);
         
         // Replace standard characters with URL-safe characters.
         final String modified = padded.replace(CHAR_PLUS, CHAR_MINUS).replace(CHAR_SLASH, CHAR_UNDERSCORE);
@@ -86,11 +86,11 @@ public class JsonUtils {
         try {
             final int toPad = 4 - (modified.length() % 4);
             if (toPad == 0 || toPad == 4)
-                return DatatypeConverter.parseBase64Binary(modified);
+                return Base64.decode(modified);
             final StringBuilder padded = new StringBuilder(modified);
             for (int i = 0; i < toPad; ++i)
                 padded.append(CHAR_EQUALS);
-            return DatatypeConverter.parseBase64Binary(padded.toString());
+            return Base64.decode(padded.toString());
         } catch (final IllegalArgumentException e) {
             return null;
         }

--- a/core/src/main/java/com/netflix/msl/util/MslUtils.java
+++ b/core/src/main/java/com/netflix/msl/util/MslUtils.java
@@ -66,7 +66,7 @@ public class MslUtils {
                     throw new MslException(MslError.UNSUPPORTED_COMPRESSION, compressionAlgo.name());
             }
         } catch (final IOException e) {
-            final String dataB64 = DatatypeConverter.printBase64Binary(data);
+            final String dataB64 = Base64.encode(data);
             throw new MslException(MslError.COMPRESSION_ERROR, "algo " + compressionAlgo.name() + " data " + dataB64, e);
         }
     }
@@ -116,7 +116,7 @@ public class MslUtils {
                     throw new MslException(MslError.UNSUPPORTED_COMPRESSION, compressionAlgo.name());
             }
         } catch (final IOException e) {
-            final String dataB64 = DatatypeConverter.printBase64Binary(data);
+            final String dataB64 = Base64.encode(data);
             throw new MslException(MslError.UNCOMPRESSION_ERROR, "algo " + compressionAlgo.name() + " data " + dataB64, e);
         }
     }

--- a/core/src/main/javascript/lib/base64.js
+++ b/core/src/main/javascript/lib/base64.js
@@ -27,7 +27,7 @@ var base64$encode,
         charNumber3 = { '=': 0, '.': 0 },
         charNumber4 = { '=': 0, '.': 0 },
         prepRegex = /\s*/g,
-        checkRegex = new RegExp('^[' + map + '_-]*[' + padchar + ']{0,2}$');
+        checkRegex = new RegExp('^([A-Za-z0-9+/_-]{4})*([A-Za-z0-9+/_-]{4}|[A-Za-z0-9+/_-]{3}=|[A-Za-z0-9+/_-]{2}==)?$');
 
     var i = map.length;
     while (i--) {
@@ -112,7 +112,7 @@ var base64$encode,
      *        should be used (http://tools.ietf.org/html/rfc4648#section-5)
      * @return {Uint8Array} the decoded data.
      * @throws Error if the Base64 string is the wrong length or is not Base64
-     *         encoded data.
+     *         encoded data. The empty string is considered valid.
      */
     base64$decode = function (s, urlSafe) {
         s = s.replace(prepRegex, '');

--- a/examples/burp/src/main/java/burp/MSLHttpListener.java
+++ b/examples/burp/src/main/java/burp/MSLHttpListener.java
@@ -23,17 +23,8 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import burp.msl.WiretapException;
-import burp.msl.WiretapModule;
-import burp.msl.msg.CaptureMessageDebugContext;
-import burp.msl.msg.WiretapMessageContext;
-import burp.msl.msg.WiretapMessageInputStream;
-import burp.msl.util.WiretapMslContext;
 
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
@@ -49,7 +40,15 @@ import com.netflix.msl.msg.MessageHeader;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
+
+import burp.msl.WiretapException;
+import burp.msl.WiretapModule;
+import burp.msl.msg.CaptureMessageDebugContext;
+import burp.msl.msg.WiretapMessageContext;
+import burp.msl.msg.WiretapMessageInputStream;
+import burp.msl.util.WiretapMslContext;
 
 /**
  * User: skommidi
@@ -334,7 +333,7 @@ public class MSLHttpListener implements IHttpListener {
             try {
                 JSONObject payloadTokenJO;
                 while((payloadTokenJO = mis.nextPayload()) != null) {
-                    final String data = new String(DatatypeConverter.parseBase64Binary(payloadTokenJO.getString(KEY_DATA)));
+                    final String data = new String(Base64.decode(payloadTokenJO.getString(KEY_DATA)));
                     payloadTokenJO.remove(KEY_DATA);
                     payloadTokenJO.put(KEY_DATA, data);
     
@@ -364,7 +363,7 @@ public class MSLHttpListener implements IHttpListener {
         boolean verified = false;
         try {
             try {
-                tokendata = DatatypeConverter.parseBase64Binary(userIdTokenJO.getString(KEY_TOKENDATA));
+                tokendata = Base64.decode(userIdTokenJO.getString(KEY_TOKENDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_INVALID, "useridtoken " + userIdTokenJO.toString(), e).setMasterToken(masterToken);
             }
@@ -372,7 +371,7 @@ public class MSLHttpListener implements IHttpListener {
                 throw new MslEncodingException(MslError.USERIDTOKEN_TOKENDATA_MISSING, "useridtoken " + userIdTokenJO.toString()).setMasterToken(masterToken);
             byte[] signature;
             try {
-                signature = DatatypeConverter.parseBase64Binary(userIdTokenJO.getString(KEY_SIGNATURE));
+                signature = Base64.decode(userIdTokenJO.getString(KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.USERIDTOKEN_SIGNATURE_INVALID, "useridtoken " + userIdTokenJO.toString(), e).setMasterToken(masterToken);
             }
@@ -400,7 +399,7 @@ public class MSLHttpListener implements IHttpListener {
                 throw new MslException(MslError.USERIDTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "usertokendata " + tokenDataJson).setMasterToken(masterToken);
             final byte[] ciphertext;
             try {
-                ciphertext = DatatypeConverter.parseBase64Binary(tokenDataJO.getString(KEY_USERDATA));
+                ciphertext = Base64.decode(tokenDataJO.getString(KEY_USERDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslException(MslError.USERIDTOKEN_USERDATA_INVALID, tokenDataJO.getString(KEY_USERDATA)).setMasterToken(masterToken);
             }
@@ -443,7 +442,7 @@ public class MSLHttpListener implements IHttpListener {
         boolean verified = false;
         try {
             try {
-                tokendata = DatatypeConverter.parseBase64Binary(masterTokenJO.getString(KEY_TOKENDATA));
+                tokendata = Base64.decode(masterTokenJO.getString(KEY_TOKENDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.MASTERTOKEN_TOKENDATA_INVALID, "mastertoken " + masterTokenJO.toString(), e);
             }
@@ -451,7 +450,7 @@ public class MSLHttpListener implements IHttpListener {
                 throw new MslEncodingException(MslError.MASTERTOKEN_TOKENDATA_MISSING, "mastertoken " + masterTokenJO.toString());
             byte[] signature;
             try {
-                signature = DatatypeConverter.parseBase64Binary(masterTokenJO.getString(KEY_SIGNATURE));
+                signature = Base64.decode(masterTokenJO.getString(KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.MASTERTOKEN_SIGNATURE_INVALID, "mastertoken " + masterTokenJO.toString(), e);
             }
@@ -478,7 +477,7 @@ public class MSLHttpListener implements IHttpListener {
                 throw new MslException(MslError.MASTERTOKEN_SERIAL_NUMBER_OUT_OF_RANGE, "mastertokendata " + tokenDataJson);
             final byte[] ciphertext;
             try {
-                ciphertext = DatatypeConverter.parseBase64Binary(tokenDataJO.getString(KEY_SESSIONDATA));
+                ciphertext = Base64.decode(tokenDataJO.getString(KEY_SESSIONDATA));
             } catch (final IllegalArgumentException e) {
                 throw new MslEncodingException(MslError.MASTERTOKEN_SESSIONDATA_INVALID, tokenDataJO.getString(KEY_SESSIONDATA));
             }

--- a/examples/burp/src/main/java/burp/msl/msg/WiretapMessageInputStream.java
+++ b/examples/burp/src/main/java/burp/msl/msg/WiretapMessageInputStream.java
@@ -20,8 +20,6 @@ import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -39,6 +37,7 @@ import com.netflix.msl.MslUserIdTokenException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.keyx.KeyRequestData;
 import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -92,7 +91,7 @@ public class WiretapMessageInputStream extends MessageInputStream {
      *         authentication data or a master token, or a token is improperly
      *         bound to another token.
      */
-    public WiretapMessageInputStream(MslContext ctx, InputStream source, Charset charset, Set<KeyRequestData> keyRequestData, Map<String, ICryptoContext> cryptoContexts) throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
+    public WiretapMessageInputStream(final MslContext ctx, final InputStream source, final Charset charset, final Set<KeyRequestData> keyRequestData, final Map<String, ICryptoContext> cryptoContexts) throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
         super(ctx, source, charset, keyRequestData, cryptoContexts);
     }
     
@@ -116,13 +115,13 @@ public class WiretapMessageInputStream extends MessageInputStream {
         byte[] payload;
         try {
             try {
-                payload = DatatypeConverter.parseBase64Binary(payloadChunk.getString(KEY_PAYLOAD));
+                payload = Base64.decode(payloadChunk.getString(KEY_PAYLOAD));
             } catch (final IllegalArgumentException e) {
                 throw new MslMessageException(MslError.PAYLOAD_INVALID, "payload chunk " + payloadChunk.toString(), e);
             }
             final byte[] signature;
             try {
-                signature = DatatypeConverter.parseBase64Binary(payloadChunk.getString(KEY_SIGNATURE));
+                signature = Base64.decode(payloadChunk.getString(KEY_SIGNATURE));
             } catch (final IllegalArgumentException e) {
                 throw new MslMessageException(MslError.PAYLOAD_SIGNATURE_INVALID, "payload chunk " + payloadChunk.toString(), e);
             }
@@ -140,7 +139,7 @@ public class WiretapMessageInputStream extends MessageInputStream {
         try {
             final JSONObject payloadJO = new JSONObject(payloadJson);
             return payloadJO;
-        } catch (JSONException e) {
+        } catch (final JSONException e) {
             throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "payload chunk payload " + payloadJson, e);
         }
     }

--- a/examples/kancolle/src/main/java/kancolle/userauth/OfficerAuthenticationData.java
+++ b/examples/kancolle/src/main/java/kancolle/userauth/OfficerAuthenticationData.java
@@ -15,14 +15,13 @@
  */
 package kancolle.userauth;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.userauth.UserAuthenticationData;
+import com.netflix.msl.util.Base64;
 
 /**
  * <p>Officers are identified by their name and fingerprint hash.</p>
@@ -71,7 +70,7 @@ public class OfficerAuthenticationData extends UserAuthenticationData {
         super(KanColleUserAuthenticationScheme.OFFICER);
         try {
             this.name = officerJo.getString(KEY_NAME);
-            this.fingerprint = DatatypeConverter.parseBase64Binary(officerJo.getString(KEY_FINGERPRINT));
+            this.fingerprint = Base64.decode(officerJo.getString(KEY_FINGERPRINT));
         } catch (final JSONException e) {
             throw new MslEncodingException(MslError.JSON_PARSE_ERROR, "officer authdata " + officerJo.toString(), e);
         }
@@ -99,7 +98,7 @@ public class OfficerAuthenticationData extends UserAuthenticationData {
         try {
             final JSONObject jo = new JSONObject();
             jo.put(KEY_NAME, name);
-            jo.put(KEY_FINGERPRINT, DatatypeConverter.printBase64Binary(fingerprint));
+            jo.put(KEY_FINGERPRINT, Base64.encode(fingerprint));
             return jo;
         } catch (final JSONException e) {
             throw new MslEncodingException(MslError.JSON_ENCODE_ERROR, this.getClass().getName(), e);

--- a/examples/mslcli/src/main/java/mslcli/common/util/SharedUtil.java
+++ b/examples/mslcli/src/main/java/mslcli/common/util/SharedUtil.java
@@ -39,9 +39,6 @@ import java.util.regex.Pattern;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
-
-import mslcli.common.Triplet;
 
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslConstants.ResponseCode;
@@ -64,9 +61,12 @@ import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslStore;
 import com.netflix.msl.util.SimpleMslStore;
+
+import mslcli.common.Triplet;
 
 /**
  * <p>Collection of utilities.</p>
@@ -493,28 +493,28 @@ public final class SharedUtil {
          * @return decoded array
          */
         public static byte[] decodeToByteArray(final String encoded) {
-            return DatatypeConverter.parseBase64Binary(encoded);
+            return Base64.decode(encoded);
         }
         /**
          * @param encoded base64-encoded string
          * @return decoded String
          */
         public static String decode(final String encoded) {
-            return new String(DatatypeConverter.parseBase64Binary(encoded), MslConstants.DEFAULT_CHARSET);
+            return new String(Base64.decode(encoded), MslConstants.DEFAULT_CHARSET);
         }
         /**
          * @param data byte array to be encoded
          * @return base64 encoding of the input byte array
          */
         public static String encode(final byte[] data) {
-            return DatatypeConverter.printBase64Binary(data);
+            return Base64.encode(data);
         }
         /**
          * @param data byte array to be encoded
          * @return base64 encoding of the input byte array
          */
         public static String encode(final String data) {
-            return DatatypeConverter.printBase64Binary(data.getBytes(MslConstants.DEFAULT_CHARSET));
+            return Base64.encode(data.getBytes(MslConstants.DEFAULT_CHARSET));
         }
     }
 

--- a/examples/oneshot/src/main/java/oneshot/Oneshot.java
+++ b/examples/oneshot/src/main/java/oneshot/Oneshot.java
@@ -28,8 +28,6 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import javax.xml.bind.DatatypeConverter;
-
 import com.netflix.msl.MslConstants.ResponseCode;
 import com.netflix.msl.MslException;
 import com.netflix.msl.msg.ErrorHeader;
@@ -37,6 +35,7 @@ import com.netflix.msl.msg.MessageContext;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.msg.MslControl;
 import com.netflix.msl.msg.MslControl.MslChannel;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -76,7 +75,7 @@ public class Oneshot {
         this.ctrl = new MslControl(0);
         
 	    // Setup remote entity public key.
-	    final byte[] pubkeyBytes = DatatypeConverter.parseBase64Binary(remoteRsaPubkeyB64);
+	    final byte[] pubkeyBytes = Base64.decode(remoteRsaPubkeyB64);
 	    final X509EncodedKeySpec pubkeySpec = new X509EncodedKeySpec(pubkeyBytes);
 	    final KeyFactory factory = KeyFactory.getInstance("RSA");
 	    final PublicKey pubkey = factory.generatePublic(pubkeySpec);

--- a/examples/simple/src/main/java/server/SimpleServlet.java
+++ b/examples/simple/src/main/java/server/SimpleServlet.java
@@ -34,18 +34,9 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.bind.DatatypeConverter;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.json.JSONObject;
-
-import server.entityauth.SimpleRsaStore;
-import server.msg.SimpleReceiveMessageContext;
-import server.msg.SimpleRequest;
-import server.msg.SimpleRespondMessageContext;
-import server.userauth.SimpleEmailPasswordStore;
-import server.userauth.SimpleUser;
-import server.util.SimpleMslContext;
 
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.crypto.JcaAlgorithm;
@@ -58,7 +49,16 @@ import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.msg.MslControl;
 import com.netflix.msl.msg.MslControl.MslChannel;
 import com.netflix.msl.userauth.EmailPasswordStore;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
+
+import server.entityauth.SimpleRsaStore;
+import server.msg.SimpleReceiveMessageContext;
+import server.msg.SimpleRequest;
+import server.msg.SimpleRespondMessageContext;
+import server.userauth.SimpleEmailPasswordStore;
+import server.userauth.SimpleUser;
+import server.util.SimpleMslContext;
 
 /**
  * <p>An example Java MSL servlet that listens for requests from the example
@@ -108,7 +108,7 @@ public class SimpleServlet extends HttpServlet {
         // Create the RSA key store.
         final RsaStore rsaStore;
         try {
-            final byte[] privKeyEncoded = DatatypeConverter.parseBase64Binary(SimpleConstants.RSA_PRIVKEY_B64);
+            final byte[] privKeyEncoded = Base64.decode(SimpleConstants.RSA_PRIVKEY_B64);
             final PKCS8EncodedKeySpec privKeySpec = new PKCS8EncodedKeySpec(privKeyEncoded);
             final KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA");
             final PrivateKey privKey = rsaKeyFactory.generatePrivate(privKeySpec);

--- a/tests/src/main/java/com/netflix/msl/entityauth/MockPresharedAuthenticationFactory.java
+++ b/tests/src/main/java/com/netflix/msl/entityauth/MockPresharedAuthenticationFactory.java
@@ -17,7 +17,6 @@ package com.netflix.msl.entityauth;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONObject;
 
@@ -28,6 +27,7 @@ import com.netflix.msl.MslInternalException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.crypto.JcaAlgorithm;
 import com.netflix.msl.crypto.SymmetricCryptoContext;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslTestUtils;
 
@@ -40,16 +40,16 @@ public class MockPresharedAuthenticationFactory extends EntityAuthenticationFact
     /** PSK ESN. */
     public static final String PSK_ESN = "PSK-ESN";
     /** PSK Kpe. */
-    private static final byte[] PSK_KPE = DatatypeConverter.parseBase64Binary("kzWYEtKSsPI8dOW5YyoILQ==");
+    private static final byte[] PSK_KPE = Base64.decode("kzWYEtKSsPI8dOW5YyoILQ==");
     /** PSK Kph. */
-    private static final byte[] PSK_KPH = DatatypeConverter.parseBase64Binary("VhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
+    private static final byte[] PSK_KPH = Base64.decode("VhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
     
     /** PSK ESN 2. */
     public static final String PSK_ESN2 = "PSK-ESN2";
     /** PSK Kpe 2. */
-    private static final byte[] PSK_KPE2 = DatatypeConverter.parseBase64Binary("lzWYEtKSsPI8dOW5YyoILQ==");
+    private static final byte[] PSK_KPE2 = Base64.decode("lzWYEtKSsPI8dOW5YyoILQ==");
     /** PSK Kph 2. */
-    private static final byte[] PSK_KPH2 = DatatypeConverter.parseBase64Binary("WhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
+    private static final byte[] PSK_KPH2 = Base64.decode("WhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
 
     /** Kpe/Kph/Kpw #1. */
     public static final SecretKey KPE, KPH, KPW;

--- a/tests/src/main/java/com/netflix/msl/entityauth/MockPresharedProfileAuthenticationFactory.java
+++ b/tests/src/main/java/com/netflix/msl/entityauth/MockPresharedProfileAuthenticationFactory.java
@@ -17,7 +17,6 @@ package com.netflix.msl.entityauth;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONObject;
 
@@ -28,6 +27,7 @@ import com.netflix.msl.MslInternalException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.crypto.JcaAlgorithm;
 import com.netflix.msl.crypto.SymmetricCryptoContext;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslTestUtils;
 
@@ -40,16 +40,16 @@ public class MockPresharedProfileAuthenticationFactory extends EntityAuthenticat
     /** PSK ESN. */
     public static final String PSK_ESN = "PSK-ESN";
     /** PSK Kpe. */
-    private static final byte[] PSK_KPE = DatatypeConverter.parseBase64Binary("kzWYEtKSsPI8dOW5YyoILQ==");
+    private static final byte[] PSK_KPE = Base64.decode("kzWYEtKSsPI8dOW5YyoILQ==");
     /** PSK Kph. */
-    private static final byte[] PSK_KPH = DatatypeConverter.parseBase64Binary("VhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
+    private static final byte[] PSK_KPH = Base64.decode("VhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
     
     /** PSK ESN 2. */
     public static final String PSK_ESN2 = "PSK-ESN2";
     /** PSK Kpe 2. */
-    private static final byte[] PSK_KPE2 = DatatypeConverter.parseBase64Binary("lzWYEtKSsPI8dOW5YyoILQ==");
+    private static final byte[] PSK_KPE2 = Base64.decode("lzWYEtKSsPI8dOW5YyoILQ==");
     /** PSK Kph 2. */
-    private static final byte[] PSK_KPH2 = DatatypeConverter.parseBase64Binary("WhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
+    private static final byte[] PSK_KPH2 = Base64.decode("WhxNUK7bYIcCV4wLE2YK90do1X3XqhPeMwwllmNh8Jw=");
     
     /** Profile. */
     public static final String PROFILE = "PROFILE";

--- a/tests/src/main/java/com/netflix/msl/entityauth/MockRsaAuthenticationFactory.java
+++ b/tests/src/main/java/com/netflix/msl/entityauth/MockRsaAuthenticationFactory.java
@@ -24,8 +24,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.json.JSONObject;
 
@@ -37,6 +35,7 @@ import com.netflix.msl.MslInternalException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.crypto.RsaCryptoContext;
 import com.netflix.msl.crypto.RsaCryptoContext.Mode;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MslContext;
 
 /**
@@ -72,8 +71,8 @@ public class MockRsaAuthenticationFactory extends EntityAuthenticationFactory {
     static {
         Security.addProvider(new BouncyCastleProvider());
         try {
-            final byte[] pubKeyEncoded = DatatypeConverter.parseBase64Binary(RSA_PUBKEY_B64);
-            final byte[] privKeyEncoded = DatatypeConverter.parseBase64Binary(RSA_PRIVKEY_B64);
+            final byte[] pubKeyEncoded = Base64.decode(RSA_PUBKEY_B64);
+            final byte[] privKeyEncoded = Base64.decode(RSA_PRIVKEY_B64);
             final X509EncodedKeySpec pubKeySpec = new X509EncodedKeySpec(pubKeyEncoded);
             final PKCS8EncodedKeySpec privKeySpec = new PKCS8EncodedKeySpec(privKeyEncoded);
             final KeyFactory keyFactory = KeyFactory.getInstance("RSA");

--- a/tests/src/main/java/com/netflix/msl/util/MslTestUtils.java
+++ b/tests/src/main/java/com/netflix/msl/util/MslTestUtils.java
@@ -117,9 +117,9 @@ public class MslTestUtils {
         final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, 1L, 1L, null, identity, encryptionKey, hmacKey);
         final String json = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(json);
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString("signature"));
+        final byte[] signature = Base64.decode(jo.getString("signature"));
         ++signature[1];
-        jo.put("signature", DatatypeConverter.printBase64Binary(signature));
+        jo.put("signature", Base64.encode(signature));
         return new MasterToken(ctx, jo);
     }
     
@@ -165,9 +165,9 @@ public class MslTestUtils {
         final UserIdToken userIdToken = new UserIdToken(ctx, renewalWindow, expiration, masterToken, serialNumber, null, user);
         final String json = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(json);
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString("signature"));
+        final byte[] signature = Base64.decode(jo.getString("signature"));
         ++signature[1];
-        jo.put("signature", DatatypeConverter.printBase64Binary(signature));
+        jo.put("signature", Base64.encode(signature));
         return new UserIdToken(ctx, jo, masterToken);
     }
     

--- a/tests/src/test/java/com/netflix/msl/crypto/JsonWebKeyTest.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/JsonWebKeyTest.java
@@ -770,7 +770,7 @@ public class JsonWebKeyTest {
     }
 
     // This unit test no longer passes because
-    // DatatypeConverter.parseBase64Binary() does not error when given invalid
+    // Base64.decode() does not error when given invalid
     // Base64 encoded data.
     @Ignore
     @Test
@@ -800,7 +800,7 @@ public class JsonWebKeyTest {
     }
     
     // This unit test no longer passes because
-    // DatatypeConverter.parseBase64Binary() does not error when given invalid
+    // Base64.decode() does not error when given invalid
     // Base64 encoded data.
     @Ignore
     @Test

--- a/tests/src/test/java/com/netflix/msl/crypto/MslCiphertextEnvelopeTest.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/MslCiphertextEnvelopeTest.java
@@ -26,8 +26,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
@@ -45,6 +43,7 @@ import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.crypto.MslCiphertextEnvelope.Version;
 import com.netflix.msl.test.ExpectedMslException;
+import com.netflix.msl.util.Base64;
 
 /**
  * MSL encryption envelope unit tests.
@@ -133,8 +132,8 @@ public class MslCiphertextEnvelopeTest {
             
             assertEquals(KEY_ID, jo.getString(KEY_KEY_ID));
             assertFalse(jo.has(KEY_CIPHERSPEC));
-            assertArrayEquals(IV, DatatypeConverter.parseBase64Binary(jo.getString(KEY_IV)));
-            assertArrayEquals(CIPHERTEXT, DatatypeConverter.parseBase64Binary(jo.getString(KEY_CIPHERTEXT)));
+            assertArrayEquals(IV, Base64.decode(jo.getString(KEY_IV)));
+            assertArrayEquals(CIPHERTEXT, Base64.decode(jo.getString(KEY_CIPHERTEXT)));
         }
 
         @Test
@@ -146,7 +145,7 @@ public class MslCiphertextEnvelopeTest {
             assertEquals(KEY_ID, jo.getString(KEY_KEY_ID));
             assertFalse(jo.has(KEY_CIPHERSPEC));
             assertFalse(jo.has(KEY_IV));
-            assertArrayEquals(CIPHERTEXT, DatatypeConverter.parseBase64Binary(jo.getString(KEY_CIPHERTEXT)));
+            assertArrayEquals(CIPHERTEXT, Base64.decode(jo.getString(KEY_CIPHERTEXT)));
         }
         
         @Test
@@ -197,10 +196,10 @@ public class MslCiphertextEnvelopeTest {
 
             final String json = envelope.toJSONString();
             final JSONObject jo = new JSONObject(json);
-            final byte[] hash = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SHA256));
+            final byte[] hash = Base64.decode(jo.getString(KEY_SHA256));
             assertNotNull(hash);
             hash[0] += 1;
-            jo.put(KEY_SHA256, DatatypeConverter.printBase64Binary(hash));
+            jo.put(KEY_SHA256, Base64.encode(hash));
 
             final MslCiphertextEnvelope joEnvelope = new MslCiphertextEnvelope(jo);
             assertEquals(KEY_ID, joEnvelope.getKeyId());
@@ -285,8 +284,8 @@ public class MslCiphertextEnvelopeTest {
             assertEquals(Version.V2.intValue(), jo.getInt(KEY_VERSION));
             assertFalse(jo.has(KEY_KEY_ID));
             assertEquals(cipherSpec.toString(), jo.getString(KEY_CIPHERSPEC));
-            assertArrayEquals(IV, DatatypeConverter.parseBase64Binary(jo.getString(KEY_IV)));
-            assertArrayEquals(CIPHERTEXT, DatatypeConverter.parseBase64Binary(jo.getString(KEY_CIPHERTEXT)));
+            assertArrayEquals(IV, Base64.decode(jo.getString(KEY_IV)));
+            assertArrayEquals(CIPHERTEXT, Base64.decode(jo.getString(KEY_CIPHERTEXT)));
         }
 
         @Test
@@ -299,7 +298,7 @@ public class MslCiphertextEnvelopeTest {
             assertFalse(jo.has(KEY_KEY_ID));
             assertEquals(cipherSpec.toString(), jo.getString(KEY_CIPHERSPEC));
             assertFalse(jo.has(KEY_IV));
-            assertArrayEquals(CIPHERTEXT, DatatypeConverter.parseBase64Binary(jo.getString(KEY_CIPHERTEXT)));
+            assertArrayEquals(CIPHERTEXT, Base64.decode(jo.getString(KEY_CIPHERTEXT)));
         }
         
         @Test

--- a/tests/src/test/java/com/netflix/msl/crypto/MslSignatureEnvelopeTest.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/MslSignatureEnvelopeTest.java
@@ -25,8 +25,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
@@ -41,6 +39,7 @@ import com.netflix.msl.MslConstants.SignatureAlgo;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.crypto.MslSignatureEnvelope.Version;
+import com.netflix.msl.util.Base64;
 
 /**
  * MSL signature envelope unit tests.
@@ -136,7 +135,7 @@ public class MslSignatureEnvelopeTest {
             
             assertEquals(Version.V2.intValue(), jo.getInt(KEY_VERSION));
             assertEquals(algorithm.toString(), jo.getString(KEY_ALGORITHM));
-            assertArrayEquals(SIGNATURE, DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE)));
+            assertArrayEquals(SIGNATURE, Base64.decode(jo.getString(KEY_SIGNATURE)));
         }
         
         @Test

--- a/tests/src/test/java/com/netflix/msl/crypto/SessionCryptoContextTest.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/SessionCryptoContextTest.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.Random;
 
 import javax.crypto.SecretKey;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -48,6 +47,7 @@ import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.entityauth.MockPresharedAuthenticationFactory;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.tokens.MasterToken;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MockMslContext;
 import com.netflix.msl.util.MslContext;
 
@@ -97,9 +97,9 @@ public class SessionCryptoContextTest {
         final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, 1L, 1L, null, identity, encryptionKey, signatureKey);
         final String json = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(json);
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString("signature"));
+        final byte[] signature = Base64.decode(jo.getString("signature"));
         ++signature[1];
-        jo.put("signature", DatatypeConverter.printBase64Binary(signature));
+        jo.put("signature", Base64.encode(signature));
         final MasterToken untrustedMasterToken = new MasterToken(ctx, jo);
         return untrustedMasterToken;
     }

--- a/tests/src/test/java/com/netflix/msl/entityauth/X509AuthenticationDataTest.java
+++ b/tests/src/test/java/com/netflix/msl/entityauth/X509AuthenticationDataTest.java
@@ -30,8 +30,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -44,6 +42,7 @@ import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslEntityAuthException;
 import com.netflix.msl.MslError;
 import com.netflix.msl.test.ExpectedMslException;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockMslContext;
 import com.netflix.msl.util.MslContext;
@@ -113,7 +112,7 @@ public class X509AuthenticationDataTest {
         assertEquals(EntityAuthenticationScheme.X509.name(), jo.getString(KEY_SCHEME));
         final JSONObject authdata = jo.getJSONObject(KEY_AUTHDATA);
         final String x509certificate = authdata.getString(KEY_X509_CERT);
-        assertArrayEquals(MockX509AuthenticationFactory.X509_CERT.getEncoded(), DatatypeConverter.parseBase64Binary(x509certificate));
+        assertArrayEquals(MockX509AuthenticationFactory.X509_CERT.getEncoded(), Base64.decode(x509certificate));
     }
     
     @Test
@@ -156,9 +155,9 @@ public class X509AuthenticationDataTest {
         final X509AuthenticationData data = new X509AuthenticationData(MockX509AuthenticationFactory.X509_CERT);
         final JSONObject authdata = data.getAuthData();
         final String x509b64 = authdata.getString(KEY_X509_CERT);
-        final byte[] x509raw = DatatypeConverter.parseBase64Binary(x509b64);
+        final byte[] x509raw = Base64.decode(x509b64);
         ++x509raw[0];
-        authdata.put(KEY_X509_CERT, DatatypeConverter.printBase64Binary(x509raw));
+        authdata.put(KEY_X509_CERT, Base64.encode(x509raw));
         new X509AuthenticationData(authdata);
     }
     

--- a/tests/src/test/java/com/netflix/msl/keyx/AsymmetricWrappedExchangeSuite.java
+++ b/tests/src/test/java/com/netflix/msl/keyx/AsymmetricWrappedExchangeSuite.java
@@ -37,7 +37,6 @@ import java.util.Date;
 import java.util.Random;
 
 import javax.crypto.SecretKey;
-import javax.xml.bind.DatatypeConverter;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
@@ -74,6 +73,7 @@ import com.netflix.msl.keyx.AsymmetricWrappedExchange.ResponseData;
 import com.netflix.msl.keyx.KeyExchangeFactory.KeyExchangeData;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.tokens.MasterToken;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockAuthenticationUtils;
 import com.netflix.msl.util.MockMslContext;
@@ -239,7 +239,7 @@ public class AsymmetricWrappedExchangeSuite {
                 final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
                 assertEquals(KEYPAIR_ID, keydata.getString(KEY_KEY_PAIR_ID));
                 assertEquals(mechanism.toString(), keydata.getString(KEY_MECHANISM));
-                assertArrayEquals(publicKey.getEncoded(), DatatypeConverter.parseBase64Binary(keydata.getString(KEY_PUBLIC_KEY)));
+                assertArrayEquals(publicKey.getEncoded(), Base64.decode(keydata.getString(KEY_PUBLIC_KEY)));
             }
 
             @Test
@@ -321,7 +321,7 @@ public class AsymmetricWrappedExchangeSuite {
 
                 final byte[] encodedKey = publicKey.getEncoded();
                 final byte[] shortKey = Arrays.copyOf(encodedKey, encodedKey.length / 2);
-                keydata.put(KEY_PUBLIC_KEY, DatatypeConverter.printBase64Binary(shortKey));
+                keydata.put(KEY_PUBLIC_KEY, Base64.encode(shortKey));
 
                 new RequestData(keydata);
             }
@@ -451,8 +451,8 @@ public class AsymmetricWrappedExchangeSuite {
             assertEquals(MASTER_TOKEN, masterToken);
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
             assertEquals(KEYPAIR_ID, keydata.getString(KEY_KEY_PAIR_ID));
-            assertArrayEquals(ENCRYPTION_KEY, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY)));
-            assertArrayEquals(HMAC_KEY, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY)));
+            assertArrayEquals(ENCRYPTION_KEY, Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY)));
+            assertArrayEquals(HMAC_KEY, Base64.decode(keydata.getString(KEY_HMAC_KEY)));
         }
         
         @Test
@@ -659,9 +659,9 @@ public class AsymmetricWrappedExchangeSuite {
             final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, 1L, 1L, null, identity, encryptionKey, hmacKey);
             final String json = masterToken.toJSONString();
             final JSONObject jo = new JSONObject(json);
-            final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString("signature"));
+            final byte[] signature = Base64.decode(jo.getString("signature"));
             ++signature[1];
-            jo.put("signature", DatatypeConverter.printBase64Binary(signature));
+            jo.put("signature", Base64.encode(signature));
             final MasterToken untrustedMasterToken = new MasterToken(ctx, jo);
             return untrustedMasterToken;
         }
@@ -820,11 +820,11 @@ public class AsymmetricWrappedExchangeSuite {
                 final MasterToken masterToken = keyResponseData.getMasterToken();
 
                 final JSONObject keydata = keyResponseData.getKeydata();
-                final byte[] wrappedEncryptionKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY));
+                final byte[] wrappedEncryptionKey = Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY));
                 // I think I have to change length - 2 because of padding.
                 ++wrappedEncryptionKey[wrappedEncryptionKey.length-2];
-                keydata.put(KEY_ENCRYPTION_KEY, DatatypeConverter.printBase64Binary(wrappedEncryptionKey));
-                final byte[] wrappedHmacKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY));
+                keydata.put(KEY_ENCRYPTION_KEY, Base64.encode(wrappedEncryptionKey));
+                final byte[] wrappedHmacKey = Base64.decode(keydata.getString(KEY_HMAC_KEY));
 
                 final KeyResponseData invalidKeyResponseData = new ResponseData(masterToken, KEYPAIR_ID, wrappedEncryptionKey, wrappedHmacKey);
                 factory.getCryptoContext(ctx, keyRequestData, invalidKeyResponseData, null);
@@ -840,11 +840,11 @@ public class AsymmetricWrappedExchangeSuite {
                 final MasterToken masterToken = keyResponseData.getMasterToken();
 
                 final JSONObject keydata = keyResponseData.getKeydata();
-                final byte[] wrappedHmacKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY));
+                final byte[] wrappedHmacKey = Base64.decode(keydata.getString(KEY_HMAC_KEY));
                 // I think I have to change length - 2 because of padding.
                 ++wrappedHmacKey[wrappedHmacKey.length-2];
-                keydata.put(KEY_HMAC_KEY, DatatypeConverter.printBase64Binary(wrappedHmacKey));
-                final byte[] wrappedEncryptionKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY));
+                keydata.put(KEY_HMAC_KEY, Base64.encode(wrappedHmacKey));
+                final byte[] wrappedEncryptionKey = Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY));
 
                 final KeyResponseData invalidKeyResponseData = new ResponseData(masterToken, KEYPAIR_ID, wrappedEncryptionKey, wrappedHmacKey);
                 factory.getCryptoContext(ctx, keyRequestData, invalidKeyResponseData, null);

--- a/tests/src/test/java/com/netflix/msl/keyx/DiffieHellmanExchangeSuite.java
+++ b/tests/src/test/java/com/netflix/msl/keyx/DiffieHellmanExchangeSuite.java
@@ -33,7 +33,6 @@ import java.util.Random;
 import javax.crypto.interfaces.DHPrivateKey;
 import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.spec.DHParameterSpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -65,6 +64,7 @@ import com.netflix.msl.keyx.DiffieHellmanExchange.ResponseData;
 import com.netflix.msl.keyx.KeyExchangeFactory.KeyExchangeData;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.tokens.MasterToken;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockAuthenticationUtils;
 import com.netflix.msl.util.MockMslContext;
@@ -183,7 +183,7 @@ public class DiffieHellmanExchangeSuite {
             assertEquals(KeyExchangeScheme.DIFFIE_HELLMAN.toString(), jo.getString(KEY_SCHEME));
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
             assertEquals(PARAMETERS_ID, keydata.getString(KEY_PARAMETERS_ID));
-            assertArrayEquals(prependNullByte(REQUEST_PUBLIC_KEY.toByteArray()), DatatypeConverter.parseBase64Binary(keydata.getString(KEY_PUBLIC_KEY)));
+            assertArrayEquals(prependNullByte(REQUEST_PUBLIC_KEY.toByteArray()), Base64.decode(keydata.getString(KEY_PUBLIC_KEY)));
         }
         
         @Test
@@ -228,7 +228,7 @@ public class DiffieHellmanExchangeSuite {
             new RequestData(keydata);
         }
         
-        // This test will not fail because DatatypeConverter.parseBase64Binary()
+        // This test will not fail because Base64.decode()
         // does not error when given invalid Base64-encoded data.
         @Ignore
         @Test
@@ -346,7 +346,7 @@ public class DiffieHellmanExchangeSuite {
             assertEquals(MASTER_TOKEN, masterToken);
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
             assertEquals(PARAMETERS_ID, keydata.getString(KEY_PARAMETERS_ID));
-            assertArrayEquals(prependNullByte(RESPONSE_PUBLIC_KEY.toByteArray()), DatatypeConverter.parseBase64Binary(keydata.getString(KEY_PUBLIC_KEY)));
+            assertArrayEquals(prependNullByte(RESPONSE_PUBLIC_KEY.toByteArray()), Base64.decode(keydata.getString(KEY_PUBLIC_KEY)));
         }
         
         @Test
@@ -391,7 +391,7 @@ public class DiffieHellmanExchangeSuite {
             new ResponseData(MASTER_TOKEN, keydata);
         }
 
-        // This test will not fail because DatatypeConverter.parseBase64Binary()
+        // This test will not fail because Base64.decode()
         // does not error when given invalid Base64-encoded data.
         @Ignore
         @Test

--- a/tests/src/test/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchangeSuite.java
+++ b/tests/src/test/java/com/netflix/msl/keyx/JsonWebEncryptionLadderExchangeSuite.java
@@ -30,7 +30,6 @@ import java.util.Random;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.json.JSONException;
@@ -74,6 +73,7 @@ import com.netflix.msl.keyx.KeyExchangeFactory.KeyExchangeData;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockAuthenticationUtils;
 import com.netflix.msl.util.MockMslContext;
@@ -204,7 +204,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
             assertEquals(Mechanism.WRAP.name(), keydata.getString(KEY_MECHANISM));
             assertFalse(keydata.has(KEY_PUBLIC_KEY));
-            assertArrayEquals(WRAPDATA, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_WRAPDATA)));
+            assertArrayEquals(WRAPDATA, Base64.decode(keydata.getString(KEY_WRAPDATA)));
         }
         
         @Test
@@ -311,7 +311,7 @@ public class JsonWebEncryptionLadderExchangeSuite {
         @Test
         public void wrapInvalidWrapdata() throws MslCryptoException, MslKeyExchangeException, MslEncodingException, JSONException {
             thrown.expect(MslKeyExchangeException.class);
-            thrown.expectMslError(MslError.KEYX_WRAPPING_KEY_MISSING);
+            thrown.expectMslError(MslError.KEYX_INVALID_WRAPPING_KEY);
 
             final RequestData req = new RequestData(Mechanism.WRAP, WRAPDATA);
             final JSONObject keydata = req.getKeydata();
@@ -410,10 +410,10 @@ public class JsonWebEncryptionLadderExchangeSuite {
             final MasterToken masterToken = new MasterToken(pskCtx, jo.getJSONObject(KEY_MASTER_TOKEN));
             assertEquals(PSK_MASTER_TOKEN, masterToken);
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
-            assertArrayEquals(PSK_ENCRYPTION_JWK, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY)));
-            assertArrayEquals(PSK_HMAC_JWK, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY)));
-            assertArrayEquals(WRAPDATA, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_WRAPDATA)));
-            assertArrayEquals(WRAP_JWK, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_WRAP_KEY)));
+            assertArrayEquals(PSK_ENCRYPTION_JWK, Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY)));
+            assertArrayEquals(PSK_HMAC_JWK, Base64.decode(keydata.getString(KEY_HMAC_KEY)));
+            assertArrayEquals(WRAPDATA, Base64.decode(keydata.getString(KEY_WRAPDATA)));
+            assertArrayEquals(WRAP_JWK, Base64.decode(keydata.getString(KEY_WRAP_KEY)));
         }
         
         @Test

--- a/tests/src/test/java/com/netflix/msl/keyx/JsonWebKeyLadderExchangeSuite.java
+++ b/tests/src/test/java/com/netflix/msl/keyx/JsonWebKeyLadderExchangeSuite.java
@@ -30,7 +30,6 @@ import java.util.Random;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.json.JSONException;
@@ -71,6 +70,7 @@ import com.netflix.msl.keyx.KeyExchangeFactory.KeyExchangeData;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.util.AuthenticationUtils;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockAuthenticationUtils;
 import com.netflix.msl.util.MockMslContext;
@@ -199,7 +199,7 @@ public class JsonWebKeyLadderExchangeSuite {
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
             assertEquals(Mechanism.WRAP.name(), keydata.getString(KEY_MECHANISM));
             assertFalse(keydata.has(KEY_PUBLIC_KEY));
-            assertArrayEquals(WRAPDATA, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_WRAPDATA)));
+            assertArrayEquals(WRAPDATA, Base64.decode(keydata.getString(KEY_WRAPDATA)));
         }
         
         @Test
@@ -306,7 +306,7 @@ public class JsonWebKeyLadderExchangeSuite {
         @Test
         public void wrapInvalidWrapdata() throws MslCryptoException, MslKeyExchangeException, MslEncodingException, JSONException {
             thrown.expect(MslKeyExchangeException.class);
-            thrown.expectMslError(MslError.KEYX_WRAPPING_KEY_MISSING);
+            thrown.expectMslError(MslError.KEYX_INVALID_WRAPDATA);
 
             final RequestData req = new RequestData(Mechanism.WRAP, WRAPDATA);
             final JSONObject keydata = req.getKeydata();
@@ -405,10 +405,10 @@ public class JsonWebKeyLadderExchangeSuite {
             final MasterToken masterToken = new MasterToken(pskCtx, jo.getJSONObject(KEY_MASTER_TOKEN));
             assertEquals(PSK_MASTER_TOKEN, masterToken);
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
-            assertArrayEquals(PSK_ENCRYPTION_JWK, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY)));
-            assertArrayEquals(PSK_HMAC_JWK, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY)));
-            assertArrayEquals(WRAPDATA, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_WRAPDATA)));
-            assertArrayEquals(WRAP_JWK, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_WRAP_KEY)));
+            assertArrayEquals(PSK_ENCRYPTION_JWK, Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY)));
+            assertArrayEquals(PSK_HMAC_JWK, Base64.decode(keydata.getString(KEY_HMAC_KEY)));
+            assertArrayEquals(WRAPDATA, Base64.decode(keydata.getString(KEY_WRAPDATA)));
+            assertArrayEquals(WRAP_JWK, Base64.decode(keydata.getString(KEY_WRAP_KEY)));
         }
         
         @Test

--- a/tests/src/test/java/com/netflix/msl/keyx/SymmetricWrappedExchangeSuite.java
+++ b/tests/src/test/java/com/netflix/msl/keyx/SymmetricWrappedExchangeSuite.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.Random;
 
 import javax.crypto.SecretKey;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -61,6 +60,7 @@ import com.netflix.msl.keyx.SymmetricWrappedExchange.RequestData;
 import com.netflix.msl.keyx.SymmetricWrappedExchange.ResponseData;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.tokens.MasterToken;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockAuthenticationUtils;
 import com.netflix.msl.util.MockMslContext;
@@ -270,8 +270,8 @@ public class SymmetricWrappedExchangeSuite {
             assertEquals(PSK_MASTER_TOKEN, masterToken);
             final JSONObject keydata = jo.getJSONObject(KEY_KEYDATA);
             assertEquals(KeyId.PSK.toString(), keydata.getString(KEY_KEY_ID));
-            assertArrayEquals(ENCRYPTION_KEY, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY)));
-            assertArrayEquals(HMAC_KEY, DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY)));
+            assertArrayEquals(ENCRYPTION_KEY, Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY)));
+            assertArrayEquals(HMAC_KEY, Base64.decode(keydata.getString(KEY_HMAC_KEY)));
         }
         
         @Test
@@ -478,9 +478,9 @@ public class SymmetricWrappedExchangeSuite {
             final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, 1L, 1L, null, identity, encryptionKey, hmacKey);
             final String json = masterToken.toJSONString();
             final JSONObject jo = new JSONObject(json);
-            final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString("signature"));
+            final byte[] signature = Base64.decode(jo.getString("signature"));
             ++signature[1];
-            jo.put("signature", DatatypeConverter.printBase64Binary(signature));
+            jo.put("signature", Base64.encode(signature));
             final MasterToken untrustedMasterToken = new MasterToken(ctx, jo);
             return untrustedMasterToken;
         }
@@ -745,10 +745,10 @@ public class SymmetricWrappedExchangeSuite {
             final MasterToken masterToken = keyResponseData.getMasterToken();
             
             final JSONObject keydata = keyResponseData.getKeydata();
-            final byte[] wrappedEncryptionKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY));
+            final byte[] wrappedEncryptionKey = Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY));
             ++wrappedEncryptionKey[wrappedEncryptionKey.length-1];
-            keydata.put(KEY_ENCRYPTION_KEY, DatatypeConverter.printBase64Binary(wrappedEncryptionKey));
-            final byte[] wrappedHmacKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY));
+            keydata.put(KEY_ENCRYPTION_KEY, Base64.encode(wrappedEncryptionKey));
+            final byte[] wrappedHmacKey = Base64.decode(keydata.getString(KEY_HMAC_KEY));
             
             final KeyResponseData invalidKeyResponseData = new ResponseData(masterToken, KeyId.PSK, wrappedEncryptionKey, wrappedHmacKey);
             factory.getCryptoContext(pskCtx, keyRequestData, invalidKeyResponseData, null);
@@ -762,10 +762,10 @@ public class SymmetricWrappedExchangeSuite {
             final MasterToken masterToken = keyResponseData.getMasterToken();
             
             final JSONObject keydata = keyResponseData.getKeydata();
-            final byte[] wrappedHmacKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_HMAC_KEY));
+            final byte[] wrappedHmacKey = Base64.decode(keydata.getString(KEY_HMAC_KEY));
             ++wrappedHmacKey[wrappedHmacKey.length-1];
-            keydata.put(KEY_HMAC_KEY, DatatypeConverter.printBase64Binary(wrappedHmacKey));
-            final byte[] wrappedEncryptionKey = DatatypeConverter.parseBase64Binary(keydata.getString(KEY_ENCRYPTION_KEY));
+            keydata.put(KEY_HMAC_KEY, Base64.encode(wrappedHmacKey));
+            final byte[] wrappedEncryptionKey = Base64.decode(keydata.getString(KEY_ENCRYPTION_KEY));
             
             final KeyResponseData invalidKeyResponseData = new ResponseData(masterToken, KeyId.PSK, wrappedEncryptionKey, wrappedHmacKey);
             factory.getCryptoContext(pskCtx, keyRequestData, invalidKeyResponseData, null);

--- a/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
@@ -34,7 +34,6 @@ import java.util.Set;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -82,6 +81,7 @@ import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.userauth.EmailPasswordAuthenticationData;
 import com.netflix.msl.userauth.MockEmailPasswordAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationData;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockMslContext;
 import com.netflix.msl.util.MslContext;
@@ -436,10 +436,10 @@ public class MessageHeaderTest {
         final JSONObject entityAuthDataJo = jo.getJSONObject(KEY_ENTITY_AUTHENTICATION_DATA);
         assertTrue(JsonUtils.equals(new JSONObject(entityAuthData.toJSONString()), entityAuthDataJo));
         assertFalse(jo.has(KEY_MASTER_TOKEN));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(jo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(jo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdata = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         assertTrue(cryptoContext.verify(ciphertext, signature));
         
         assertEquals(NON_REPLAYABLE_ID, (Long)headerdata.getLong(KEY_NON_REPLAYABLE_ID));
@@ -484,10 +484,10 @@ public class MessageHeaderTest {
         final JSONObject entityAuthDataJo = jo.getJSONObject(KEY_ENTITY_AUTHENTICATION_DATA);
         assertTrue(JsonUtils.equals(new JSONObject(entityAuthData.toJSONString()), entityAuthDataJo));
         assertFalse(jo.has(KEY_MASTER_TOKEN));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(jo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(jo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdata = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         assertTrue(cryptoContext.verify(ciphertext, signature));
         
         assertFalse(headerdata.has(KEY_NON_REPLAYABLE_ID));
@@ -609,10 +609,10 @@ public class MessageHeaderTest {
         final JSONObject entityAuthDataJo = jo.getJSONObject(KEY_ENTITY_AUTHENTICATION_DATA);
         assertTrue(JsonUtils.equals(new JSONObject(entityAuthData.toJSONString()), entityAuthDataJo));
         assertFalse(jo.has(KEY_MASTER_TOKEN));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(jo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(jo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdata = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         assertTrue(cryptoContext.verify(ciphertext, signature));
         
         assertEquals(NON_REPLAYABLE_ID, (Long)headerdata.getLong(KEY_NON_REPLAYABLE_ID));
@@ -658,10 +658,10 @@ public class MessageHeaderTest {
         final JSONObject entityAuthDataJo = jo.getJSONObject(KEY_ENTITY_AUTHENTICATION_DATA);
         assertTrue(JsonUtils.equals(new JSONObject(entityAuthData.toJSONString()), entityAuthDataJo));
         assertFalse(jo.has(KEY_MASTER_TOKEN));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(jo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(jo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdata = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         assertTrue(cryptoContext.verify(ciphertext, signature));
         
         assertFalse(headerdata.has(KEY_NON_REPLAYABLE_ID));
@@ -740,10 +740,10 @@ public class MessageHeaderTest {
         assertFalse(jo.has(KEY_ENTITY_AUTHENTICATION_DATA));
         final JSONObject masterToken = jo.getJSONObject(KEY_MASTER_TOKEN);
         assertTrue(JsonUtils.equals(new JSONObject(MASTER_TOKEN.toJSONString()), masterToken));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(jo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(jo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdata = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         assertTrue(cryptoContext.verify(ciphertext, signature));
         
         assertEquals(NON_REPLAYABLE_ID, (Long)headerdata.getLong(KEY_NON_REPLAYABLE_ID));
@@ -830,10 +830,10 @@ public class MessageHeaderTest {
         assertFalse(jo.has(KEY_ENTITY_AUTHENTICATION_DATA));
         final JSONObject masterToken = jo.getJSONObject(KEY_MASTER_TOKEN);
         assertTrue(JsonUtils.equals(new JSONObject(MASTER_TOKEN.toJSONString()), masterToken));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(jo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(jo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdata = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         assertTrue(cryptoContext.verify(ciphertext, signature));
         
         assertEquals(NON_REPLAYABLE_ID, (Long)headerdata.getLong(KEY_NON_REPLAYABLE_ID));
@@ -1737,7 +1737,7 @@ public class MessageHeaderTest {
     @Test
     public void invalidHeaderDataParseHeader() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslKeyExchangeException, MslUserAuthException, MslException, JSONException {
         thrown.expect(MslMessageException.class);
-        thrown.expectMslError(MslError.HEADER_DATA_MISSING);
+        thrown.expectMslError(MslError.HEADER_DATA_INVALID);
 
         final HeaderDataBuilder builder = new HeaderDataBuilder(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, false);
         final HeaderData headerData = builder.build();
@@ -1763,9 +1763,9 @@ public class MessageHeaderTest {
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, MASTER_TOKEN, headerData, peerData);
         final JSONObject messageHeaderJo = new JSONObject(messageHeader.toJSONString());
         
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         ++ciphertext[0];
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(ciphertext));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(ciphertext));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -1829,7 +1829,7 @@ public class MessageHeaderTest {
         final EntityAuthenticationScheme scheme = entityAuthData.getScheme();
         final EntityAuthenticationFactory factory = p2pCtx.getEntityAuthenticationFactory(scheme);
         final ICryptoContext cryptoContext = factory.getCryptoContext(p2pCtx, entityAuthData);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -1838,11 +1838,11 @@ public class MessageHeaderTest {
         headerdataJo.put(KEY_SERVICE_TOKENS, new JSONArray());
         headerdataJo.put(KEY_PEER_SERVICE_TOKENS, new JSONArray());
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         final Header header = Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
         assertNotNull(header);
@@ -1930,7 +1930,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -1939,11 +1939,11 @@ public class MessageHeaderTest {
         headerdataJo.put(KEY_SERVICE_TOKENS, new JSONArray());
         headerdataJo.put(KEY_PEER_SERVICE_TOKENS, new JSONArray());
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         final Header header = Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
         assertNotNull(header);
@@ -1999,7 +1999,7 @@ public class MessageHeaderTest {
         final EntityAuthenticationScheme scheme = entityAuthData.getScheme();
         final EntityAuthenticationFactory factory = trustedNetCtx.getEntityAuthenticationFactory(scheme);
         final ICryptoContext cryptoContext = factory.getCryptoContext(trustedNetCtx, entityAuthData);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2007,11 +2007,11 @@ public class MessageHeaderTest {
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER);
         headerdataJo.put(KEY_USER_ID_TOKEN, userIdToken);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2031,7 +2031,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2039,11 +2039,11 @@ public class MessageHeaderTest {
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, PEER_MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER);
         headerdataJo.put(KEY_USER_ID_TOKEN, userIdToken);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2065,7 +2065,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2073,11 +2073,11 @@ public class MessageHeaderTest {
         final UserAuthenticationData userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL_2, MockEmailPasswordAuthenticationFactory.PASSWORD_2);
         headerdataJo.put(KEY_USER_AUTHENTICATION_DATA, userAuthData);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2098,18 +2098,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_PEER_MASTER_TOKEN));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2127,18 +2127,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_PEER_MASTER_TOKEN, MASTER_TOKEN);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2158,7 +2158,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2167,11 +2167,11 @@ public class MessageHeaderTest {
         serviceTokens.addAll(MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, null));
         headerdataJo.put(KEY_SERVICE_TOKENS, JsonUtils.createArray(serviceTokens));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2191,7 +2191,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2201,11 +2201,11 @@ public class MessageHeaderTest {
         serviceTokens.addAll(MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, userIdToken));
         headerdataJo.put(KEY_SERVICE_TOKENS, JsonUtils.createArray(serviceTokens));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2226,18 +2226,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_PEER_MASTER_TOKEN));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2258,18 +2258,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_PEER_MASTER_TOKEN, MASTER_TOKEN);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2290,7 +2290,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2298,11 +2298,11 @@ public class MessageHeaderTest {
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(p2pCtx, PEER_MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
         headerdataJo.put(KEY_PEER_USER_ID_TOKEN, userIdToken);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2348,18 +2348,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_SENDER));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2377,18 +2377,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_TIMESTAMP));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2409,18 +2409,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_TIMESTAMP, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2441,18 +2441,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_MESSAGE_ID));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2473,18 +2473,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_MESSAGE_ID, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2527,18 +2527,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_MESSAGE_ID, -1);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2559,18 +2559,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_MESSAGE_ID, MslConstants.MAX_LONG_VALUE + 1);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2592,18 +2592,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_NON_REPLAYABLE_ID, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2625,18 +2625,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_RENEWABLE));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2658,18 +2658,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_RENEWABLE, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2693,18 +2693,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataJo.remove(KEY_HANDSHAKE));
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         // FIXME For now a missing handshake flag will result in a false value.
         final Header header = Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
@@ -2730,18 +2730,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_HANDSHAKE, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2763,18 +2763,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_CAPABILITIES, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2795,18 +2795,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_KEY_REQUEST_DATA, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2827,7 +2827,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2836,11 +2836,11 @@ public class MessageHeaderTest {
         a.put("x");
         headerdataJo.put(KEY_PEER_SERVICE_TOKENS, a);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2861,18 +2861,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_SERVICE_TOKENS, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2893,7 +2893,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2902,11 +2902,11 @@ public class MessageHeaderTest {
         a.put("x");
         headerdataJo.put(KEY_SERVICE_TOKENS, a);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2927,18 +2927,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_PEER_SERVICE_TOKENS, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2959,7 +2959,7 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -2968,11 +2968,11 @@ public class MessageHeaderTest {
         a.put("x");
         headerdataJo.put(KEY_PEER_SERVICE_TOKENS, a);
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -2993,18 +2993,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_PEER_MASTER_TOKEN, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -3025,18 +3025,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_PEER_USER_ID_TOKEN, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }
@@ -3057,18 +3057,18 @@ public class MessageHeaderTest {
         
         // Before modifying the header data we need to decrypt it.
         final ICryptoContext cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(messageHeaderJo.getString(KEY_HEADERDATA));
+        final byte[] ciphertext = Base64.decode(messageHeaderJo.getString(KEY_HEADERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject headerdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the header data we need to encrypt it.
         headerdataJo.put(KEY_USER_AUTHENTICATION_DATA, "x");
         final byte[] headerdata = cryptoContext.encrypt(headerdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        messageHeaderJo.put(KEY_HEADERDATA, DatatypeConverter.printBase64Binary(headerdata));
+        messageHeaderJo.put(KEY_HEADERDATA, Base64.encode(headerdata));
         
         // The header data must be signed or it will not be processed.
         final byte[] signature = cryptoContext.sign(headerdata);
-        messageHeaderJo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        messageHeaderJo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         Header.parseHeader(p2pCtx, messageHeaderJo, CRYPTO_CONTEXTS);
     }

--- a/tests/src/test/java/com/netflix/msl/tokens/MasterTokenTest.java
+++ b/tests/src/test/java/com/netflix/msl/tokens/MasterTokenTest.java
@@ -26,7 +26,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.Date;
 
 import javax.crypto.SecretKey;
-import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -46,6 +45,7 @@ import com.netflix.msl.crypto.JcaAlgorithm;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.entityauth.MockPresharedAuthenticationFactory;
 import com.netflix.msl.test.ExpectedMslException;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockMslContext;
 import com.netflix.msl.util.MslContext;
@@ -208,11 +208,11 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_EXPIRATION, System.currentTimeMillis() / MILLISECONDS_PER_SECOND - 1);
         tokendataJo.put(KEY_RENEWAL_WINDOW, System.currentTimeMillis() / MILLISECONDS_PER_SECOND);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -249,9 +249,9 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         ++tokendata[0];
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendata));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendata));
         
         new MasterToken(ctx, jo);
     }
@@ -279,10 +279,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_RENEWAL_WINDOW));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -296,10 +296,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_RENEWAL_WINDOW, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -313,10 +313,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_EXPIRATION));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -330,10 +330,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_EXPIRATION, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -347,10 +347,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_SEQUENCE_NUMBER));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -364,10 +364,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SEQUENCE_NUMBER, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -381,10 +381,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SEQUENCE_NUMBER, -1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -398,10 +398,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SEQUENCE_NUMBER, MslConstants.MAX_LONG_VALUE + 1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -415,10 +415,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_SERIAL_NUMBER));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -432,10 +432,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERIAL_NUMBER, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -449,10 +449,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERIAL_NUMBER, -1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -466,10 +466,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERIAL_NUMBER, MslConstants.MAX_LONG_VALUE + 1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -483,10 +483,10 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_SESSIONDATA));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new MasterToken(ctx, jo);
     }
@@ -494,21 +494,21 @@ public class MasterTokenTest {
     @Test
     public void invalidSessiondata() throws UnsupportedEncodingException, JSONException, MslException {
         thrown.expect(MslException.class);
-        thrown.expectMslError(MslError.MASTERTOKEN_SESSIONDATA_MISSING);
+        thrown.expectMslError(MslError.MASTERTOKEN_SESSIONDATA_INVALID);
 
         final MasterToken masterToken = new MasterToken(ctx, RENEWAL_WINDOW, EXPIRATION, SEQUENCE_NUMBER, SERIAL_NUMBER, ISSUER_DATA, IDENTITY, ENCRYPTION_KEY, SIGNATURE_KEY);
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SESSIONDATA, "x");
         
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -522,16 +522,16 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         final byte[] ciphertext = new byte[0];
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(ciphertext));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(ciphertext));
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -543,17 +543,17 @@ public class MasterTokenTest {
         final JSONObject jo = new JSONObject(jsonString);
         
         // This is testing session data that is verified but corrupt.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] sessiondata = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] sessiondata = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         ++sessiondata[sessiondata.length-1];
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -564,9 +564,9 @@ public class MasterTokenTest {
         final String jsonString = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         ++signature[0];
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         final MasterToken joMasterToken = new MasterToken(ctx, jo);
         assertFalse(joMasterToken.isDecrypted());
@@ -600,23 +600,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         sessiondataJo.put(KEY_ISSUER_DATA, "x");
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -633,23 +633,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         assertNotNull(sessiondataJo.remove(KEY_IDENTITY));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -666,23 +666,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         assertNotNull(sessiondataJo.remove(KEY_ENCRYPTION_KEY));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -699,23 +699,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         sessiondataJo.put(KEY_ENCRYPTION_KEY, "");
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -729,23 +729,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         assertNotNull(sessiondataJo.remove(KEY_ENCRYPTION_ALGORITHM));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         // Confirm default algorithm.
         final MasterToken joMasterToken = new MasterToken(ctx, jo);
@@ -765,23 +765,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         sessiondataJo.put(KEY_ENCRYPTION_ALGORITHM, "x");
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -795,23 +795,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         assertNotNull(sessiondataJo.remove(KEY_HMAC_KEY));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         // Confirm signature key.
         final MasterToken joMasterToken = new MasterToken(ctx, jo);
@@ -828,23 +828,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         assertNotNull(sessiondataJo.remove(KEY_SIGNATURE_KEY));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         // Confirm signature key.
         final MasterToken joMasterToken = new MasterToken(ctx, jo);
@@ -861,23 +861,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         assertNotNull(sessiondataJo.remove(KEY_SIGNATURE_ALGORITHM));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         // Confirm default algorithm.
         final MasterToken joMasterToken = new MasterToken(ctx, jo);
@@ -897,23 +897,23 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the session data we need to encrypt it.
         sessiondataJo.put(KEY_SIGNATURE_ALGORITHM, "x");
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -930,9 +930,9 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -940,14 +940,14 @@ public class MasterTokenTest {
         assertNotNull(sessiondataJo.remove(KEY_HMAC_KEY));
         assertNotNull(sessiondataJo.remove(KEY_SIGNATURE_KEY));
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -964,9 +964,9 @@ public class MasterTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         
         // Before modifying the session data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SESSIONDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_SESSIONDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject sessiondataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
@@ -974,14 +974,14 @@ public class MasterTokenTest {
         sessiondataJo.put(KEY_HMAC_KEY, "");
         sessiondataJo.put(KEY_SIGNATURE_KEY, "");
         final byte[] sessiondata = cryptoContext.encrypt(sessiondataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_SESSIONDATA, DatatypeConverter.printBase64Binary(sessiondata));
+        tokendataJo.put(KEY_SESSIONDATA, Base64.encode(sessiondata));
         
         // The tokendata must be signed otherwise the session data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new MasterToken(ctx, jo);
     }
@@ -1123,9 +1123,9 @@ public class MasterTokenTest {
         
         final String json = masterToken.toJSONString();
         final JSONObject jo = new JSONObject(json);
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString("signature"));
+        final byte[] signature = Base64.decode(jo.getString("signature"));
         ++signature[1];
-        jo.put("signature", DatatypeConverter.printBase64Binary(signature));
+        jo.put("signature", Base64.encode(signature));
         final MasterToken untrustedMasterToken = new MasterToken(ctx, jo);
         
         assertTrue(masterToken.equals(untrustedMasterToken));

--- a/tests/src/test/java/com/netflix/msl/tokens/ServiceTokenTest.java
+++ b/tests/src/test/java/com/netflix/msl/tokens/ServiceTokenTest.java
@@ -31,8 +31,8 @@ import java.util.Random;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
+import org.bouncycastle.crypto.CryptoException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -57,6 +57,7 @@ import com.netflix.msl.crypto.SymmetricCryptoContext;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.userauth.MockEmailPasswordAuthenticationFactory;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.MockMslContext;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslTestUtils;
@@ -143,7 +144,7 @@ public class ServiceTokenTest {
     }
     
     /** Compression algorithm. */
-    private CompressionAlgorithm compressionAlgo;
+    private final CompressionAlgorithm compressionAlgo;
     
     /**
      * Create a new master token test instance.
@@ -362,9 +363,9 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         ++tokendata[0];
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendata));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendata));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -392,10 +393,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_NAME));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -406,10 +407,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_MASTER_TOKEN_SERIAL_NUMBER));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         final ServiceToken joServiceToken = new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
         assertEquals(-1, joServiceToken.getMasterTokenSerialNumber());
@@ -425,10 +426,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -442,10 +443,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, -1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -459,10 +460,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, MslConstants.MAX_LONG_VALUE + 1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -473,10 +474,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_USER_ID_TOKEN_SERIAL_NUMBER));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         final ServiceToken joServiceToken = new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
         assertEquals(-1, joServiceToken.getUserIdTokenSerialNumber());
@@ -492,10 +493,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_USER_ID_TOKEN_SERIAL_NUMBER, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -509,10 +510,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_USER_ID_TOKEN_SERIAL_NUMBER, -1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -526,10 +527,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_USER_ID_TOKEN_SERIAL_NUMBER, MslConstants.MAX_LONG_VALUE + 1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -543,10 +544,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_ENCRYPTED));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -560,10 +561,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_ENCRYPTED, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -577,10 +578,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_COMPRESSION_ALGORITHM, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -594,10 +595,10 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_SERVICEDATA));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -614,14 +615,14 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERVICEDATA, "x");
         
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = CRYPTO_CONTEXT.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -644,9 +645,9 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         ++signature[0];
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         final ServiceToken joServiceToken = new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
         assertTrue(joServiceToken.isDeleted());
@@ -660,16 +661,16 @@ public class ServiceTokenTest {
         final JSONObject jo = new JSONObject(jsonString);
         
         // This is testing service data that is verified but corrupt.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] servicedata = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_SERVICEDATA));
+        final byte[] servicedata = Base64.decode(tokendataJo.getString(KEY_SERVICEDATA));
         ++servicedata[servicedata.length-1];
-        tokendataJo.put(KEY_SERVICEDATA, DatatypeConverter.printBase64Binary(servicedata));
+        tokendataJo.put(KEY_SERVICEDATA, Base64.encode(servicedata));
         
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = CRYPTO_CONTEXT.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
     }
@@ -680,9 +681,9 @@ public class ServiceTokenTest {
         final String jsonString = serviceToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         ++signature[0];
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         final ServiceToken joServiceToken = new ServiceToken(ctx, jo, MASTER_TOKEN, USER_ID_TOKEN, CRYPTO_CONTEXT);
         assertFalse(joServiceToken.isDecrypted());

--- a/tests/src/test/java/com/netflix/msl/tokens/UserIdTokenTest.java
+++ b/tests/src/test/java/com/netflix/msl/tokens/UserIdTokenTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.UnsupportedEncodingException;
 import java.util.Date;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -42,6 +40,7 @@ import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.test.ExpectedMslException;
 import com.netflix.msl.userauth.MockEmailPasswordAuthenticationFactory;
+import com.netflix.msl.util.Base64;
 import com.netflix.msl.util.JsonUtils;
 import com.netflix.msl.util.MockMslContext;
 import com.netflix.msl.util.MslContext;
@@ -196,11 +195,11 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_EXPIRATION, System.currentTimeMillis() / MILLISECONDS_PER_SECOND - 1);
         tokendataJo.put(KEY_RENEWAL_WINDOW, System.currentTimeMillis() / MILLISECONDS_PER_SECOND);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -225,9 +224,9 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
         
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         ++tokendata[0];
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendata));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendata));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -255,10 +254,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_RENEWAL_WINDOW));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -272,10 +271,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_RENEWAL_WINDOW, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -289,10 +288,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_EXPIRATION));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -306,10 +305,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_EXPIRATION, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -323,10 +322,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_SERIAL_NUMBER));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -340,10 +339,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERIAL_NUMBER, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -357,10 +356,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERIAL_NUMBER, -1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -374,10 +373,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_SERIAL_NUMBER, MslConstants.MAX_LONG_VALUE + 1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -391,10 +390,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_MASTER_TOKEN_SERIAL_NUMBER));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -408,10 +407,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, "x");
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -425,10 +424,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, -1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -442,10 +441,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, MslConstants.MAX_LONG_VALUE + 1);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -459,10 +458,10 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         assertNotNull(tokendataJo.remove(KEY_USERDATA));
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(tokendataJo.toString().getBytes()));
+        jo.put(KEY_TOKENDATA, Base64.encode(tokendataJo.toString().getBytes()));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -470,21 +469,21 @@ public class UserIdTokenTest {
     @Test
     public void invalidUserdata() throws MslEncodingException, MslCryptoException, MslException, UnsupportedEncodingException, JSONException {
         thrown.expect(MslException.class);
-        thrown.expectMslError(MslError.USERIDTOKEN_USERDATA_MISSING);
+        thrown.expectMslError(MslError.USERIDTOKEN_USERDATA_INVALID);
 
         final UserIdToken userIdToken = new UserIdToken(ctx, RENEWAL_WINDOW, EXPIRATION, MASTER_TOKEN, SERIAL_NUMBER, ISSUER_DATA, USER);
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
         tokendataJo.put(KEY_USERDATA, "x");
         
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -498,16 +497,16 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
 
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         final byte[] ciphertext = new byte[0];
-        tokendataJo.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(ciphertext));
+        tokendataJo.put(KEY_USERDATA, Base64.encode(ciphertext));
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -519,17 +518,17 @@ public class UserIdTokenTest {
         final JSONObject jo = new JSONObject(jsonString);
 
         // This is testing user data that is verified but corrupt.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] userdata = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_USERDATA));
+        final byte[] userdata = Base64.decode(tokendataJo.getString(KEY_USERDATA));
         ++userdata[userdata.length-1];
-        tokendataJo.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(userdata));
+        tokendataJo.put(KEY_USERDATA, Base64.encode(userdata));
         
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -546,23 +545,23 @@ public class UserIdTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
 
         // Before modifying the user data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_USERDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_USERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject userdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the user data we need to encrypt it.
         userdataJo.put(KEY_IDENTITY, "x");
         final byte[] userdata = cryptoContext.encrypt(userdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(userdata));
+        tokendataJo.put(KEY_USERDATA, Base64.encode(userdata));
 
         // The tokendata must be signed otherwise the user data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -579,23 +578,23 @@ public class UserIdTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
 
         // Before modifying the user data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_USERDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_USERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject userdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the user data we need to encrypt it.
         userdataJo.put(KEY_IDENTITY, "");
         final byte[] userdata = cryptoContext.encrypt(userdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(userdata));
+        tokendataJo.put(KEY_USERDATA, Base64.encode(userdata));
 
         // The tokendata must be signed otherwise the user data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -612,23 +611,23 @@ public class UserIdTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
 
         // Before modifying the user data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_USERDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_USERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject userdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the user data we need to encrypt it.
         userdataJo.remove(KEY_IDENTITY);
         final byte[] userdata = cryptoContext.encrypt(userdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(userdata));
+        tokendataJo.put(KEY_USERDATA, Base64.encode(userdata));
 
         // The tokendata must be signed otherwise the user data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -645,23 +644,23 @@ public class UserIdTokenTest {
         final ICryptoContext cryptoContext = ctx.getMslCryptoContext();
 
         // Before modifying the user data we need to decrypt it.
-        final byte[] tokendata = DatatypeConverter.parseBase64Binary(jo.getString(KEY_TOKENDATA));
+        final byte[] tokendata = Base64.decode(jo.getString(KEY_TOKENDATA));
         final JSONObject tokendataJo = new JSONObject(new String(tokendata, MslConstants.DEFAULT_CHARSET));
-        final byte[] ciphertext = DatatypeConverter.parseBase64Binary(tokendataJo.getString(KEY_USERDATA));
+        final byte[] ciphertext = Base64.decode(tokendataJo.getString(KEY_USERDATA));
         final byte[] plaintext = cryptoContext.decrypt(ciphertext);
         final JSONObject userdataJo = new JSONObject(new String(plaintext, MslConstants.DEFAULT_CHARSET));
         
         // After modifying the user data we need to encrypt it.
         userdataJo.put(KEY_ISSUER_DATA, "x");
         final byte[] userdata = cryptoContext.encrypt(userdataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET));
-        tokendataJo.put(KEY_USERDATA, DatatypeConverter.printBase64Binary(userdata));
+        tokendataJo.put(KEY_USERDATA, Base64.encode(userdata));
 
         // The tokendata must be signed otherwise the user data will not be
         // processed.
         final byte[] modifiedTokendata = tokendataJo.toString().getBytes(MslConstants.DEFAULT_CHARSET);
         final byte[] signature = cryptoContext.sign(modifiedTokendata);
-        jo.put(KEY_TOKENDATA, DatatypeConverter.printBase64Binary(modifiedTokendata));
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_TOKENDATA, Base64.encode(modifiedTokendata));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         new UserIdToken(ctx, jo, MASTER_TOKEN);
     }
@@ -672,9 +671,9 @@ public class UserIdTokenTest {
         final String jsonString = userIdToken.toJSONString();
         final JSONObject jo = new JSONObject(jsonString);
 
-        final byte[] signature = DatatypeConverter.parseBase64Binary(jo.getString(KEY_SIGNATURE));
+        final byte[] signature = Base64.decode(jo.getString(KEY_SIGNATURE));
         ++signature[0];
-        jo.put(KEY_SIGNATURE, DatatypeConverter.printBase64Binary(signature));
+        jo.put(KEY_SIGNATURE, Base64.encode(signature));
         
         final UserIdToken joUserIdToken = new UserIdToken(ctx, jo, MASTER_TOKEN);
         assertFalse(joUserIdToken.isDecrypted());

--- a/tests/src/test/java/com/netflix/msl/util/Base64Test.java
+++ b/tests/src/test/java/com/netflix/msl/util/Base64Test.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+
+/**
+ * Base64 tests.
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class Base64Test {
+    /** UTF-8 charset. */
+    private static final Charset CHARSET = Charset.forName("utf-8");
+    
+    /** Standard Base64 examples. */
+    private static final Object[][] EXAMPLES = {
+        { "The long winded author is going for a walk while the light breeze bellows in his ears.".getBytes(CHARSET),
+          "VGhlIGxvbmcgd2luZGVkIGF1dGhvciBpcyBnb2luZyBmb3IgYSB3YWxrIHdoaWxlIHRoZSBsaWdodCBicmVlemUgYmVsbG93cyBpbiBoaXMgZWFycy4=" },
+        { "Sometimes porcupines need beds to sleep on.".getBytes(CHARSET),
+          "U29tZXRpbWVzIHBvcmN1cGluZXMgbmVlZCBiZWRzIHRvIHNsZWVwIG9uLg==" },
+        { "Even the restless dreamer enjoys home-cooked foods.".getBytes(CHARSET),
+          "RXZlbiB0aGUgcmVzdGxlc3MgZHJlYW1lciBlbmpveXMgaG9tZS1jb29rZWQgZm9vZHMu" },
+    };
+    
+    @Test
+    public void standard() {
+        for (int i = 0; i < EXAMPLES.length; ++i) {
+            final Object[] example = EXAMPLES[i];
+            final byte[] data = (byte[])example[0];
+            final String base64 = (String)example[1];
+            final String encoded = Base64.encode(data);
+            final byte[] decoded = Base64.decode(base64);
+            assertEquals(base64, encoded);
+            assertArrayEquals(data, decoded);
+        }
+    }
+}

--- a/tests/src/test/java/com/netflix/msl/util/JsonUtilsTest.java
+++ b/tests/src/test/java/com/netflix/msl/util/JsonUtilsTest.java
@@ -70,7 +70,7 @@ public class JsonUtilsTest {
     private static final String randomString(final Random random) {
         final byte[] raw = new byte[random.nextInt(MAX_STRING_CHARS) + 1];
         random.nextBytes(raw);
-        return DatatypeConverter.printBase64Binary(raw);
+        return Base64.encode(raw);
     }
     
     /**

--- a/tests/src/test/javascript/keyx/JsonWebKeyLadderExchangeSuite.js
+++ b/tests/src/test/javascript/keyx/JsonWebKeyLadderExchangeSuite.js
@@ -384,7 +384,7 @@ if (mslCrypto$version != MslCrypto$WebCryptoVersion.LEGACY) {
 
                 RequestData$parse(keydata);
             };
-            expect(f).toThrow(new MslKeyExchangeException(MslError.KEYX_WRAPPING_KEY_MISSING));
+            expect(f).toThrow(new MslKeyExchangeException(MslError.KEYX_INVALID_WRAPDATA));
         });
         
         it("equals mechanism", function() {

--- a/tests/src/test/javascript/msg/ErrorHeaderTest.js
+++ b/tests/src/test/javascript/msg/ErrorHeaderTest.js
@@ -631,7 +631,7 @@ describe("ErrorHeader", function() {
 	        //
 	        // This differs from the Java unit tests because we cannot sign
 	        // empty ciphertext.
-	        errorHeaderJo[KEY_ERRORDATA] = base64$encode("x");
+	        errorHeaderJo[KEY_ERRORDATA] = "AA==";
 	        var ciphertext = base64$decode(errorHeaderJo[KEY_ERRORDATA]);
 	        cryptoContext.sign(ciphertext, {
 	        	result: function(signature) {

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -270,7 +270,7 @@ describe("MessageHeader", function() {
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
             });
-            waitsFor(function() { return trustedNetCtx && p2pCtx; }, "trustedNetCtx and p2pCtx", 100);
+            waitsFor(function() { return trustedNetCtx && p2pCtx; }, "trustedNetCtx and p2pCtx", 900);
             
 			runs(function() {
 				MslTestUtils.getMasterToken(trustedNetCtx, 1, 1, {
@@ -2970,7 +2970,7 @@ describe("MessageHeader", function() {
 		var exception;
 		runs(function() {
             var messageHeaderJo = JSON.parse(JSON.stringify(messageHeader));
-            messageHeaderJo[KEY_HEADERDATA] = "";
+            messageHeaderJo[KEY_HEADERDATA] = "x";
 			Header$parseHeader(trustedNetCtx, messageHeaderJo, CRYPTO_CONTEXTS, {
 				result: function() {},
 				error: function(err) { exception = err; },
@@ -2979,7 +2979,7 @@ describe("MessageHeader", function() {
 		waitsFor(function() { return exception; }, "exception not received", 100);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslMessageException(MslError.HEADER_DATA_MISSING));
+			expect(f).toThrow(new MslMessageException(MslError.HEADER_DATA_INVALID));
 		});
 	});
 

--- a/tests/src/test/javascript/msg/PayloadChunkTest.js
+++ b/tests/src/test/javascript/msg/PayloadChunkTest.js
@@ -91,7 +91,7 @@ describe("PayloadChunk", function() {
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
             });
-            waitsFor(function() { return ctx; }, "ctx", 100);
+            waitsFor(function() { return ctx; }, "ctx", 900);
 
             runs(function () {
                 var encryptionBytes = new Uint8Array(16);
@@ -648,7 +648,7 @@ describe("PayloadChunk", function() {
         runs(function() {
 	        var jo = JSON.parse(JSON.stringify(chunk));
 	
-	        jo[KEY_PAYLOAD] = "AAA=";
+	        jo[KEY_PAYLOAD] = "x";
 	
 	        PayloadChunk$parse(jo, CRYPTO_CONTEXT, {
 	        	result: function() {},
@@ -658,7 +658,7 @@ describe("PayloadChunk", function() {
         waitsFor(function() { return exception; }, "exception not received", 100);
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslCryptoException(MslError.PAYLOAD_VERIFICATION_FAILED));
+            expect(f).toThrow(new MslMessageException(MslError.PAYLOAD_INVALID));
         });
     });
     

--- a/tests/src/test/javascript/tokens/MasterTokenTest.js
+++ b/tests/src/test/javascript/tokens/MasterTokenTest.js
@@ -835,7 +835,7 @@ describe("MasterToken", function() {
 	        
 	        var tokendata = base64$decode(jo[KEY_TOKENDATA]);
 	        var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
-	        tokendataJo[KEY_SESSIONDATA] = "";
+	        tokendataJo[KEY_SESSIONDATA] = "x";
 	        
 	        var cryptoContext = ctx.getMslCryptoContext();
 	        var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
@@ -855,7 +855,7 @@ describe("MasterToken", function() {
         waitsFor(function() { return exception; }, "exception not received", 500);
     	runs(function() {
     	    var f = function() { throw exception; };
-    	    expect(f).toThrow(new MslException(MslError.MASTERTOKEN_SESSIONDATA_MISSING));
+    	    expect(f).toThrow(new MslException(MslError.MASTERTOKEN_SESSIONDATA_INVALID));
     	});
     });
     

--- a/tests/src/test/javascript/tokens/UserIdTokenTest.js
+++ b/tests/src/test/javascript/tokens/UserIdTokenTest.js
@@ -831,7 +831,7 @@ describe("UserIdToken", function() {
 	
 	        var tokendata = base64$decode(jo[KEY_TOKENDATA]);
 	        var tokendataJo = JSON.parse(textEncoding$getString(tokendata, MslConstants$DEFAULT_CHARSET));
-	        tokendataJo[KEY_USERDATA] = "";
+	        tokendataJo[KEY_USERDATA] = "x";
 	        
 	        var cryptoContext = ctx.getMslCryptoContext();
 	        var modifiedTokendata = textEncoding$getBytes(JSON.stringify(tokendataJo), MslConstants$DEFAULT_CHARSET);
@@ -851,7 +851,7 @@ describe("UserIdToken", function() {
     	waitsFor(function() { return exception; }, "exception not received", 100);
 	    runs(function() {
 	        var f = function() { throw exception; };
-	        expect(f).toThrow(new MslException(MslError.USERIDTOKEN_USERDATA_MISSING));
+	        expect(f).toThrow(new MslException(MslError.USERIDTOKEN_USERDATA_INVALID));
 	    });
     });
     


### PR DESCRIPTION
* Create Base64 abstraction in Java code base, with a default implementation based on DatatypeConverter.
* Restore Base64 encoding validity check, in sync with the JavaScript implementation (which now also has an improved regex).
* Update unit tests to match Base64 encoding validity checks.

This allows the MSL code to be used in JREs that do not include DatatypeConverter.