### PR TITLE
Change MslEncoderFactory to an abstract class.

### DIFF
--- a/core/.cproject
+++ b/core/.cproject
@@ -25,11 +25,11 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.GNU_ELF" id="cdt.managedbuild.target.gnu.platform.base.1400965496" name="Debug Platform" osList="linux,hpux,aix,qnx" superClass="cdt.managedbuild.target.gnu.platform.base"/>
 							<builder buildPath="${workspace_loc:/msl-core}/Debug" id="cdt.managedbuild.target.gnu.builder.base.192413189" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.base"/>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.base.2107711396" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.base.566882653" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.base">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.base.566882653" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.base">
 								<option id="gnu.cpp.compiler.option.include.paths.1176293145" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.248467956" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -48,9 +48,12 @@
 								<option id="gnu.cpp.compiler.option.other.other.2089049824" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -Wpointer-arith -fno-omit-frame-pointer -Wformat -Werror=format-security -Werror=array-bounds -fstack-protector" valueType="string"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1568521198" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.base.1042528537" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.base">
+							<tool command="/usr/local/bin/gcc-6" id="cdt.managedbuild.tool.gnu.c.compiler.base.1042528537" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.base">
 								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.1731951814" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.debugging.level.463270755" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.include.paths.662142595" superClass="gnu.c.compiler.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
+								</option>
 								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.633297990" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.c.linker.base.594559233" name="GCC C Linker" superClass="cdt.managedbuild.tool.gnu.c.linker.base"/>
@@ -96,11 +99,11 @@
 								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1540364342" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.2133422945" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="g++" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1119489500" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1119489500" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
 								<option id="gnu.cpp.compiler.option.include.paths.1221189470" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1724244947" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -119,10 +122,13 @@
 								<option id="gnu.cpp.compiler.option.other.other.388119371" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -Wpointer-arith -fno-omit-frame-pointer -Wformat -Werror=format-security -Werror=array-bounds -fstack-protector" valueType="string"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.2023418286" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool command="gcc" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.953879823" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+							<tool command="/usr/local/bin/gcc-6" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.953879823" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
 								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.193423605" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.debugging.level.1590413777" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.dialect.std.1707864846" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.include.paths.1644780074" superClass="gnu.c.compiler.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
+								</option>
 								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1011007670" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>

--- a/core/src/main/cpp/io/DefaultMslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/DefaultMslEncoderFactory.cpp
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <io/DefaultMslEncoderFactory.h>
+#include <io/JsonMslObject.h>
+#include <io/JsonMslTokenizer.h>
+#include <io/MslEncoderException.h>
+#include <io/MslEncoderFormat.h>
+#include <memory>
+#include <set>
+#include <string>
+
+using namespace std;
+
+namespace netflix {
+namespace msl {
+namespace io {
+
+MslEncoderFormat DefaultMslEncoderFactory::getPreferredFormat(const set<MslEncoderFormat>&)
+{
+    // We don't know about any other formats right now.
+    return MslEncoderFormat::JSON;
+}
+
+shared_ptr<MslTokenizer> DefaultMslEncoderFactory::generateTokenizer(shared_ptr<InputStream> source, const MslEncoderFormat& format)
+{
+    // JSON.
+    if (format == MslEncoderFormat::JSON)
+        return make_shared<JsonMslTokenizer>(source);
+
+    // Unsupported encoder format.
+    stringstream ss;
+    ss << "Unsupported encoder format: " << format << ".";
+    throw MslEncoderException(ss.str());
+}
+
+shared_ptr<MslObject> DefaultMslEncoderFactory::parseObject(shared_ptr<ByteArray> encoding)
+{
+    // Identify the encoder format.
+    const MslEncoderFormat format = parseFormat(encoding);
+
+    // JSON.
+    if (format == MslEncoderFormat::JSON)
+        return make_shared<JsonMslObject>(encoding);
+
+    // Unsupported encoder format.
+    stringstream ss;
+    ss << "Unsupported encoder format: " << format << ".";
+    throw MslEncoderException(ss.str());
+}
+
+shared_ptr<ByteArray> DefaultMslEncoderFactory::encodeObject(shared_ptr<MslObject> object, const MslEncoderFormat& format)
+{
+    // JSON.
+    if (format == MslEncoderFormat::JSON)
+    	return JsonMslObject::getEncoded(shared_from_this(), object);
+
+    // Unsupported encoder format.
+    stringstream ss;
+    ss << "Unsupported encoder format: " << format << ".";
+    throw MslEncoderException(ss.str());
+}
+
+}}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/DefaultMslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/DefaultMslEncoderFactory.cpp
@@ -21,6 +21,7 @@
 #include <io/MslEncoderFormat.h>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 
 using namespace std;

--- a/core/src/main/cpp/io/DefaultMslEncoderFactory.h
+++ b/core/src/main/cpp/io/DefaultMslEncoderFactory.h
@@ -60,3 +60,5 @@ public:
 };
 
 }}} // namespace netflix::msl::io
+
+#endif /* SRC_IO_DEFAULTMSLENCODERFACTORY_H_ */

