### PR TITLE
Create URL abstraction interface for MslControl.request().

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,6 +69,7 @@ task javadoc_public(type: Javadoc) {
         "**/MslUserIdTokenException.java",
         "**/ServiceToken.java",
         "**/TokenFactory.java",
+        "**/Url.java",
         "**/UserAuthenticationData.java",
         "**/UserAuthenticationFactory.java",
         "**/UserAuthenticationScheme.java",

--- a/core/src/main/java/com/netflix/msl/io/JavaUrl.java
+++ b/core/src/main/java/com/netflix/msl/io/JavaUrl.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2012-2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * An implementation of the {@link Url} interface based on the built-in Java
+ * {@link URL} class.
+ */
+public class JavaUrl implements Url {
+    /**
+     * An implementation of the {@link Connection} interface backed by the
+     * built-in Java {@link URLConnection} class.
+     */
+    public class JavaConnection implements Connection {
+        /**
+         * Create a new Java connection with the backing URL connection.
+         * 
+         * @param conn the backing URL connection.
+         */
+        public JavaConnection(final URLConnection conn) {
+            this.conn = conn;
+        }
+
+        /* (non-Javadoc)
+         * @see com.netflix.msl.io.Url.Connection#getInputStream()
+         */
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return conn.getInputStream();
+        }
+
+        /* (non-Javadoc)
+         * @see com.netflix.msl.io.Url.Connection#getOutputStream()
+         */
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return conn.getOutputStream();
+        }
+        
+        /** URL connection. */
+        private final URLConnection conn;
+    }
+    
+    /**
+     * @param url the target location.
+     */
+    public JavaUrl(final URL url) {
+        this.url = url;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.io.Url#setTimeout(int)
+     */
+    @Override
+    public void setTimeout(final int timeout) {
+        this.timeout = timeout;
+    }
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.io.Url#openConnection()
+     */
+    @Override
+    public Connection openConnection() throws IOException {
+        final URLConnection connection = url.openConnection();
+        connection.setConnectTimeout(timeout);
+        connection.setReadTimeout(timeout);
+        connection.setDoOutput(true);
+        connection.setDoInput(true);
+        connection.connect();
+        return new JavaConnection(connection);
+    }
+    
+    /** URL. */
+    private final URL url;
+    /** Connection timeout. */
+    private int timeout = 0;
+}

--- a/core/src/main/java/com/netflix/msl/io/Url.java
+++ b/core/src/main/java/com/netflix/msl/io/Url.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2012-2016 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * The URL interface provides access to an input stream and output stream tied
+ * to a specific URL.
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public interface Url {
+    /**
+     * The Connection interface represents a communication link between the
+     * application and a URL.
+     */
+    public static interface Connection {
+        /**
+         * Returns an input stream that reads from this connection.
+         * 
+         * @return an input stream that reads from this connection.
+         * @throws IOException if an I/O error occurs while creating the input
+         *         stream.
+         */
+        public InputStream getInputStream() throws IOException;
+        
+        /**
+         * Returns an output stream that writes to this connection.
+         * 
+         * @return an output stream that writes to this connection.
+         * @throws IOException if an I/O error occurs while creating the output
+         *         stream.
+         */
+        public OutputStream getOutputStream() throws IOException;
+    }
+    
+    /**
+     * Set the timeout.
+     *
+     * @param timeout connect/read/write timeout in milliseconds.
+     */
+    public void setTimeout(final int timeout);
+    
+    /**
+     * Open a new connection to the target location.
+     *
+     * @return a {@link #Connection} linking to the URL.
+     * @throws IOException if an I/O exception occurs.
+     */
+    public Connection openConnection() throws IOException;
+}

--- a/examples/kancolle/src/main/java/kancolle/Kanmusu.java
+++ b/examples/kancolle/src/main/java/kancolle/Kanmusu.java
@@ -27,26 +27,28 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import kancolle.keyx.DiffieHellmanManager;
+import kancolle.keyx.KanColleDiffieHellmanParameters;
+import kancolle.msg.CriticalMessageContext;
+import kancolle.msg.Message;
+import kancolle.msg.Message.Type;
+import kancolle.msg.MessageProcessor;
+import kancolle.msg.OrderRequestMessageContext;
+import kancolle.msg.PingMessageContext;
+import kancolle.msg.ReportMessageContext;
+import kancolle.util.ConsoleManager;
+import kancolle.util.KanmusuMslContext;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslMessageException;
+import com.netflix.msl.io.JavaUrl;
+import com.netflix.msl.io.Url;
 import com.netflix.msl.msg.ErrorHeader;
 import com.netflix.msl.msg.MessageContext;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.msg.MslControl;
 import com.netflix.msl.msg.MslControl.MslChannel;
 import com.netflix.msl.util.MslContext;
