### PR TITLE
Do not include encrypted data in MSL token toString() methods.

### DIFF
--- a/core/src/main/java/com/netflix/msl/tokens/MasterToken.java
+++ b/core/src/main/java/com/netflix/msl/tokens/MasterToken.java
@@ -571,27 +571,12 @@ public class MasterToken implements JSONString {
     @Override
     public String toString() {
         try {
-            final JSONObject sessiondataJO;
-            if (isDecrypted()) {
-                sessiondataJO = new JSONObject();
-                if (issuerData != null)
-                    sessiondataJO.put(KEY_ISSUER_DATA, issuerData);
-                sessiondataJO.put(KEY_IDENTITY, identity);
-                sessiondataJO.put(KEY_ENCRYPTION_KEY, encryptionKey);
-                sessiondataJO.put(KEY_ENCRYPTION_ALGORITHM, encryptionKey.getAlgorithm());
-                sessiondataJO.put(KEY_HMAC_KEY, signatureKey);
-                sessiondataJO.put(KEY_SIGNATURE_KEY, signatureKey);
-                sessiondataJO.put(KEY_SIGNATURE_ALGORITHM, signatureKey.getAlgorithm());
-            } else {
-                sessiondataJO = null;
-            }
-            
             final JSONObject tokendataJO = new JSONObject();
             tokendataJO.put(KEY_RENEWAL_WINDOW, renewalWindow);
             tokendataJO.put(KEY_EXPIRATION, expiration);
             tokendataJO.put(KEY_SEQUENCE_NUMBER, sequenceNumber);
             tokendataJO.put(KEY_SERIAL_NUMBER, serialNumber);
-            tokendataJO.put(KEY_SESSIONDATA, sessiondataJO);
+            tokendataJO.put(KEY_SESSIONDATA, "(redacted)");
             
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_TOKENDATA, tokendataJO);

--- a/core/src/main/java/com/netflix/msl/tokens/ServiceToken.java
+++ b/core/src/main/java/com/netflix/msl/tokens/ServiceToken.java
@@ -550,7 +550,7 @@ public class ServiceToken implements JSONString {
             tokendataJO.put(KEY_NAME, name);
             tokendataJO.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, mtSerialNumber);
             tokendataJO.put(KEY_USER_ID_TOKEN_SERIAL_NUMBER, uitSerialNumber);
-            tokendataJO.put(KEY_SERVICEDATA, Base64.encode(servicedata));
+            tokendataJO.put(KEY_SERVICEDATA, "(redacted)");
             
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_TOKENDATA, tokendataJO);

--- a/core/src/main/java/com/netflix/msl/tokens/UserIdToken.java
+++ b/core/src/main/java/com/netflix/msl/tokens/UserIdToken.java
@@ -453,22 +453,12 @@ public class UserIdToken implements JSONString {
     @Override
     public String toString() {
         try {
-            final JSONObject userdataJO;
-            if (isDecrypted()) {
-                userdataJO = new JSONObject();
-                if (issuerData != null)
-                    userdataJO.put(KEY_ISSUER_DATA, issuerData);
-                userdataJO.put(KEY_IDENTITY, user);
-            } else {
-                userdataJO = null;
-            }
-            
             final JSONObject tokendataJO = new JSONObject();
             tokendataJO.put(KEY_RENEWAL_WINDOW, renewalWindow);
             tokendataJO.put(KEY_EXPIRATION, expiration);
             tokendataJO.put(KEY_MASTER_TOKEN_SERIAL_NUMBER, mtSerialNumber);
             tokendataJO.put(KEY_SERIAL_NUMBER, serialNumber);
-            tokendataJO.put(KEY_USERDATA, userdataJO);
+            tokendataJO.put(KEY_USERDATA, "(redacted)");
             
             final JSONObject jsonObj = new JSONObject();
             jsonObj.put(KEY_TOKENDATA, tokendataJO);


### PR DESCRIPTION
Fixes #139: Replace encrypted data in MSL token toString() methods with "(redacted)" to prevent data leakage.
JavaScript JSON.stringify() of tokens does not include all properties, and default toString() prints "[object X]".