--- a/core/src/main/cpp/io/DefaultMslEncoderFactory.h
+++ b/core/src/main/cpp/io/DefaultMslEncoderFactory.h
@@ -18,10 +18,15 @@
 #define SRC_IO_DEFAULTMSLENCODERFACTORY_H_
 
 #include <io/MslEncoderFactory.h>
+#include <io/MslEncoderFormat.h>
+#include <memory>
+#include <set>
 
 namespace netflix {
 namespace msl {
+typedef std::vector<uint8_t> ByteArray;
 namespace io {
+class InputStream; class MslObject; class MslTokenizer;
 
 /**
  * <p>Default {@link MslEncoderFactory} implementation that supports the
@@ -33,5 +38,25 @@ namespace io {
  *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
+class DefaultMslEncoderFactory : public MslEncoderFactory
+{
+public:
+	virtual ~DefaultMslEncoderFactory() {}
+	DefaultMslEncoderFactory() {}
+
+	/** @inheritDoc */
+	virtual MslEncoderFormat getPreferredFormat(const std::set<MslEncoderFormat>& formats = std::set<MslEncoderFormat>());
+
+protected:
+	/** @inheritDoc */
+	virtual std::shared_ptr<MslTokenizer> generateTokenizer(std::shared_ptr<InputStream> source, const MslEncoderFormat& format);
+
+public:
+	/** @inheritDoc */
+	virtual std::shared_ptr<MslObject> parseObject(std::shared_ptr<ByteArray> encoding);
+
+	/** @inheritDoc */
+	virtual std::shared_ptr<ByteArray> encodeObject(std::shared_ptr<MslObject> object, const MslEncoderFormat& format);
+};
 
 }}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/MslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/MslEncoderFactory.cpp
@@ -134,7 +134,7 @@ shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStre
     } catch (const MslEncoderException& e) {
         throw MslEncoderException("Failure reading the byte stream identifier.", e);
     }
-    return createTokenizer(source, format);
+    return generateTokenizer(source, format);
 }
 
 }}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/MslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/MslEncoderFactory.cpp
@@ -15,8 +15,6 @@
  */
 
 #include <io/InputStream.h>
-#include <io/JsonMslObject.h>
-#include <io/JsonMslTokenizer.h>
 #include <io/MslArray.h>
 #include <io/MslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
@@ -103,12 +101,6 @@ string MslEncoderFactory::stringify(const Variant& value)
     }
 }
 
-MslEncoderFormat MslEncoderFactory::getPreferredFormat(const set<MslEncoderFormat>&)
-{
-    // We don't know about any other formats right now.
-    return MslEncoderFormat::JSON;
-}
-
 MslEncoderFormat MslEncoderFactory::parseFormat(shared_ptr<ByteArray> encoding)
 {
     // Fail if the encoding is too short.
@@ -127,33 +119,6 @@ MslEncoderFormat MslEncoderFactory::parseFormat(shared_ptr<ByteArray> encoding)
     return format;
 }
 
-shared_ptr<MslObject> MslEncoderFactory::parseObject(shared_ptr<ByteArray> encoding)
-{
-    // Identify the encoder format.
-    const MslEncoderFormat format = parseFormat(encoding);
-
-    // JSON.
-    if (format == MslEncoderFormat::JSON)
-        return make_shared<JsonMslObject>(encoding);
-
-    // Unsupported encoder format.
-    stringstream ss;
-    ss << "Unsupported encoder format: " << format << ".";
-    throw MslEncoderException(ss.str());
-}
-
-shared_ptr<ByteArray> MslEncoderFactory::encodeObject(shared_ptr<MslObject> object, const MslEncoderFormat& format)
-{
-    // JSON.
-    if (format == MslEncoderFormat::JSON)
-    	return JsonMslObject::getEncoded(shared_from_this(), object);
-
-    // Unsupported encoder format.
-    stringstream ss;
-    ss << "Unsupported encoder format: " << format << ".";
-    throw MslEncoderException(ss.str());
-}
-
 shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStream> source)
 {
     // Identify the encoder format.
@@ -170,18 +135,6 @@ shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStre
         throw MslEncoderException("Failure reading the byte stream identifier.", e);
     }
     return createTokenizer(source, format);
-}
-
-shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStream> source, const MslEncoderFormat& format)
-{
-    // JSON.
-    if (format == MslEncoderFormat::JSON)
-        return make_shared<JsonMslTokenizer>(source);
-
-    // Unsupported encoder format.
-    stringstream ss;
-    ss << "Unsupported encoder format: " << format << ".";
-    throw MslEncoderException(ss.str());
 }
 
 }}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/MslEncoderFactory.h