-
-import kancolle.keyx.DiffieHellmanManager;
-import kancolle.keyx.KanColleDiffieHellmanParameters;
-import kancolle.msg.CriticalMessageContext;
-import kancolle.msg.Message;
-import kancolle.msg.MessageProcessor;
-import kancolle.msg.OrderRequestMessageContext;
-import kancolle.msg.PingMessageContext;
-import kancolle.msg.ReportMessageContext;
-import kancolle.msg.Message.Type;
-import kancolle.util.ConsoleManager;
-import kancolle.util.KanmusuMslContext;
 
 /**
  * <p>KanColle Kanmusu ship.</p>
@@ -157,7 +159,7 @@ public class Kanmusu extends Thread {
     public void run() {
         while (true) try {
             // Construct the port URL.
-            final URL portUrl = new URL("kc://" + port.getIdentity() + "/");
+            final Url portUrl = new JavaUrl(new URL("kc://" + port.getIdentity() + "/"));
             
             // Wait for a request or send a ping if the ping interval has
             // elapsed.

--- a/examples/mslcli/src/main/java/mslcli/client/Client.java
+++ b/examples/mslcli/src/main/java/mslcli/client/Client.java
@@ -17,7 +17,6 @@
 package mslcli.client;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -30,6 +29,7 @@ import mslcli.common.util.ConfigurationException;
 import mslcli.common.util.SharedUtil;
 
 import com.netflix.msl.MslException;
+import com.netflix.msl.io.JavaUrl;
 import com.netflix.msl.msg.ErrorHeader;
 import com.netflix.msl.msg.MessageContext;
 import com.netflix.msl.msg.MslControl;
@@ -164,7 +164,7 @@ public final class Client {
         mslCfg.validate();
 
         // set remote URL
-        final URL remoteUrl = args.getUrl();
+        final JavaUrl remoteUrl = new JavaUrl(args.getUrl());
 
         final MslContext mslCtx = new ClientMslContext(appCtx, mslCfg);
         final MessageContext msgCtx = new ClientRequestMessageContext(mslCfg, request);

--- a/examples/oneshot/src/main/java/oneshot/Oneshot.java
+++ b/examples/oneshot/src/main/java/oneshot/Oneshot.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Future;
 
 import com.netflix.msl.MslConstants.ResponseCode;
 import com.netflix.msl.MslException;
+import com.netflix.msl.io.JavaUrl;
+import com.netflix.msl.io.Url;
 import com.netflix.msl.msg.ErrorHeader;
 import com.netflix.msl.msg.MessageContext;
 import com.netflix.msl.msg.MessageInputStream;
@@ -100,7 +102,7 @@ public class Oneshot {
 	 * @throws OneshotErrorResponse if the remote entity returned a MSL error.
 	 * @throws IOException if there is an error reading the response.
 	 */
