### PR TITLE
Catch MslException from MessageInputStream.isHandshake()

### DIFF
--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -2918,12 +2918,24 @@ var MslControl$MslChannel;
                                // If we were cancelled then return null.
                                if (cancelled(e)) return null;
 
-                               // We couldn't read, but maybe we can write an error response.
-                               var recipient = request.getIdentity();
-                               var requestMessageId = requestHeader.messageId;
-                               var mslError = MslError.INTERNAL_EXCEPTION;
-                               var toThrow = new MslInternalException("Error peeking into the message payloads.");
-                               sendError(this, this._ctrl, this._ctx, this._msgCtx.getDebugContext(), recipient, requestMessageId, mslError, null, this._output, this._timeout, {
+                               // Try to send an error response.
+                               var recipient, requestMessageId, mslError, userMessage, toThrow;
+                               if (e instanceof MslException) {
+                                   var masterToken = e.masterToken;
+                                   var entityAuthData = e.entityAuthenticationData;
+                                   recipient = (masterToken) ? masterToken.identity : ((entityAuthData) ? entityAuthData.getIdentity() : null);
+                                   requestMessageId = e.messageId;
+                                   mslError = e.error;
+                                   userMessage = this._ctrl.messageRegistry.getUserMessage(mslError, null);
+                                   toThrow = e;
+                               } else {
+                                   recipient = request.getIdentity();
+                                   requestMessageId = requestHeader.messageId;
+                                   mslError = MslError.INTERNAL_EXCEPTION;
+                                   userMessage = null;
+                                   toThrow = new MslInternalException("Error peeking into the message payloads.", e);
+                               }
+                               sendError(this, this._ctrl, this._ctx, this._msgCtx.getDebugContext(), recipient, requestMessageId, mslError, userMessage, this._output, this._timeout, {
                                    result: function(success) { callback.error(toThrow); },
                                    timeout: function() { callback.timeout(); },
                                    error: function(re) {

--- a/examples/simple/src/main/javascript/client/SimpleClient.html
+++ b/examples/simple/src/main/javascript/client/SimpleClient.html
@@ -55,6 +55,7 @@
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/WebCryptoAdapter.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/WebCryptoAlgorithm.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/KeyFormat.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/CipherKey.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/PublicKey.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/PrivateKey.js"></script>

--- a/examples/simple/src/main/javascript/client/SimpleClient.js
+++ b/examples/simple/src/main/javascript/client/SimpleClient.js
@@ -73,7 +73,7 @@ var SimpleClient$create;
             var self = this;
             
             // Import the server RSA public key.
-            PublicKey$import(SimpleConstants.RSA_PUBKEY_B64, WebCryptoAlgorithm.RSASSA_SHA256, WebCryptoUsage.VERIFY, {
+            PublicKey$import(SimpleConstants.RSA_PUBKEY_B64, WebCryptoAlgorithm.RSASSA_SHA256, WebCryptoUsage.VERIFY, KeyFormat.SPKI, {
                 result: function(publicKey) {
                 	AsyncExecutor(callback, function() {
 	                    // Create the key manager.


### PR DESCRIPTION
Fixes #134.
Catch MslException before catching generic Throwable from MessageInputStream.isHandshake() in ReceiveService so a proper MSL error response can be sent back in response.

Update simple example JavaScript client so it uses provides the key format argument to PublicKey$import().