### PR TITLE
Allow null identity for session crypto contexts.

### DIFF
--- a/core/src/main/java/com/netflix/msl/crypto/SessionCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/SessionCryptoContext.java
@@ -30,7 +30,8 @@ import com.netflix.msl.util.MslContext;
  */
 public class SessionCryptoContext extends SymmetricCryptoContext {
     /**
-     * Construct a new session crypto context from the provided master token.
+     * <p>Construct a new session crypto context from the provided master
+     * token.</p>
      * 
      * @param ctx MSL context.
      * @param masterToken the master token.
@@ -43,17 +44,17 @@ public class SessionCryptoContext extends SymmetricCryptoContext {
     }
     
     /**
-     * Construct a new session crypto context from the provided master token.
+     * <p>Construct a new session crypto context from the provided master token.
      * The entity identity and keys are assumed to be the same as what is
-     * inside the master token, which may be untrusted.
+     * inside the master token, which may be untrusted.</p>
      * 
      * @param ctx MSL context.
      * @param masterToken master token. May be untrusted.
-     * @param identity entity identity.
+     * @param identity entity identity. May be {@code null}.
      * @param encryptionKey encryption key.
      * @param hmacKey HMAC key.
      */
     public SessionCryptoContext(final MslContext ctx, final MasterToken masterToken, final String identity, final SecretKey encryptionKey, final SecretKey hmacKey) {
-        super(ctx, identity + "_" + masterToken.getSequenceNumber(), encryptionKey, hmacKey, null);
+        super(ctx, (identity != null) ? identity + "_" + masterToken.getSequenceNumber() : Long.toString(masterToken.getSequenceNumber()), encryptionKey, hmacKey, null);
     }
 }

--- a/core/src/main/javascript/crypto/SessionCryptoContext.js
+++ b/core/src/main/javascript/crypto/SessionCryptoContext.js
@@ -22,24 +22,26 @@
  */
 var SessionCryptoContext = SymmetricCryptoContext.extend({
     /**
-     * Construct a new session crypto context from the provided master token.
+     * <p>Construct a new session crypto context from the provided master
+     * token.</p>
      *
-     * If an identity, encryption key, and HMAC key are provided then they are
-     * assumed to be the same as what is inside the master token, which may be
-     * untrusted.
+     * <p>If an identity, encryption key, and HMAC key are provided then they
+     * are assumed to be the same as what is inside the master token, which may
+     * be untrusted.</p>
      *
      * @param {MslContext} ctx MSL context.
      * @param {MasterToken} masterToken the master token. May be untrusted if
      *        the identity, encryption key, and HMAC key are provided.
-     * @param {string=} identity entity identity.
+     * @param {?string=} identity entity identity. May be {@code null}.
      * @param {CipherKey=} encryptionKey encryption key.
      * @param {CipherKey=} signatureKey signature key.
      * @throws MslMasterTokenException if the master token is not trusted.
      * @throws MslCryptoException if the encryption key length is unsupported.
      */
     init: function init(ctx, masterToken, identity, encryptionKey, signatureKey) {
-        if (identity || encryptionKey || signatureKey) {
-            init.base.call(this, ctx, identity + '_' + masterToken.sequenceNumber, encryptionKey, signatureKey, null);
+        if (identity !== undefined || encryptionKey || signatureKey) {
+            var keyId = (identity) ? identity + '_' + masterToken.sequenceNumber : '' + masterToken.sequenceNumber;
+            init.base.call(this, ctx, keyId, encryptionKey, signatureKey, null);
         } else {
             if (!masterToken.isDecrypted())
                 throw new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, masterToken);


### PR DESCRIPTION
Allow session crypto contexts to be created when the identity is not known. The constructors should only be explicitly called with a null entity identity in special cases, as EntityAuthenticationData is prohibited by contract from returning a null value for its identity.