-	public byte[] request(final URL remoteEntity, final byte[] data) throws MslException, ExecutionException, InterruptedException, OneshotErrorResponse, IOException {
+	public byte[] request(final Url remoteEntity, final byte[] data) throws MslException, ExecutionException, InterruptedException, OneshotErrorResponse, IOException {
 	    // Setup message context.
 	    final MessageContext msgCtx = new OneshotMessageContext(data, email, password);
 	    
@@ -167,7 +169,7 @@ public class Oneshot {
 	        }
 
             // Grab remote URL and data file.
-            final URL url = new URL(args[0]);
+            final Url url = new JavaUrl(new URL(args[0]));
 	        final String file = args[1];
 
 	        // Read request data.

--- a/integ-tests/src/test/java/com/netflix/msl/client/common/BaseTestClass.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/common/BaseTestClass.java
@@ -18,7 +18,6 @@ package com.netflix.msl.client.common;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URLConnection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Properties;
@@ -47,6 +46,7 @@ import com.netflix.msl.crypto.NullCryptoContext;
 import com.netflix.msl.crypto.SessionCryptoContext;
 import com.netflix.msl.crypto.SymmetricCryptoContext;
 import com.netflix.msl.entityauth.MockPresharedAuthenticationFactory;
+import com.netflix.msl.io.Url.Connection;
 import com.netflix.msl.keyx.KeyRequestData;
 import com.netflix.msl.msg.MessageBuilder;
 import com.netflix.msl.msg.MessageHeader;
@@ -283,7 +283,7 @@ public class BaseTestClass {
          *
          * @param conn backing URL connection.
          */
-        public DelayedInputStream(final URLConnection conn) {
+        public DelayedInputStream(final Connection conn) {
             super(null);
             this.conn = conn;
         }
@@ -347,6 +347,6 @@ public class BaseTestClass {
         }
 
         /** URL connection providing the input stream. */
-        private final URLConnection conn;
+        private final Connection conn;
     }
 }

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
@@ -15,6 +15,12 @@
  */
 package com.netflix.msl.client.configuration;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
@@ -33,6 +39,8 @@ import com.netflix.msl.entityauth.RsaAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationFactory;
 import com.netflix.msl.entityauth.X509AuthenticationData;
+import com.netflix.msl.io.JavaUrl;
+import com.netflix.msl.io.Url;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MslControl;
 import com.netflix.msl.userauth.EmailPasswordAuthenticationData;
@@ -41,12 +49,6 @@ import com.netflix.msl.userauth.UserAuthenticationData;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
 import com.netflix.msl.util.AuthenticationUtils;
 import com.netflix.msl.util.MockAuthenticationUtils;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * User: skommidi
@@ -60,7 +62,7 @@ public class ClientConfiguration {
     private MslControl mslControl;
     private ClientMslContext mslContext;
     private ClientMessageContext messageContext;
-    private URL remoteEntity;
+    private Url remoteEntity;
     private String scheme = "http";
     private String remoteHost = "localhost";
     private String path = "";
@@ -176,7 +178,7 @@ public class ClientConfiguration {
     }
 
     public void commitConfiguration() throws URISyntaxException, IOException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
-        remoteEntity = new URL(scheme + "://" + remoteHost + path);
+        remoteEntity = new JavaUrl(new URL(scheme + "://" + remoteHost + path));
 
         /** create msl context and configure */
         mslContext = new ClientMslContext(entityAuthenticationScheme, isPeerToPeer, isNullCryptoContext);
@@ -283,7 +285,7 @@ public class ClientConfiguration {
         return messageContext;
     }
 
-    public URL getRemoteEntity() {
+    public Url getRemoteEntity() {
         return remoteEntity;
     }
 

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/MasterTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/MasterTokenTests.java
@@ -24,6 +24,8 @@ import com.netflix.msl.client.common.BaseTestClass;
 import com.netflix.msl.client.configuration.ClientConfiguration;
 import com.netflix.msl.client.configuration.ServerConfiguration;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.io.Url;
+import com.netflix.msl.io.Url.Connection;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.tokens.MasterToken;
@@ -36,7 +38,6 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
-import java.net.URLConnection;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
@@ -85,13 +86,10 @@ public class MasterTokenTests extends BaseTestClass {
     @BeforeMethod
     public void beforeTest() throws IOException, ExecutionException, InterruptedException {
         try {
-            final URLConnection connection = clientConfig.getRemoteEntity().openConnection();
-            connection.setConnectTimeout(TIME_OUT);
-            connection.setReadTimeout(TIME_OUT);
-            connection.setDoOutput(true);
-            connection.setDoInput(true);
+            final Url remoteEntity = clientConfig.getRemoteEntity();
+            remoteEntity.setTimeout(TIME_OUT);
+            final Connection connection = remoteEntity.openConnection();
 
-            connection.connect();
             out = connection.getOutputStream();
             in = new DelayedInputStream(connection);
         } catch (final IOException e) {

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
@@ -23,6 +23,8 @@ import com.netflix.msl.client.common.BaseTestClass;
 import com.netflix.msl.client.configuration.ClientConfiguration;
 import com.netflix.msl.client.configuration.ServerConfiguration;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.io.Url;
+import com.netflix.msl.io.Url.Connection;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.tokens.MasterToken;
@@ -40,7 +42,6 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
-import java.net.URLConnection;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
@@ -93,13 +94,10 @@ public class ServiceTokenTests extends BaseTestClass {
     @BeforeMethod
     public void beforeTest() throws IOException, ExecutionException, InterruptedException {
         try {
-            final URLConnection connection = clientConfig.getRemoteEntity().openConnection();
-            connection.setConnectTimeout(TIME_OUT);
-            connection.setReadTimeout(TIME_OUT);
-            connection.setDoOutput(true);
-            connection.setDoInput(true);
+            final Url remoteEntity = clientConfig.getRemoteEntity();
+            remoteEntity.setTimeout(TIME_OUT);
+            final Connection connection = remoteEntity.openConnection();
 
-            connection.connect();
             out = connection.getOutputStream();
             in = new DelayedInputStream(connection);
         } catch (final IOException e) {

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/UserIdTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/UserIdTokenTests.java
@@ -23,11 +23,14 @@ import com.netflix.msl.client.common.BaseTestClass;
 import com.netflix.msl.client.configuration.ClientConfiguration;
 import com.netflix.msl.client.configuration.ServerConfiguration;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.io.Url;
+import com.netflix.msl.io.Url.Connection;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
+
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -36,7 +39,6 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
-import java.net.URLConnection;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
@@ -87,13 +89,10 @@ public class UserIdTokenTests extends BaseTestClass {
     @BeforeMethod
     public void beforeTest() throws IOException, ExecutionException, InterruptedException {
         try {
-            final URLConnection connection = clientConfig.getRemoteEntity().openConnection();
-            connection.setConnectTimeout(TIME_OUT);
-            connection.setReadTimeout(TIME_OUT);
-            connection.setDoOutput(true);
-            connection.setDoInput(true);
+            final Url remoteEntity = clientConfig.getRemoteEntity();
+            remoteEntity.setTimeout(TIME_OUT);
+            final Connection connection = remoteEntity.openConnection();
 
-            connection.connect();
             out = connection.getOutputStream();
             in = new DelayedInputStream(connection);
         } catch (final IOException e) {


### PR DESCRIPTION
Fixes #106 by creating an interface which can be implemented by the caller to provide custom behavior.

Create MSL com.netflix.msl.io.Url interface to match JavaScript Url interface. This differs from the Java java.net.URL class but provides the same functionality. A default JavaUrl implementation is provided that is backed by java.net.URL and java.net.URLConnection.

Interface name is undesirable as potentially confusing with java.net.URL but it's a starting point and is at least consistent with JavaScript.