### PR TITLE
Use message stream factory for message input stream creation

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -1630,7 +1630,7 @@ public class MslControl {
             keyRequestData.addAll(request.getKeyRequestData());
         final Map<String,ICryptoContext> cryptoContexts = msgCtx.getCryptoContexts();
         final InputStream is = (filterFactory != null) ? filterFactory.getInputStream(in) : in;
-        final MessageInputStream response = new MessageInputStream(ctx, is, MslConstants.DEFAULT_CHARSET, keyRequestData, cryptoContexts);
+        final MessageInputStream response = streamFactory.createInputStream(ctx, is, MslConstants.DEFAULT_CHARSET, keyRequestData, cryptoContexts);
 
         // Deliver the received header to the debug context.
         final MessageHeader responseHeader = response.getMessageHeader();


### PR DESCRIPTION
It appears that the MessageStreamFactory was not being used when creating the MessageInputStream. This is necessary to provide a custom MessageInputStream (or more importantly to me, the ability to catch exceptions made during MessageInputStream's creation.)