+++ b/core/src/main/cpp/io/MslEncoderFactory.h
@@ -32,6 +32,17 @@ namespace io {
 class InputStream;
 class Variant;
 
+/**
+ * <p>An abstract factory class for producing {@link MslTokener},
+ * {@link MslObject}, and {@link MslArray} instances of various encoder
+ * formats.</p>
+ *
+ * <p>A concrete implementations must identify its supported and preferred
+ * encoder formats and provide implementations for encoding and decoding those
+ * formats.</p>
+ *
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
 class MslEncoderFactory : public std::enable_shared_from_this<MslEncoderFactory>
 {
 public:
@@ -65,7 +76,7 @@ public:
      * @return the preferred format from the provided set or the default format
      *         if format set is missing or empty.
      */
-    MslEncoderFormat getPreferredFormat(const std::set<MslEncoderFormat>& formats = std::set<MslEncoderFormat>());
+    virtual MslEncoderFormat getPreferredFormat(const std::set<MslEncoderFormat>& formats = std::set<MslEncoderFormat>()) = 0;
 
     /**
      * Create a new {@link MslTokenizer}. The encoder format will be
@@ -79,6 +90,7 @@ public:
      */
     std::shared_ptr<MslTokenizer> createTokenizer(std::shared_ptr<InputStream> source);
 
+protected:
     /**
      * Create a new {@link MslTokenizer} of the specified encoder format.
      *
@@ -87,8 +99,9 @@ public:
      * @return the {@link MslTokenizer}.
      * @throws MslEncoderException if the encoder format is not supported.
      */
-    std::shared_ptr<MslTokenizer> createTokenizer(std::shared_ptr<InputStream> source, const MslEncoderFormat& format);
+    virtual std::shared_ptr<MslTokenizer> generateTokenizer(std::shared_ptr<InputStream> source, const MslEncoderFormat& format) = 0;
 
+public:
     /**
      * Create a new {@link MslObject} populated with the provided map.
      *
@@ -122,7 +135,7 @@ public:
      * @throws MslEncoderException if the encoder format is not supported or
      *         there is an error parsing the encoded data.
      */
-    std::shared_ptr<MslObject> parseObject(std::shared_ptr<ByteArray> encoding);
+    virtual std::shared_ptr<MslObject> parseObject(std::shared_ptr<ByteArray> encoding) = 0;
 
     /**
      * Encode a {@link MslObject} into the specified encoder format.
@@ -133,7 +146,7 @@ public:
      * @throws MslEncoderException if the encoder format is not supported or
      *         there is an error encoding the object.
      */
-    std::shared_ptr<ByteArray> encodeObject(std::shared_ptr<MslObject> object, const MslEncoderFormat& format);
+    virtual std::shared_ptr<ByteArray> encodeObject(std::shared_ptr<MslObject> object, const MslEncoderFormat& format) = 0;
 
     /**
      * Create a new {@link MslArray} populated with the provided list.

--- a/core/src/main/cpp/msg/MslControl.cpp
+++ b/core/src/main/cpp/msg/MslControl.cpp
@@ -94,6 +94,36 @@ namespace {
  */
 class DummyMslContext : public MslContext
 {
+private:
+	class DummyMslEncoderFactory : public MslEncoderFactory
+	{
+	public:
+		virtual ~DummyMslEncoderFactory() {}
+		DummyMslEncoderFactory() {}
+
+		/** @inheritDoc */
+		virtual MslEncoderFormat getPreferredFormat(const std::set<MslEncoderFormat>& formats = std::set<MslEncoderFormat>()) {
+			return MslEncoderFormat::JSON;
+		}
+
+	protected:
+		/** @inheritDoc */
+		virtual std::shared_ptr<MslTokenizer> generateTokenizer(std::shared_ptr<InputStream> source, const MslEncoderFormat& format) {
+			throw new MslInternalException("DummyMslEncoderFactory.createTokenizer() not supported.");
+		}
+
+	public:
+		/** @inheritDoc */
+		virtual std::shared_ptr<MslObject> parseObject(std::shared_ptr<ByteArray> encoding) {
+            throw new MslInternalException("DummyMslEncoderFactory.parseObject() not supported.");
+		}
+
+		/** @inheritDoc */
+		virtual std::shared_ptr<ByteArray> encodeObject(std::shared_ptr<MslObject> object, const MslEncoderFormat& format) {
+            throw new MslInternalException("DummyMslEncoderFactory.encodeObject() not supported.");
+		}
+	};
+
 public:
     virtual ~DummyMslContext() {}
     DummyMslContext()
@@ -101,7 +131,7 @@ public:
     , entityAuthData(make_shared<UnauthenticatedAuthenticationData>("dummy"))
     , mslCryptoContext(make_shared<NullCryptoContext>())
     , store(make_shared<SimpleMslStore>())
-    , encoderFactory(make_shared<MslEncoderFactory>())
+    , encoderFactory(make_shared<DummyMslEncoderFactory>())
     {}
     /** @inheritDoc */
     virtual int64_t getTime() override {

--- a/tests/.cproject
+++ b/tests/.cproject
@@ -20,17 +20,17 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.43558529" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
 							<builder buildPath="${workspace_loc:/msl-tests}/Debug" id="cdt.managedbuild.target.gnu.builder.macosx.base.756034131" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
 							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.1459502394" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1654787322" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
-								<option id="macosx.cpp.link.option.libs.1283465021" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" valueType="libs">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1654787322" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
+								<option id="macosx.cpp.link.option.libs.1283465021" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="msl-core"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="crypto"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="pthread"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="curl"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="z"/>
 								</option>
-								<option id="macosx.cpp.link.option.paths.1082102412" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" valueType="libPaths">
+								<option id="macosx.cpp.link.option.paths.1082102412" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/lib"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/lib"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1103657322" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
@@ -38,20 +38,20 @@
 								</inputType>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.598028434" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<option id="gnu.both.asm.option.include.paths.1616660223" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+								<option id="gnu.both.asm.option.include.paths.1616660223" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.738645599" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1675106369" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1378869369" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+							<tool command="/usr/local/bin/g++-6" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1378869369" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
 								<option id="gnu.cpp.compiler.option.include.paths.592003339" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1527158162" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -71,7 +71,7 @@
 								<option id="gnu.cpp.compiler.option.warnings.wconversion.480305465" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1835043685" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.697820670" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+							<tool command="/usr/local/bin/gcc-6" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.697820670" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
 								<option id="gnu.c.compiler.option.include.paths.1641897067" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
@@ -122,17 +122,17 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.1489325537" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
 							<builder buildPath="${workspace_loc:/msl-tests}/Release" id="cdt.managedbuild.target.gnu.builder.macosx.base.897652761" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
 							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.81692079" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.97252435" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
-								<option id="macosx.cpp.link.option.libs.1535008202" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" valueType="libs">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.97252435" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
+								<option id="macosx.cpp.link.option.libs.1535008202" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="msl-core"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="crypto"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="pthread"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="curl"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="z"/>
 								</option>
-								<option id="macosx.cpp.link.option.paths.1230734662" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" valueType="libPaths">
+								<option id="macosx.cpp.link.option.paths.1230734662" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Release}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/lib"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/lib"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.715455431" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
@@ -140,20 +140,20 @@
 								</inputType>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.721091445" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<option id="gnu.both.asm.option.include.paths.658336774" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+								<option id="gnu.both.asm.option.include.paths.658336774" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1037113984" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.968914762" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.254011418" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.254011418" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
 								<option id="gnu.cpp.compiler.option.include.paths.1714447920" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.349980858" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -173,7 +173,7 @@
 								<option id="gnu.cpp.compiler.option.debugging.other.1896894688" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="-ggdb" valueType="string"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.2000522692" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1428963431" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+							<tool command="/usr/local/bin/gcc-6" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1428963431" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
 								<option id="gnu.c.compiler.option.include.paths.608128227" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
@@ -231,14 +231,14 @@
 								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1049126314" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1137820216" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.271260144" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.271260144" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
 								<option id="gnu.cpp.compiler.option.include.paths.561756412" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1845721471" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -258,7 +258,7 @@
 								<option id="gnu.cpp.compiler.option.warnings.wconversion.879985015" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.359003652" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.859845840" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+							<tool command="/usr/local/bin/gcc-6" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.859845840" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
 								<option id="gnu.c.compiler.option.include.paths.2045100379" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
@@ -317,14 +317,14 @@
 								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.84373148" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1443167072" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1424187117" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1424187117" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
 								<option id="gnu.cpp.compiler.option.include.paths.465623166" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2j/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2k/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1520566858" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -344,7 +344,7 @@
 								<option id="gnu.cpp.compiler.option.debugging.other.1083324839" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="-ggdb" valueType="string"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1518815171" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1158370398" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+							<tool command="/usr/local/bin/gcc-6" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1158370398" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
 								<option id="gnu.c.compiler.option.include.paths.1586792133" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
@@ -395,19 +395,10 @@
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.c.compiler.1271217917;cdt.managedbuild.tool.gnu.c.compiler.input.1047369648">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.;cdt.managedbuild.tool.gnu.cross.c.compiler.193001381;cdt.managedbuild.tool.gnu.c.compiler.input.1700288313">
-			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1758396738;cdt.managedbuild.tool.gnu.cpp.compiler.input.1907247798">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.2038242061;cdt.managedbuild.tool.gnu.cpp.compiler.input.1208744840">
-			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1713394223;cdt.managedbuild.tool.gnu.cpp.compiler.input.594573441">
-			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.997365688;cdt.managedbuild.tool.gnu.cpp.compiler.input.1274738516">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1646818905;cdt.managedbuild.tool.gnu.cpp.compiler.input.1208905405">
@@ -419,7 +410,40 @@
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.c.compiler.1507735585;cdt.managedbuild.tool.gnu.c.compiler.input.111761167">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.697820670;cdt.managedbuild.tool.gnu.c.compiler.input.672006609">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619.;cdt.managedbuild.tool.gnu.cross.c.compiler.1117066135;cdt.managedbuild.tool.gnu.c.compiler.input.341131599">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633.;cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1424187117;cdt.managedbuild.tool.gnu.cpp.compiler.input.1518815171">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1378869369;cdt.managedbuild.tool.gnu.cpp.compiler.input.1835043685">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.;cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.254011418;cdt.managedbuild.tool.gnu.cpp.compiler.input.2000522692">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.859845840;cdt.managedbuild.tool.gnu.c.compiler.input.870066761">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.;cdt.managedbuild.tool.gnu.cross.c.compiler.193001381;cdt.managedbuild.tool.gnu.c.compiler.input.1700288313">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1428963431;cdt.managedbuild.tool.gnu.c.compiler.input.898258631">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.2038242061;cdt.managedbuild.tool.gnu.cpp.compiler.input.1208744840">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.997365688;cdt.managedbuild.tool.gnu.cpp.compiler.input.1274738516">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619.;cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.271260144;cdt.managedbuild.tool.gnu.cpp.compiler.input.359003652">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1158370398;cdt.managedbuild.tool.gnu.c.compiler.input.1796434685">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 	</storageModule>

--- a/tests/src/main/cpp/util/MockMslContext.cpp
+++ b/tests/src/main/cpp/util/MockMslContext.cpp
@@ -25,7 +25,7 @@
 #include <entityauth/RsaAuthenticationData.h>
 #include <entityauth/UnauthenticatedAuthenticationData.h>
 #include <entityauth/UnauthenticatedAuthenticationFactory.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <keyx/AsymmetricWrappedExchange.h>
 #include <keyx/DiffieHellmanExchange.h>
 #include <keyx/KeyExchangeScheme.h>
@@ -125,7 +125,7 @@ MockMslContext::MockMslContext(const EntityAuthenticationScheme& scheme, bool pe
 
     tokenFactory = make_shared<MockTokenFactory>();
     store = make_shared<SimpleMslStore>();
-    encoderFactory = make_shared<MslEncoderFactory>();
+    encoderFactory = make_shared<DefaultMslEncoderFactory>();
 
     shared_ptr<DiffieHellmanParameters> params = MockDiffieHellmanParameters::getDefaultParameters();
     authutils = make_shared<MockAuthenticationUtils>();

--- a/tests/src/test/cpp/MslExceptionTest.cpp
+++ b/tests/src/test/cpp/MslExceptionTest.cpp
@@ -18,7 +18,7 @@
 #include <gmock/gmock.h>
 #include <entityauth/EntityAuthenticationData.h>
 #include <entityauth/EntityAuthenticationScheme.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <io/MslObject.h>
 #include <MslException.h>
@@ -240,7 +240,7 @@ TEST_F(MslExceptionTest, UserAuthenticationData)
     shared_ptr<ByteArray> encoding1 = make_shared<ByteArray>(data1, data1 + sizeof(data1));
     const char data2[] = { 0x4, 0x5, 0x6 };
     shared_ptr<ByteArray> encoding2 = make_shared<ByteArray>(data2, data2 + sizeof(data2));
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> mef = make_shared<DefaultMslEncoderFactory>();
     MslEncoderFormat format = MslEncoderFormat::JSON;
 
     // set / get

--- a/tests/src/test/cpp/crypto/MslCiphertextEnvelopeSuite.cpp
+++ b/tests/src/test/cpp/crypto/MslCiphertextEnvelopeSuite.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <crypto/MslCiphertextEnvelope.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <io/MslObject.h>
 #include <MslCryptoException.h>
@@ -309,6 +309,8 @@ TEST_F(MslCiphertextEnvelopeTest, CreateMslCiphertextEnvelopebadVersion)
     }
 }
 
+// FIXME: This is an error-prone test because there is no guarantee of how
+// a JSON encoding might be constructed or formatted.
 TEST_F(MslCiphertextEnvelopeTest, ToMslEncoding)
 {
     shared_ptr<MslObject> mo1 = make_shared<MslObject>();
@@ -320,7 +322,7 @@ TEST_F(MslCiphertextEnvelopeTest, ToMslEncoding)
     mo1->put<shared_ptr<ByteArray>>(KEY_SHA256, sha);
 
     // V1 with IV
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> mef = make_shared<DefaultMslEncoderFactory>();
     shared_ptr<ByteArray> ba;
     ba = createMslCiphertextEnvelope(mo1).toMslEncoding(mef, io::MslEncoderFormat::JSON);
     EXPECT_EQ(

--- a/tests/src/test/cpp/crypto/MslSignatureEnvelopeSuite.cpp
+++ b/tests/src/test/cpp/crypto/MslSignatureEnvelopeSuite.cpp
@@ -18,6 +18,7 @@
 #include <crypto/MslSignatureEnvelope.h>
 #include <crypto/OpenSslLib.h>
 #include <crypto/Random.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <io/MslObject.h>
@@ -33,7 +34,7 @@ namespace crypto {
 
 namespace {
 
-std::shared_ptr<io::MslEncoderFactory> encoder = std::make_shared<io::MslEncoderFactory>();
+std::shared_ptr<io::MslEncoderFactory> encoder = std::make_shared<io::DefaultMslEncoderFactory>();
 const std::string KEY_VERSION = "version";
 const std::string KEY_ALGORITHM = "algorithm";
 const std::string KEY_SIGNATURE = "signature";

--- a/tests/src/test/cpp/crypto/NullCryptoContextTest.cpp
+++ b/tests/src/test/cpp/crypto/NullCryptoContextTest.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <crypto/NullCryptoContext.h>
 #include <crypto/Random.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 
 using namespace std;
@@ -39,7 +39,7 @@ TEST_F(NullCryptoContextTest, Main)
     random.nextBytes(*dataA);
     EXPECT_EQ(128u, dataA->size());
     NullCryptoContext ctx;
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> mef = make_shared<DefaultMslEncoderFactory>();
     MslEncoderFormat fmt = MslEncoderFormat::JSON;
 
 

--- a/tests/src/test/cpp/crypto/SymmetricCryptoContextTest.cpp
+++ b/tests/src/test/cpp/crypto/SymmetricCryptoContextTest.cpp
@@ -22,7 +22,7 @@
 #include <crypto/Key.h>
 #include <crypto/MslCiphertextEnvelope.h>
 #include <crypto/Random.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <IllegalArgumentException.h>
 #include <MslCryptoException.h>
@@ -99,7 +99,7 @@ protected:
     const SecretKey encryptionKey_;
     const SecretKey signatureKey_;
     const SecretKey wrappingKey_;
-    shared_ptr<MslEncoderFactory> encoder_ = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> encoder_ = make_shared<DefaultMslEncoderFactory>();
     const MslEncoderFormat encoderFormat_;
     const string KEY_CIPHERTEXT;
     const string KEYSET_ID;

--- a/tests/src/test/cpp/crypto/SymmetricCryptoContextTest.cpp
+++ b/tests/src/test/cpp/crypto/SymmetricCryptoContextTest.cpp
@@ -150,7 +150,7 @@ TEST_P(SymmetricCryptoContextTest, EncryptDecrypt1)
     SecretKey encryptionKey(util::fromHex("000102030405060708090a0b0c0d0e0f"), JcaAlgorithm::AES);
     SymmetricCryptoContext scc(ctx_, "foobar", encryptionKey, nullKey, nullKey);
 
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> mef = make_shared<DefaultMslEncoderFactory>();
     const MslEncoderFormat fmt = MslEncoderFormat::JSON;
     shared_ptr<ByteArray> data = util::fromHex("00112233445566778899aa");
     shared_ptr<ByteArray> ciphertext = scc.encrypt(data, mef, fmt);

--- a/tests/src/test/cpp/entityauth/EntityAuthenticationDataTest.cpp
+++ b/tests/src/test/cpp/entityauth/EntityAuthenticationDataTest.cpp
@@ -48,10 +48,16 @@ const string KEY_AUTHDATA = "authdata";
 class EntityAuthenticationDataTest : public ::testing::Test
 {
 public:
-    EntityAuthenticationDataTest() {}
+	virtual ~EntityAuthenticationDataTest() {}
+
+    EntityAuthenticationDataTest()
+    	: ctx(make_shared<MockMslContext>(EntityAuthenticationScheme::PSK, false))
+		, encoder(ctx->getMslEncoderFactory())
+	{}
+
 protected:
-    shared_ptr<MslContext> ctx = make_shared<MockMslContext>(EntityAuthenticationScheme::PSK, false);
-    shared_ptr<MslEncoderFactory> encoder = make_shared<MslEncoderFactory>();
+    shared_ptr<MslContext> ctx;
+    shared_ptr<MslEncoderFactory> encoder;
 };
 
 TEST_F(EntityAuthenticationDataTest, noScheme)

--- a/tests/src/test/cpp/entityauth/PresharedAuthenticationDataTest.cpp
+++ b/tests/src/test/cpp/entityauth/PresharedAuthenticationDataTest.cpp
@@ -17,7 +17,7 @@
 #include <entityauth/EntityAuthenticationScheme.h>
 #include <gtest/gtest.h>
 #include <entityauth/PresharedAuthenticationData.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <io/MslObject.h>
 #include <MslEncodingException.h>
@@ -39,7 +39,7 @@ class PresharedAuthenticationDataTest : public ::testing::Test
 public:
     PresharedAuthenticationDataTest() : format_(MslEncoderFormat::JSON) {}
 protected:
-    shared_ptr<MslEncoderFactory> encoder_ = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> encoder_ = make_shared<DefaultMslEncoderFactory>();
     const MslEncoderFormat format_;
 };
 

--- a/tests/src/test/cpp/io/DefaultMslEncoderFactorySuite.cpp
+++ b/tests/src/test/cpp/io/DefaultMslEncoderFactorySuite.cpp
@@ -32,13 +32,21 @@ namespace {
 shared_ptr<ByteArray> makeByteArray(const string s) {return make_shared<ByteArray>(s.begin(), s.end());}
 }
 
-class MslEncoderFactoryTest : public ::testing::Test
+class DefaultMslEncoderFactoryTest : public ::testing::Test
 {
+public:
+	virtual ~DefaultMslEncoderFactoryTest() {}
+
+	DefaultMslEncoderFactoryTest()
+		: mef(make_shared<DefaultMslEncoderFactory>())
+	{}
+
+protected:
+	shared_ptr<MslEncoderFactory> mef;
 };
 
-TEST_F(MslEncoderFactoryTest, Main)
+TEST_F(DefaultMslEncoderFactoryTest, Main)
 {
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
     Variant nullVar = VariantFactory::createNull();
     EXPECT_EQ("null", mef->stringify(nullVar));
 
@@ -46,10 +54,8 @@ TEST_F(MslEncoderFactoryTest, Main)
     EXPECT_EQ("5", mef->stringify(intVar));
 }
 
-TEST_F(MslEncoderFactoryTest, StringifyPrimitives)
+TEST_F(DefaultMslEncoderFactoryTest, StringifyPrimitives)
 {
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
-
     const Variant nullVar = VariantFactory::createNull();
     EXPECT_EQ("null", mef->stringify(nullVar));
 
@@ -85,12 +91,10 @@ TEST_F(MslEncoderFactoryTest, StringifyPrimitives)
     EXPECT_EQ("[]", mef->stringify(mslAryVar));
 }
 
-TEST_F(MslEncoderFactoryTest, StringifyObjects)
+TEST_F(DefaultMslEncoderFactoryTest, StringifyObjects)
 {
     // NOTE: To a large degree these are duplicates of the ToString tests in
     // MslObject_test and MslArray_test
-
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
 
     shared_ptr<MslObject> mslObj1 = make_shared<MslObject>();
     mslObj1->put<int32_t>("one", 1);
@@ -131,14 +135,13 @@ TEST_F(MslEncoderFactoryTest, StringifyObjects)
     EXPECT_EQ("{\"a\":1,\"b\":[0,1.11,\"2\"],\"c\":3}", mef->stringify(mslObj4));
 }
 
-TEST_F(MslEncoderFactoryTest, Quote)
+TEST_F(DefaultMslEncoderFactoryTest, Quote)
 {
     // FIXME: TODO
 }
 
-TEST_F(MslEncoderFactoryTest, GetPreferredFormat)
+TEST_F(DefaultMslEncoderFactoryTest, GetPreferredFormat)
 {
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
     MslEncoderFormat fmt = mef->getPreferredFormat();
     EXPECT_EQ(MslEncoderFormat::JSON, fmt);
     const std::set<MslEncoderFormat> formats; // empty
@@ -146,9 +149,8 @@ TEST_F(MslEncoderFactoryTest, GetPreferredFormat)
     EXPECT_EQ(MslEncoderFormat::JSON, fmt);
 }
 
-TEST_F(MslEncoderFactoryTest, CreateObject)
+TEST_F(DefaultMslEncoderFactoryTest, CreateObject)
 {
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
     shared_ptr<MslObject> mo1 = mef->createObject();
     EXPECT_EQ(0u, mo1->size());
     MslObject::MapType map;
@@ -168,9 +170,8 @@ TEST_F(MslEncoderFactoryTest, CreateObject)
     EXPECT_NE(*mo1, *mo2);
 }
 
-TEST_F(MslEncoderFactoryTest, ParseFormat)
+TEST_F(DefaultMslEncoderFactoryTest, ParseFormat)
 {
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
     EXPECT_THROW(mef->parseFormat(makeByteArray("")), MslEncoderException);
     EXPECT_THROW(mef->parseFormat(makeByteArray("sdkfgsaflkgd")), MslEncoderException);
     EXPECT_THROW(mef->parseFormat(makeByteArray("[]")), MslEncoderException);
@@ -178,9 +179,8 @@ TEST_F(MslEncoderFactoryTest, ParseFormat)
     EXPECT_EQ(MslEncoderFormat::JSON, format);
 }
 
-TEST_F(MslEncoderFactoryTest, ParseObject)
+TEST_F(DefaultMslEncoderFactoryTest, ParseObject)
 {
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
     EXPECT_THROW(mef->parseObject(makeByteArray("sdkfgsaflkgd")), MslEncoderException);
 
     try {
@@ -195,12 +195,11 @@ TEST_F(MslEncoderFactoryTest, ParseObject)
     }
 }
 
-TEST_F(MslEncoderFactoryTest, EncodeObject)
+TEST_F(DefaultMslEncoderFactoryTest, EncodeObject)
 {
 	shared_ptr<ByteArray> json = makeByteArray(
         "{\"a\":[1,{\"aa\":[10,20,{\"ccc\":[100,200,300]},30]},2],\"b\":9.9}"
     );
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
     shared_ptr<MslObject> jmo = make_shared<JsonMslObject>(json);
     EXPECT_THROW(mef->encodeObject(jmo, MslEncoderFormat::INVALID), MslEncoderException);
     try {
@@ -213,12 +212,11 @@ TEST_F(MslEncoderFactoryTest, EncodeObject)
     }
 }
 
-TEST_F(MslEncoderFactoryTest, CreateTokenizer)
+TEST_F(DefaultMslEncoderFactoryTest, CreateTokenizer)
 {
     const string json =
         "{\"a\":[1,{\"aa\":[10,20,{\"ccc\":[100,200,300]},30]},2],\"b\":9.9}";
     shared_ptr<InputStream> is = make_shared<ByteArrayInputStream>(json);
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
 
     // explicit format
     EXPECT_THROW(mef->createTokenizer(is, MslEncoderFormat::INVALID), MslEncoderException);

--- a/tests/src/test/cpp/io/DefaultMslEncoderFactorySuite.cpp
+++ b/tests/src/test/cpp/io/DefaultMslEncoderFactorySuite.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <io/ByteArrayInputStream.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/JsonMslObject.h>
 #include <io/MslArray.h>
 #include <io/MslEncoderFactory.h>
@@ -219,8 +220,7 @@ TEST_F(DefaultMslEncoderFactoryTest, CreateTokenizer)
     shared_ptr<InputStream> is = make_shared<ByteArrayInputStream>(json);
 
     // explicit format
-    EXPECT_THROW(mef->createTokenizer(is, MslEncoderFormat::INVALID), MslEncoderException);
-    shared_ptr<MslTokenizer> mt = mef->createTokenizer(is, MslEncoderFormat::JSON);
+    shared_ptr<MslTokenizer> mt = mef->createTokenizer(is);
 
     // deduced format
     shared_ptr<InputStream> bad = make_shared<ByteArrayInputStream>("afkhadgfk");

--- a/tests/src/test/cpp/io/JsonMslArrayTest.cpp
+++ b/tests/src/test/cpp/io/JsonMslArrayTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <entityauth/EntityAuthenticationScheme.h>
 #include <io/JsonMslArray.h>
 #include <io/MslEncoderFactory.h>
 #include <io/MslObject.h>
@@ -22,6 +23,7 @@
 #include <util/MockMslContext.h>
 
 using namespace std;
+using namespace netflix::msl::entityauth;
 using namespace netflix::msl::util;
 
 namespace netflix {

--- a/tests/src/test/cpp/io/JsonMslArrayTest.cpp
+++ b/tests/src/test/cpp/io/JsonMslArrayTest.cpp
@@ -19,17 +19,28 @@
 #include <io/MslEncoderFactory.h>
 #include <io/MslObject.h>
 #include <util/Base64.h>
+#include <util/MockMslContext.h>
+
+using namespace std;
+using namespace netflix::msl::util;
 
 namespace netflix {
 namespace msl {
 namespace io {
 
-using namespace std;
-
 class JsonMslArrayTest : public ::testing::Test
 {
+public:
+	virtual ~JsonMslArrayTest() {}
+
+	JsonMslArrayTest()
+	{
+    	shared_ptr<MslContext> ctx = make_shared<MockMslContext>(EntityAuthenticationScheme::PSK, false);
+		encoder = ctx->getMslEncoderFactory();
+	}
+
 protected:
-    shared_ptr<MslEncoderFactory> encoder = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> encoder;
 };
 
 namespace

--- a/tests/src/test/cpp/io/JsonMslObjectTest.cpp
+++ b/tests/src/test/cpp/io/JsonMslObjectTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <entityauth/EntityAuthenticationScheme.h>
 #include <io/JsonMslObject.h>
 #include <io/MslArray.h>
 #include <io/MslEncoderException.h>
@@ -23,6 +24,7 @@
 #include <util/MockMslContext.h>
 
 using namespace std;
+using namespace netflix::msl::entityauth;
 using namespace netflix::msl::util;
 
 namespace netflix {

--- a/tests/src/test/cpp/io/JsonMslObjectTest.cpp
+++ b/tests/src/test/cpp/io/JsonMslObjectTest.cpp
@@ -20,8 +20,10 @@
 #include <io/MslEncoderException.h>
 #include <io/MslEncoderFactory.h>
 #include <util/Base64.h>
+#include <util/MockMslContext.h>
 
 using namespace std;
+using namespace netflix::msl::util;
 
 namespace netflix {
 namespace msl {
@@ -35,8 +37,17 @@ shared_ptr<ByteArray> makeByteArray(const string s) {
 
 class JsonMslObjectTest : public ::testing::Test
 {
+public:
+	virtual ~JsonMslObjectTest() {}
+
+	JsonMslObjectTest()
+	{
+    	shared_ptr<MslContext> ctx = make_shared<MockMslContext>(EntityAuthenticationScheme::PSK, false);
+		encoder = ctx->getMslEncoderFactory();
+	}
+
 protected:
-    shared_ptr<MslEncoderFactory> encoder = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> encoder;
 };
 
 TEST_F(JsonMslObjectTest, ElementTypes)

--- a/tests/src/test/cpp/msg/MessageCapabilitiesTest.cpp
+++ b/tests/src/test/cpp/msg/MessageCapabilitiesTest.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <io/MslObject.h>
 #include <io/MslArray.h>
-#include <io/MslEncoderFactory.h>
+#include <io/DefaultMslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <msg/MessageCapabilities.h>
 #include <MslConstants.h>
@@ -123,8 +123,10 @@ TEST_F(MessageCapabilitiesTest, mslObjectCtor)
 
 TEST_F(MessageCapabilitiesTest, toMslEncoding)
 {
+	// FIXME: This is an error-prone test because there is no guarantee of how
+	// a JSON encoding might be constructed or formatted.
     shared_ptr<MessageCapabilities> mc1 = make_shared<MessageCapabilities>(compressionAlgos_, languages_, encoderFormats_);
-    shared_ptr<MslEncoderFactory> mef = make_shared<MslEncoderFactory>();
+    shared_ptr<MslEncoderFactory> mef = make_shared<DefaultMslEncoderFactory>();
     shared_ptr<ByteArray> ba1 = mc1->toMslEncoding(mef, MslEncoderFormat::JSON);
     EXPECT_EQ(
         "{\"compressionalgos\":[\"GZIP\",\"LZW\",\"NOCOMPRESSION\"],\"encoderformats\":[\"JSON\"],\"languages\":[\"aa\",\"cc\",\"bb\"]}",


### PR DESCRIPTION
Fixes #149. MslEncoderFactory must be abstract in order to allow MSL configurations to provide their own encoder implementations.