### PR TITLE
Process Base64 strings as ISO 8859-1 character strings.

### DIFF
--- a/core/src/main/java/com/netflix/msl/util/Base64Secure.java
+++ b/core/src/main/java/com/netflix/msl/util/Base64Secure.java
@@ -3,6 +3,8 @@
  */
 package com.netflix.msl.util;
 
+import java.nio.charset.StandardCharsets;
+
 import com.netflix.msl.util.Base64.Base64Impl;
 
 /**
@@ -122,9 +124,12 @@ public class Base64Secure implements Base64Impl {
         // reached the end of the string prematurely.
         boolean invalid = false;
         
+        // Convert string to ISO 8859-1 bytes.
+        final byte[] sb = s.getBytes(StandardCharsets.ISO_8859_1);
+        
         // Allocate the destination buffer, which may be too large due to
         // whitespace.
-        final int strlen = s.length();
+        final int strlen = sb.length;
         final int outlen = strlen * 3 / 4;
         final byte[] out = new byte[outlen];
         int o = 0;
@@ -134,7 +139,15 @@ public class Base64Secure implements Base64Impl {
         int q = 0;
         boolean lastQuad = false;
         for (int i = 0; i < strlen; ++i) {
-            final char c = s.charAt(i);
+            final byte c = sb[i];
+            
+            // Ensure the character is not "negative".
+            if (c < 0) {
+                invalid = true;
+                continue;
+            }
+            
+            // Lookup the character in the decoder map.
             final byte b = DECODE_MAP[c];
             
             // Skip invalid characters.

--- a/tests/src/test/java/com/netflix/msl/util/Base64Test.java
+++ b/tests/src/test/java/com/netflix/msl/util/Base64Test.java
@@ -71,6 +71,7 @@ public class Base64Test {
         "U29tZXRpbWVzIHBvcmN1cGluZX=gbmVlZCBiZWRzIHRvIHNsZWVwIG9uLg==",
         "RXZlbiB0aGUgcmVzdGxlc3MgZHJ=YW1lciBlbmpveXMgaG9tZS1jb29rZWQgZm9vZHMu",
         "RXZlbiB0aGUgcmVzdGxlc3MgZHJ=Y",
+        "VGhlIGxvbmcgd2luZGVkIGF1dGhvciBpcyBnb2luZyBmb3IgY幸B3YWxrIHdoaWxlIHRoZSBsaWdodCBicmVlemUgYmVsbG93cyBpbiBoaXMgZWFycy4=",
     };
     
     @Parameters


### PR DESCRIPTION
Fixes #148. Convert Base64.decode() input to ISO 8859-1 byte[] (see java.util.Base64.Decoder) before processing.