### PR TITLE
Alternative approach to regex for Jaxb's implementation

### DIFF
--- a/core/src/main/java/com/netflix/msl/util/Base64Jaxb.java
+++ b/core/src/main/java/com/netflix/msl/util/Base64Jaxb.java
@@ -38,7 +38,7 @@ public class Base64Jaxb implements Base64Impl {
      */
     @Override
     public byte[] decode(final String s) {
-        if (s.isEmpty()) {
+        if (s != null && s.isEmpty()) {
             return new byte[0];
         }
         byte[] bytes = DatatypeConverter.parseBase64Binary(s);

--- a/core/src/main/java/com/netflix/msl/util/Base64Jaxb.java
+++ b/core/src/main/java/com/netflix/msl/util/Base64Jaxb.java
@@ -38,8 +38,13 @@ public class Base64Jaxb implements Base64Impl {
      */
     @Override
     public byte[] decode(final String s) {
-        if (!Base64.isValidBase64(s))
+        if (s.isEmpty()) {
+            return new byte[0];
+        }
+        byte[] bytes = DatatypeConverter.parseBase64Binary(s);
+        if( bytes.length == 0) {
             throw new IllegalArgumentException("Invalid Base64 encoded string: " + s);
-        return DatatypeConverter.parseBase64Binary(s);
+        }
+        return bytes;
     }
 }

--- a/tests/src/test/java/com/netflix/msl/util/Base64JaxbTest.java
+++ b/tests/src/test/java/com/netflix/msl/util/Base64JaxbTest.java
@@ -1,0 +1,52 @@
+package com.netflix.msl.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test the Jaxb implementation of Base64Impl
+ */
+public class Base64JaxbTest {
+    Base64.Base64Impl subject = new Base64Jaxb();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void decodeSimple() throws Exception {
+        byte[] decoded = subject.decode("UEFZTE9BRA==");
+        assertEquals("PAYLOAD", new String(decoded, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void decodeBinary() throws Exception {
+        byte[] decoded = subject.decode("R0lGODlhPQBEAPeoAJosM//AwO/AwHVYZ/z595kzAP/s7P+goOXMv8+fhw/v739/f+8PD98fH/8mJl+fn/9ZWb8/PzWlwv///6wWGbImAPgTEMImIN9gUFCEm/gDALULDN8PAD6atYdCTX9gUNKlj8wZAKUsAOzZz+UMAOsJAP/Z2ccMDA8PD/95eX5NWvsJCOVNQPtfX/8zM8+QePLl38MGBr8JCP+zs9myn/8GBqwpAP/GxgwJCPny78lzYLgjAJ8vAP9fX/+MjMUcAN8zM/9wcM8ZGcATEL+QePdZWf/29uc/P9cmJu9MTDImIN+/r7+/vz8/P8VNQGNugV8AAF9fX8swMNgTAFlDOICAgPNSUnNWSMQ5MBAQEJE3QPIGAM9AQMqGcG9vb6MhJsEdGM8vLx8fH98AANIWAMuQeL8fABkTEPPQ0OM5OSYdGFl5jo+Pj/+pqcsTE78wMFNGQLYmID4dGPvd3UBAQJmTkP+8vH9QUK+vr8ZWSHpzcJMmILdwcLOGcHRQUHxwcK9PT9DQ0O/v70w5MLypoG8wKOuwsP/g4P/Q0IcwKEswKMl8aJ9fX2xjdOtGRs/Pz+Dg4GImIP8gIH0sKEAwKKmTiKZ8aB/f39Wsl+LFt8dgUE9PT5x5aHBwcP+AgP+WltdgYMyZfyywz78AAAAAAAD///8AAP9mZv///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAKgALAAAAAA9AEQAAAj/AFEJHEiwoMGDCBMqXMiwocAbBww4nEhxoYkUpzJGrMixogkfGUNqlNixJEIDB0SqHGmyJSojM1bKZOmyop0gM3Oe2liTISKMOoPy7GnwY9CjIYcSRYm0aVKSLmE6nfq05QycVLPuhDrxBlCtYJUqNAq2bNWEBj6ZXRuyxZyDRtqwnXvkhACDV+euTeJm1Ki7A73qNWtFiF+/gA95Gly2CJLDhwEHMOUAAuOpLYDEgBxZ4GRTlC1fDnpkM+fOqD6DDj1aZpITp0dtGCDhr+fVuCu3zlg49ijaokTZTo27uG7Gjn2P+hI8+PDPERoUB318bWbfAJ5sUNFcuGRTYUqV/3ogfXp1rWlMc6awJjiAAd2fm4ogXjz56aypOoIde4OE5u/F9x199dlXnnGiHZWEYbGpsAEA3QXYnHwEFliKAgswgJ8LPeiUXGwedCAKABACCN+EA1pYIIYaFlcDhytd51sGAJbo3onOpajiihlO92KHGaUXGwWjUBChjSPiWJuOO/LYIm4v1tXfE6J4gCSJEZ7YgRYUNrkji9P55sF/ogxw5ZkSqIDaZBV6aSGYq/lGZplndkckZ98xoICbTcIJGQAZcNmdmUc210hs35nCyJ58fgmIKX5RQGOZowxaZwYA+JaoKQwswGijBV4C6SiTUmpphMspJx9unX4KaimjDv9aaXOEBteBqmuuxgEHoLX6Kqx+yXqqBANsgCtit4FWQAEkrNbpq7HSOmtwag5w57GrmlJBASEU18ADjUYb3ADTinIttsgSB1oJFfA63bduimuqKB1keqwUhoCSK374wbujvOSu4QG6UvxBRydcpKsav++Ca6G8A6Pr1x2kVMyHwsVxUALDq/krnrhPSOzXG1lUTIoffqGR7Goi2MAxbv6O2kEG56I7CSlRsEFKFVyovDJoIRTg7sugNRDGqCJzJgcKE0ywc0ELm6KBCCJo8DIPFeCWNGcyqNFE06ToAfV0HBRgxsvLThHn1oddQMrXj5DyAQgjEHSAJMWZwS3HPxT/QMbabI/iBCliMLEJKX2EEkomBAUCxRi42VDADxyTYDVogV+wSChqmKxEKCDAYFDFj4OmwbY7bDGdBhtrnTQYOigeChUmc1K3QTnAUfEgGFgAWt88hKA6aCRIXhxnQ1yg3BCayK44EWdkUQcBByEQChFXfCB776aQsG0BIlQgQgE8qO26X1h8cEUep8ngRBnOy74E9QgRgEAC8SvOfQkh7FDBDmS43PmGoIiKUUEGkMEC/PJHgxw0xH74yx/3XnaYRJgMB8obxQW6kL9QYEJ0FIFgByfIL7/IQAlvQwEpnAC7DtLNJCKUoO/w45c44GwCXiAFB/OXAATQryUxdN4LfFiwgjCNYg+kYMIEFkCKDs6PKAIJouyGWMS1FSKJOMRB/BoIxYJIUXFUxNwoIkEKPAgCBZSQHQ1A2EWDfDEUVLyADj5AChSIQW6gu10bE/JG2VnCZGfo4R4d0sdQoBAHhPjhIB94v/wRoRKQWGRHgrhGSQJxCS+0pCZbEhAAOw==");
+        assertEquals(1951, decoded.length);
+    }
+
+    @Test
+    public void decodeEmpty() throws Exception {
+        byte[] decoded = subject.decode("");
+        assertEquals(0, decoded.length);
+    }
+
+    @Test
+    public void decodeIncorrect() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        byte[] decoded = subject.decode("%$#@=");
+
+        assertNotNull(decoded);
+    }
+
+    @Test
+    public void decodeInvalid() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        subject.decode("ZZZZZZZZZZ=");
+    }
+
+}

--- a/tests/src/test/java/com/netflix/msl/util/Base64JaxbTest.java
+++ b/tests/src/test/java/com/netflix/msl/util/Base64JaxbTest.java
@@ -36,6 +36,12 @@ public class Base64JaxbTest {
     }
 
     @Test
+    public void decodeNull() throws Exception {
+        expectedException.expect(NullPointerException.class);
+        subject.decode(null);
+    }
+
+    @Test
     public void decodeIncorrect() throws Exception {
         expectedException.expect(RuntimeException.class);
         byte[] decoded = subject.decode("%$#@=");


### PR DESCRIPTION
I believe JAXB has a consistent behavior when it reaches invalid characters, it returns an empty byte array. We should only get an empty byte array in a normal case if the input string is empty, so I just filter out that case up front.