### PR TITLE
Add format parameter to Pubkey/Privkey import methods.

### DIFF
--- a/core/src/main/javascript/crypto/KeyFormat.js
+++ b/core/src/main/javascript/crypto/KeyFormat.js
@@ -19,7 +19,10 @@
  *
  */
 
+var KeyFormat;
+
 (function() {
+    "use strict";
 
     KeyFormat = {
         RAW : "raw",
@@ -30,22 +33,27 @@
         /**
          * Normalize public key input into expected WebCrypto format.
          *
-         * @param {string|JSON|Uint8Array} input Base64-encoded or JSON or ByteArray of key.
-         * @param {string} format key format type ("spki" | "jwk")
-         * @return webcrypto format for the public key.
+         * @param {string|object|Uint8Array} input Base64-encoded or JSON object or ByteArray of key.
+         * @param {KeyFormat} format key format type ("spki" | "jwk")
+         * @return WebCrypto acceptable format of the public key.
          * @throws MslCryptoException if the key data is invalid.
          */
         normalizePubkeyInput: function normalizePubkeyInput(input, format) {
             if (format == KeyFormat.SPKI) {
                 try {
-                    input = (typeof input == "string") ? base64$decode(input) : input;
+                    input = (typeof input === "string") ? base64$decode(input) : input;
                 } catch (e) {
                     throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, format + " " + input, e);
                 }
             }
             else if (format == KeyFormat.JWK) {
                 try {
-                    input = (typeof input == "string") ? JSON.parse(input) : input;
+                    input = (typeof input === "string") ? JSON.parse(input) : input;
+                    /* input must be a JSON object */
+                    if (typeof input !== "object") {
+                        console.log("JWK key is not JSON format")
+                        throw "JWK key is not JSON format";
+                    }
                 } catch (e) {
                     throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, format + " " + input, e);
                 }
@@ -60,24 +68,29 @@
         /**
          * Normalize private key input into expected WebCrypto format.
          *
-         * @param {string|JSON|Uint8Array} input Base64-encoded or JSON or ByteArray of key.
-         * @param {string} format key format type ("pkcs8" | "jwk")
-         * @return webcrypto format for private key.
+         * @param {string|object|Uint8Array} input Base64-encoded or JSON object or ByteArray of key.
+         * @param {KeyFormat} format key format type ("pkcs8" | "jwk")
+         * @return WebCrypto acceptable format of the private key.
          * @throws MslCryptoException if the key data is invalid.
          */
         normalizePrivkeyInput: function normalizePrivkeyInput(input, format) {
             if (format == KeyFormat.PKCS8) {
                 try {
-                    input = (typeof input == "string") ? base64$decode(input) : input;
+                    input = (typeof input === "string") ? base64$decode(input) : input;
                 } catch (e) {
                     throw new MslCryptoException(MslError.INVALID_PRIVATE_KEY, format + " " + input, e);
                 }
             }
-            else if (format == "jwk") {
+            else if (format == KeyFormat.JWK) {
                 try {
-                    input = (typeof input == "string") ? JSON.parse(input) : input;
+                    input = (typeof input === "string") ? JSON.parse(input) : input;
+                    /* input must be a JSON object */
+                    if (typeof input !== "object") {
+                        console.log("JWK key is not JSON format")
+                        throw "JWK key is not JSON format";
+                    }
                 } catch (e) {
-                    throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, format + " " + input, e);
+                    throw new MslCryptoException(MslError.INVALID_PRIVATE_KEY, format + " " + input, e);
                 }
             }
             else {

--- a/core/src/main/javascript/crypto/KeyFormat.js
+++ b/core/src/main/javascript/crypto/KeyFormat.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>Key Format constants and utility methods.</p>
+ *
+ */
+
+(function() {
+
+    KeyFormat = {
+        RAW : "raw",
+        JWK : "jwk",
+        SPKI: "spki",
+        PKCS8: "pkcs8",
+
+        /**
+         * Normalize public key input into expected WebCrypto format.
+         *
+         * @param {string|JSON|Uint8Array} input Base64-encoded or JSON or ByteArray of key.
+         * @param {string} format key format type ("spki" | "jwk")
+         * @return webcrypto format for the public key.
+         * @throws MslCryptoException if the key data is invalid.
+         */
+        normalizePubkeyInput: function normalizePubkeyInput(input, format) {
+            if (format == KeyFormat.SPKI) {
+                try {
+                    input = (typeof input == "string") ? base64$decode(input) : input;
+                } catch (e) {
+                    throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, format + " " + input, e);
+                }
+            }
+            else if (format == KeyFormat.JWK) {
+                try {
+                    input = (typeof input == "string") ? JSON.parse(input) : input;
+                } catch (e) {
+                    throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, format + " " + input, e);
+                }
+            }
+            else {
+                throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, "Invalid format '" + format + "'", e);
+            }
+
+            return input;
+        },
+
+        /**
+         * Normalize private key input into expected WebCrypto format.
+         *
+         * @param {string|JSON|Uint8Array} input Base64-encoded or JSON or ByteArray of key.
+         * @param {string} format key format type ("pkcs8" | "jwk")
+         * @return webcrypto format for private key.
+         * @throws MslCryptoException if the key data is invalid.
+         */
+        normalizePrivkeyInput: function normalizePrivkeyInput(input, format) {
+            if (format == KeyFormat.PKCS8) {
+                try {
+                    input = (typeof input == "string") ? base64$decode(input) : input;
+                } catch (e) {
+                    throw new MslCryptoException(MslError.INVALID_PRIVATE_KEY, format + " " + input, e);
+                }
+            }
+            else if (format == "jwk") {
+                try {
+                    input = (typeof input == "string") ? JSON.parse(input) : input;
+                } catch (e) {
+                    throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, format + " " + input, e);
+                }
+            }
+            else {
+                throw new MslCryptoException(MslError.INVALID_PRIVATE_KEY, "Invalid format '" + format + "'", e);
+            }
+
+            return input;
+        }
+    };
+})();

--- a/core/src/main/javascript/crypto/KeyFormat.js
+++ b/core/src/main/javascript/crypto/KeyFormat.js
@@ -50,8 +50,7 @@ var KeyFormat;
                 try {
                     input = (typeof input === "string") ? JSON.parse(input) : input;
                     /* input must be a JSON object */
-                    if (typeof input !== "object") {
-                        console.log("JWK key is not JSON format")
+                    if (typeof input !== "object" || input.constructor !== Object) {
                         throw "JWK key is not JSON format";
                     }
                 } catch (e) {
@@ -85,8 +84,7 @@ var KeyFormat;
                 try {
                     input = (typeof input === "string") ? JSON.parse(input) : input;
                     /* input must be a JSON object */
-                    if (typeof input !== "object") {
-                        console.log("JWK key is not JSON format")
+                    if (typeof input !== "object" || input.constructor !== Object) {
                         throw "JWK key is not JSON format";
                     }
                 } catch (e) {

--- a/core/src/main/javascript/crypto/PrivateKey.js
+++ b/core/src/main/javascript/crypto/PrivateKey.js
@@ -107,9 +107,10 @@ var PrivateKey$import;
      * Creates a private key from the provided key data. The key's
      * byte encoding will be available.
      *
-     * @param {string|Uint8Array|JSON Object} input Base64-encoded or raw PKCS#8.
+     * @param {string|Uint8Array|object} input Base64-encoded, Raw or JSON key data (PKCS#8|JWK).
      * @param {WebCryptoAlgorithm} algo Web Crypto algorithm.
      * @param {WebCryptoUsage} usages Web Crypto key usages.
+     * @param {KeyFormat} format format of the key to import.
      * @param {{result: function(PrivateKey), error: function(Error)}}
      *        callback the callback will receive the new public key
      *        or any thrown exceptions.

--- a/core/src/main/javascript/crypto/PrivateKey.js
+++ b/core/src/main/javascript/crypto/PrivateKey.js
@@ -53,9 +53,9 @@ var PrivateKey$import;
                         createKey(new Uint8Array(result));
                     };
                     var onerror = function(e) {
-                        callback.error(new MslCryptoException(MslError.KEY_EXPORT_ERROR, "pkcs8"));
+                        callback.error(new MslCryptoException(MslError.KEY_EXPORT_ERROR, KeyFormat.PKCS8));
                     };
-                    mslCrypto['exportKey']("pkcs8", rawKey)
+                    mslCrypto['exportKey'](KeyFormat.PKCS8, rawKey)
                         .then(oncomplete, onerror);
                 } else {
                     createKey(encoded);
@@ -107,7 +107,7 @@ var PrivateKey$import;
      * Creates a private key from the provided key data. The key's
      * byte encoding will be available.
      *
-     * @param {string|Uint8Array} pkcs8 Base64-encoded or raw PKCS#8.
+     * @param {string|Uint8Array|JSON Object} input Base64-encoded or raw PKCS#8.
      * @param {WebCryptoAlgorithm} algo Web Crypto algorithm.
      * @param {WebCryptoUsage} usages Web Crypto key usages.
      * @param {{result: function(PrivateKey), error: function(Error)}}
@@ -115,20 +115,17 @@ var PrivateKey$import;
      *        or any thrown exceptions.
      * @throws MslCryptoException if the key data is invalid.
      */
-    PrivateKey$import = function PrivateKey$import(pkcs8, algo, usages, callback) {
+    PrivateKey$import = function PrivateKey$import(input, algo, usages, format, callback) {
         AsyncExecutor(callback, function() {
-            try {
-                pkcs8 = (typeof pkcs8 == "string") ? base64$decode(pkcs8) : pkcs8;
-            } catch (e) {
-                throw new MslCryptoException(MslError.INVALID_PRIVATE_KEY, "pkcs8 " + pkcs8, e);
-            }
+            input = KeyFormat.normalizePrivkeyInput(input, format);
+
             var oncomplete = function(result) {
-                new PrivateKey(result, callback, pkcs8);
+                new PrivateKey(result, callback, input);
             };
             var onerror = function(e) {
                 callback.error(new MslCryptoException(MslError.INVALID_PRIVATE_KEY));
             };
-            mslCrypto["importKey"]("pkcs8", pkcs8, algo, true, usages)
+            mslCrypto["importKey"](format, input, algo, true, usages)
                 .then(oncomplete, onerror);
         });
     };

--- a/core/src/main/javascript/crypto/PublicKey.js
+++ b/core/src/main/javascript/crypto/PublicKey.js
@@ -104,7 +104,7 @@ var PublicKey$import;
      * Creates a public key from the provided key data. The key's
      * byte encoding will be available.
      *
-     * @param {string|Uint8Array|JSON} input Base64-encoded, Raw or JSON key data (SPKI|JWK).
+     * @param {string|Uint8Array|object} input Base64-encoded, Raw or JSON key data (SPKI|JWK).
      * @param {WebCryptoAlgorithm} algo Web Crypto algorithm.
      * @param {WebCryptoUsage} usages Web Crypto key usages.
      * @param {KeyFormat} format format of the key to import.

--- a/core/src/main/javascript/crypto/PublicKey.js
+++ b/core/src/main/javascript/crypto/PublicKey.js
@@ -52,9 +52,9 @@ var PublicKey$import;
                         createKey(new Uint8Array(result));
                     };
                     var onerror = function(e) {
-                        callback.error(new MslCryptoException(MslError.KEY_EXPORT_ERROR, "spki"));
+                        callback.error(new MslCryptoException(MslError.KEY_EXPORT_ERROR, KeyFormat.SPKI));
                     };
-                    mslCrypto['exportKey']("spki", rawKey)
+                    mslCrypto['exportKey'](KeyFormat.SPKI, rawKey)
                         .then(oncomplete, onerror);
                 } else {
                     createKey(encoded);
@@ -104,28 +104,25 @@ var PublicKey$import;
      * Creates a public key from the provided key data. The key's
      * byte encoding will be available.
      *
-     * @param {string|Uint8Array} spki Base64-encoded or raw SPKI.
+     * @param {string|Uint8Array|JSON} input Base64-encoded, Raw or JSON key data (SPKI|JWK).
      * @param {WebCryptoAlgorithm} algo Web Crypto algorithm.
      * @param {WebCryptoUsage} usages Web Crypto key usages.
+     * @param {KeyFormat} format format of the key to import.
      * @param {{result: function(PublicKey), error: function(Error)}}
      *        callback the callback will receive the new public key
      *        or any thrown exceptions.
      * @throws MslCryptoException if the key data is invalid.
      */
-    PublicKey$import = function PublicKey$import(spki, algo, usages, callback) {
+    PublicKey$import = function PublicKey$import(input, algo, usages, format, callback) {
         AsyncExecutor(callback, function() {
-            try {
-                spki = (typeof spki == "string") ? base64$decode(spki) : spki;
-            } catch (e) {
-                throw new MslCryptoException(MslError.INVALID_PUBLIC_KEY, "spki " + spki, e);
-            }
+            input = KeyFormat.normalizePubkeyInput(input, format);
             var oncomplete = function(result) {
-                new PublicKey(result, callback, spki);
+                new PublicKey(result, callback, input);
             };
             var onerror = function(e) {
                 callback.error(new MslCryptoException(MslError.INVALID_PUBLIC_KEY));
             };
-            mslCrypto['importKey']("spki", spki, algo, true, usages)
+            mslCrypto['importKey'](format, input, algo, true, usages)
                 .then(oncomplete, onerror);
         });
     };

--- a/core/src/main/javascript/crypto/WebCryptoAdapter.js
+++ b/core/src/main/javascript/crypto/WebCryptoAdapter.js
@@ -270,7 +270,7 @@ var MslCrypto$setCryptoSubtle;
                                 throw new Error("Could not make valid JWK from DER input");
                             }
                             var jwk = JSON.stringify(jwkObj);
-                            return nfCryptoSubtle.importKey('jwk', utf8$getBytes(jwk), algorithm, ext, ku);
+                            return nfCryptoSubtle.importKey(KeyFormat.JWK, utf8$getBytes(jwk), algorithm, ext, ku);
                         });
                     } else {
                         var op = nfCryptoSubtle.importKey(format, keyData, algorithm, ext, ku);
@@ -290,7 +290,7 @@ var MslCrypto$setCryptoSubtle;
                     return promisedOperation(op);
                 case WebCryptoVersion.V2014_02_SAFARI:
                     if (format == KeyFormat.SPKI || format == KeyFormat.PKCS8) {
-						var op = nfCryptoSubtle.exportKey('jwk', key);
+						var op = nfCryptoSubtle.exportKey(KeyFormat.JWK, key);
                         return promisedOperation(op).then(function (result) {
                             var jwkObj = JSON.parse(utf8$getString(new Uint8Array(result)));
                             var rsaKey = ASN1.jwkToRsaDer(jwkObj);

--- a/core/src/main/javascript/crypto/WebCryptoAdapter.js
+++ b/core/src/main/javascript/crypto/WebCryptoAdapter.js
@@ -261,7 +261,7 @@ var MslCrypto$setCryptoSubtle;
                     var op = nfCryptoSubtle.importKey(format, keyData, algorithm, ext, ku);
                     return promisedOperation(op);
                 case WebCryptoVersion.V2014_02_SAFARI:
-                    if (format == 'spki' || format == 'pkcs8') {
+                    if (format == KeyFormat.SPKI || format == KeyFormat.PKCS8) {
                         return Promise.resolve().then(function() {
                             var alg = ASN1.webCryptoAlgorithmToJwkAlg(algorithm);
                             var keyOps = ASN1.webCryptoUsageToJwkKeyOps(ku);
@@ -289,7 +289,7 @@ var MslCrypto$setCryptoSubtle;
                     var op = nfCryptoSubtle.exportKey(format, key);
                     return promisedOperation(op);
                 case WebCryptoVersion.V2014_02_SAFARI:
-                    if (format == 'spki' || format == 'pkcs8') {
+                    if (format == KeyFormat.SPKI || format == KeyFormat.PKCS8) {
 						var op = nfCryptoSubtle.exportKey('jwk', key);
                         return promisedOperation(op).then(function (result) {
                             var jwkObj = JSON.parse(utf8$getString(new Uint8Array(result)));

--- a/core/src/main/javascript/keyx/AsymmetricWrappedExchange.js
+++ b/core/src/main/javascript/keyx/AsymmetricWrappedExchange.js
@@ -198,7 +198,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                 case Mechanism.JWEJS_RSA:
                 case Mechanism.JWK_RSA:
                 {
-                    PublicKey$import(encodedKey, WebCryptoAlgorithm.RSA_OAEP, WebCryptoUsage.WRAP, {
+                    PublicKey$import(encodedKey, WebCryptoAlgorithm.RSA_OAEP, WebCryptoUsage.WRAP, KeyFormat.SPKI, {
                         result: function(publicKey) {
                             constructRequestData(keyPairId, mechanism, publicKey);
                         },
@@ -208,7 +208,7 @@ var AsymmetricWrappedExchange$ResponseData$parse;
                 }
                 case Mechanism.JWK_RSAES:
                 {
-                    PublicKey$import(encodedKey, WebCryptoAlgorithm.RSAES, WebCryptoUsage.WRAP, {
+                    PublicKey$import(encodedKey, WebCryptoAlgorithm.RSAES, WebCryptoUsage.WRAP, KeyFormat.SPKI, {
                         result: function(publicKey) {
                             constructRequestData(keyPairId, mechanism, publicKey);
                         },

--- a/core/src/main/javascript/keyx/DiffieHellmanExchange.js
+++ b/core/src/main/javascript/keyx/DiffieHellmanExchange.js
@@ -141,7 +141,7 @@ var DiffieHellmanExchange$ResponseData$parse;
             }
             if (!publicKeyBytes || publicKeyBytes.length == 0)
                 throw new MslKeyExchangeException(MslError.KEYX_INVALID_PUBLIC_KEY, "keydata " + JSON.stringify(keyDataJO));
-            PublicKey$import(publicKeyBytes, WebCryptoAlgorithm.DIFFIE_HELLMAN, WebCryptoUsage.DERIVE_KEY, {
+            PublicKey$import(publicKeyBytes, WebCryptoAlgorithm.DIFFIE_HELLMAN, WebCryptoUsage.DERIVE_KEY, KeyFormat.SPKI, {
                 result: function(publicKey) {
                     constructRequestData(parametersId, publicKey);
                 },

--- a/core/src/main/javascript/lib/asnjwk.concat.js
+++ b/core/src/main/javascript/lib/asnjwk.concat.js
@@ -1070,10 +1070,10 @@ function jwkToRsaDer(jwk) {
     var type;
     var der;
     if (rsaKey instanceof RsaPublicKey) {
-        type = 'spki';
+        type = KeyFormat.SPKI;
         der = buildRsaSpki(rsaKey).der;
     } else if (rsaKey instanceof RsaPrivateKey) {
-        type = 'pkcs8';
+        type = KeyFormat.PKCS8;
         der = buildRsaPkcs8(rsaKey).der;
     } else {
         return undefined;

--- a/examples/simple/src/main/javascript/client/App.js
+++ b/examples/simple/src/main/javascript/client/App.js
@@ -108,7 +108,7 @@ function addRsaKey() {
     keyB64 = keyB64.replace(/\s+/g, '');
 
     // Import the public key.
-    PublicKey$import(keyB64, WebCryptoAlgorithm.RSASSA_SHA256, WebCryptoUsage.VERIFY, {
+    PublicKey$import(keyB64, WebCryptoAlgorithm.RSASSA_SHA256, WebCryptoUsage.VERIFY, KeyFormat.SPKI, {
         result: function (pubkey) {
             client.addRsaPublicKey(identity, pubkey);
             keyform.style.visibility = 'hidden';

--- a/tests/src/test/javascript/crypto/EccCryptoContextSuite.js
+++ b/tests/src/test/javascript/crypto/EccCryptoContextSuite.js
@@ -65,7 +65,7 @@ describe("EccCryptoContext", function() {
             "y":   "eBVHsIhtASlzUIzGnMAl0TDfj0pqgldZrbsZobEL-78",
             "d":   "TBP2kKufnhTHEf88VPcOIPDlk8uAFlLgi7C1iv86huY",
             "use": "sig",
-            "kid": "B"
+            "kid": "Bpriv"
         }
     };
 
@@ -84,43 +84,24 @@ describe("EccCryptoContext", function() {
                 var extractable = true;
                 var _algo = WebCryptoAlgorithm.ECDSA_SHA256;
                 _algo['namedCurve'] = ECDSA_KEYPAIR_A.publicKeyJSON['crv'];
+                
+                PublicKey$import(ECDSA_KEYPAIR_A.publicKeyJSON, WebCryptoAlgorithm.ECDSA_SHA256, WebCryptoUsage.VERIFY, KeyFormat.JWK, {
+                    result: function (pubkey) { publicKeyA = pubkey; },
+                    error:  function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                PrivateKey$import(ECDSA_KEYPAIR_A.privateKeyJSON, WebCryptoAlgorithm.ECDSA_SHA256, WebCryptoUsage.SIGN, KeyFormat.JWK, {
+                    result: function (privkey) { privateKeyA = privkey; },
+                    error:  function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+                PublicKey$import(ECDSA_KEYPAIR_B.publicKeyJSON, WebCryptoAlgorithm.ECDSA_SHA256, WebCryptoUsage.VERIFY, KeyFormat.JWK, {
+                    result: function (pubkey) { publicKeyB = pubkey; },
+                    error:  function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
 
-                mslCrypto["importKey"]("jwk", ECDSA_KEYPAIR_A.publicKeyJSON, _algo, extractable, ["verify"])
-                    .then(function (key) {
-                        PublicKey$create(key, {
-                            result: function(publicKey) { publicKeyA = publicKey; },
-                            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-                        });
-                    },
-                    function(e) { expect(function() { throw e; }).not.toThrow(); }
-                );
-                mslCrypto["importKey"]("jwk", ECDSA_KEYPAIR_A.privateKeyJSON, _algo, extractable, ["sign"])
-                    .then(function (key) {
-                        PrivateKey$create(key, {
-                            result: function(privateKey) { privateKeyA = privateKey; },
-                            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-                        });
-                    },
-                    function(e) { expect(function() { throw e; }).not.toThrow(); }
-                );
-                mslCrypto["importKey"]("jwk", ECDSA_KEYPAIR_B.publicKeyJSON, _algo, extractable, ["verify"])
-                    .then(function (key) {
-                        PublicKey$create(key, {
-                            result: function(publicKey) { publicKeyB = publicKey; },
-                            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-                        });
-                    },
-                    function(e) { expect(function() { throw e; }).not.toThrow(); }
-                );
-                mslCrypto["importKey"]("jwk", ECDSA_KEYPAIR_B.privateKeyJSON, _algo, extractable, ["sign"])
-                    .then(function (key) {
-                        PrivateKey$create(key, {
-                            result: function(privateKey) { privateKeyB = privateKey; },
-                            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-                        });
-                    },
-                    function(e) { expect(function() { throw e; }).not.toThrow(); }
-                );
+                PrivateKey$import(ECDSA_KEYPAIR_B.privateKeyJSON, WebCryptoAlgorithm.ECDSA_SHA256, WebCryptoUsage.SIGN, KeyFormat.JWK, {
+                    result: function (privkey) { privateKeyB = privkey; },
+                    error:  function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
             });
             waitsFor(function() { return publicKeyA && privateKeyA && publicKeyB && privateKeyB; }, "Import ECDSA keypairs A/B", 1500);
             runs(function() { initialized = true; });

--- a/tests/src/test/javascript/msltests.html
+++ b/tests/src/test/javascript/msltests.html
@@ -70,6 +70,7 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/WebCryptoUsage.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/CipherKey.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/PublicKey.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/crypto/KeyFormat.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/PrivateKey.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/MslCiphertextEnvelope.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/MslSignatureEnvelope.js"></script>

--- a/tests/src/test/javascript/msltests.html
+++ b/tests/src/test/javascript/msltests.html
@@ -45,6 +45,7 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslMessageException.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslUserAuthException.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslUserIdTokenException.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/crypto/KeyFormat.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/WebCryptoAdapter.js"></script>
 <script type="text/javascript">
 	// Change crypto if an override environment is set.
@@ -70,7 +71,6 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/WebCryptoUsage.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/CipherKey.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/PublicKey.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/crypto/KeyFormat.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/PrivateKey.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/MslCiphertextEnvelope.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/MslSignatureEnvelope.js"></script>


### PR DESCRIPTION
This commit addresses Issue#122.
Enables support for import of JWK format, whereas before it was hard-coded to PKCS8 for private keys and SPKI for public keys.