### PR TITLE
Allow whitespace in Base64 encoded strings.

### DIFF
--- a/core/src/main/java/com/netflix/msl/util/Base64.java
+++ b/core/src/main/java/com/netflix/msl/util/Base64.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.msl.util;
 
+import java.util.regex.Pattern;
+
 /**
  * <p>Base64 encoder/decoder. Can be configured with a backing
  * implementation.</p>
@@ -22,19 +24,23 @@ package com.netflix.msl.util;
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class Base64 {
+    /** Whitespace regular expression. */
+    private static final String WHITESPACE_REGEX = "\\s";
     /** Base64 validation regular expression. */
-    private static final String VALID_REGEXP = "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$";
+    private static final Pattern BASE64_PATTERN = Pattern.compile("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$");
+    
     
     /**
      * <p>Validates that a string is a valid Base64 encoding. This uses a
      * regular expression to perform the check. The empty string is also
-     * considered valid.</p>
+     * considered valid. All whitespace is ignored.</p>
      * 
      * @param s the string to validate.
      * @return true if the string is a valid Base64 encoding.
      */
     public static boolean isValidBase64(final String s) {
-        return s.matches(VALID_REGEXP);
+        final String sanitized = s.replaceAll(WHITESPACE_REGEX, "");
+        return BASE64_PATTERN.matcher(sanitized).matches();
     }
     
     /**

--- a/tests/src/test/java/com/netflix/msl/util/Base64Test.java
+++ b/tests/src/test/java/com/netflix/msl/util/Base64Test.java
@@ -44,11 +44,38 @@ public class Base64Test {
     @Test
     public void standard() {
         for (int i = 0; i < EXAMPLES.length; ++i) {
+            // Prepare.
             final Object[] example = EXAMPLES[i];
             final byte[] data = (byte[])example[0];
             final String base64 = (String)example[1];
+            
+            // Encode/decode.
             final String encoded = Base64.encode(data);
             final byte[] decoded = Base64.decode(base64);
+            
+            // Validate.
+            assertEquals(base64, encoded);
+            assertArrayEquals(data, decoded);
+        }
+    }
+    
+    @Test
+    public void whitespace() {
+        for (int i = 0; i < EXAMPLES.length; ++i) {
+            // Prepare.
+            final Object[] example = EXAMPLES[i];
+            final byte[] data = (byte[])example[0];
+            final String base64 = (String)example[1];
+            
+            // Modify.
+            final int half = base64.length() / 2;
+            final String modifiedBase64 = "  \t" + base64.substring(0, half) + "\r\n \r\n\t" + base64.substring(half) + " \t \n";
+            
+            // Encode/decode.
+            final String encoded = Base64.encode(data);
+            final byte[] decoded = Base64.decode(modifiedBase64);
+            
+            // Validate.
             assertEquals(base64, encoded);
             assertArrayEquals(data, decoded);
         }

--- a/tests/src/test/javascript/lib/base64test.js
+++ b/tests/src/test/javascript/lib/base64test.js
@@ -44,21 +44,56 @@ describe("base64", function() {
     
     it("standard", function() {
        for (var i = 0; i < EXAMPLES.length; ++i) {
+    	   // Prepare.
            var example = EXAMPLES[i];
-           var encoded = base64$encode(example.data);
-           var decoded = base64$decode(example.base64);
-           expect(encoded).toEqual(example.base64);
-           expect(decoded).toEqual(example.data);
+           var data = example.data;
+           var base64 = example.base64;
+           
+           // Encode/decode.
+           var encoded = base64$encode(data);
+           var decoded = base64$decode(base64);
+           
+           // Validate.
+           expect(encoded).toEqual(base64);
+           expect(decoded).toEqual(data);
        }
+    });
+    
+    it("whitespace", function() {
+        for (var i = 0; i < EXAMPLES.length; ++i) {
+        	// Prepare.
+            var example = EXAMPLES[i];
+            var data = example.data;
+            var base64 = example.base64;
+            
+            // Modify.
+            var half = base64.length / 2;
+            var modifiedBase64 = "  \t" + base64.substring(0, half) + "\r\n \r\n\t" + base64.substring(half) + " \t \n";
+            
+            // Encode/decode.
+            var encoded = base64$encode(data);
+            var decoded = base64$decode(modifiedBase64);
+            
+            // Validate.
+            expect(encoded).toEqual(base64);
+            expect(decoded).toEqual(data);
+        }
     });
     
     it("url-safe", function() {
         for (var i = 0; i < URL_EXAMPLES.length; ++i) {
+     	   // Prepare.
             var example = URL_EXAMPLES[i];
-            var encoded = base64$encode(example.data, true);
-            var decoded = base64$decode(example.base64, true);
-            expect(encoded).toEqual(example.base64);
-            expect(decoded).toEqual(example.data);
+            var data = example.data;
+            var base64 = example.base64;
+            
+            // Encode/decode.
+            var encoded = base64$encode(data, true);
+            var decoded = base64$decode(base64, true);
+            
+            // Validate.
+            expect(encoded).toEqual(base64);
+            expect(decoded).toEqual(data);
         }
     });
 });


### PR DESCRIPTION
Fixes #100.
The JavaScript implementation already stripped whitespace.