### PR TITLE
Use shared_ptr<Date>

### DIFF
--- a/core/src/main/cpp/Date.cpp
+++ b/core/src/main/cpp/Date.cpp
@@ -40,7 +40,7 @@ shared_ptr<Date> Date::now()
 // if this Date is after the Date argument.
 int Date::compareTo(shared_ptr<Date> other) const
 {
-    if (*this == *other) return 0;
+    if (this == other.get() || *this == *other) return 0;
     if (*this < *other) return -1;
     else return 1;
 }

--- a/core/src/main/cpp/Date.cpp
+++ b/core/src/main/cpp/Date.cpp
@@ -18,6 +18,7 @@
 #include <Date.h>
 #include <sys/time.h>
 #include <ctime>
+#include <memory>
 #include <sstream>
 
 using namespace std;
@@ -26,39 +27,21 @@ namespace netflix {
 namespace msl {
 
 // static
-Date Date::now()
-{
-    return Date();
-}
-
-// static
-Date Date::null()
-{
-    return Date(-1, true);
-}
-
-Date::Date()
+shared_ptr<Date> Date::now()
 {
     struct timeval tp;
     gettimeofday(&tp, NULL);
-    msSinceEpoch_ = static_cast<int64_t>(static_cast<uint64_t>(tp.tv_sec) * 1000ull + static_cast<uint64_t>(tp.tv_usec) / 1000ull);
-    isNull_ = false;
-}
-
-Date& Date::operator=(const Date& rhs)
-{
-    msSinceEpoch_ = rhs.msSinceEpoch_;
-    isNull_ = rhs.isNull_;
-    return *this;
+    const int64_t msSinceEpoch = static_cast<int64_t>(static_cast<uint64_t>(tp.tv_sec) * 1000ull + static_cast<uint64_t>(tp.tv_usec) / 1000ull);
+    return make_shared<Date>(msSinceEpoch);
 }
 
 // Return the value 0 if the argument Date is equal to this Date; a value less
 // than 0 if this Date is before the Date argument; and a value greater than 0
 // if this Date is after the Date argument.
-int Date::compareTo(const Date& other) const
+int Date::compareTo(shared_ptr<Date> other) const
 {
-    if (*this == other) return 0;
-    if (*this < other) return -1;
+    if (*this == *other) return 0;
+    if (*this < *other) return -1;
     else return 1;
 }
 
@@ -80,7 +63,6 @@ int Date::compareTo(const Date& other) const
  */
 string Date::toString() const
 {
-    if (isNull_) return "null";
     const time_t secondsSinceEpoch = static_cast<time_t>(msSinceEpoch_ / 1000ll);
     const tm* const t = gmtime(&secondsSinceEpoch);
     string out(asctime(t));
@@ -92,6 +74,12 @@ string Date::toString() const
 ostream& operator<<(ostream &os, const Date& date)
 {
     os << date.toString();
+    return os;
+}
+
+ostream& operator<<(ostream &os, std::shared_ptr<Date> date)
+{
+    os << date->toString();
     return os;
 }
 

--- a/core/src/main/cpp/Date.h
+++ b/core/src/main/cpp/Date.h
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <iosfwd>
+#include <memory>
 #include <string>
 
 namespace netflix {
@@ -37,49 +38,39 @@ inline bool operator<=(const Date& a, const Date& b);
 class Date
 {
 public:
-    Date();
-    Date(int64_t msSinceEpoch, bool isNull = false) : isNull_(isNull), msSinceEpoch_(msSinceEpoch) {}
-    Date(const Date& rhs) : isNull_(rhs.isNull_), msSinceEpoch_(rhs.msSinceEpoch_) {}
-    Date& operator=(const Date& rhs);
-    static Date now();
-    static Date null();
-    bool isNull() const { return isNull_; }
+    Date(int64_t msSinceEpoch) : msSinceEpoch_(msSinceEpoch) {}
+    static std::shared_ptr<Date> now();
 
     // -- Java method equivalents --
 
     //Tests if this date is after the specified date.
-    bool after(const Date& when) const { return *this > when; }
+    bool after(std::shared_ptr<Date> when) const { return *this > *when; }
     // Tests if this date is before the specified date.
-    bool before(const Date& when) const { return *this < when; }
+    bool before(std::shared_ptr<Date> when) const { return *this < *when; }
     // Return a copy of this object.
-    Date clone() const { return *this; }
+    std::shared_ptr<Date> clone() const { return std::make_shared<Date>(*this); }
     // Compares two Dates for ordering.
-    int compareTo(const Date& anotherDate) const;
-    // Compares two dates for equality.
-    bool equals(const Date& other) const { return other == *this; }
+    int compareTo(std::shared_ptr<Date> anotherDate) const;
     // Returns the number of milliseconds since January 1, 1970, 00:00:00 GMT represented by this Date object.
     int64_t getTime() const { return msSinceEpoch_; }
     // Converts this Date object to a String of the form:
     std::string toString() const;
 
 private:
-    bool isNull_;
     int64_t msSinceEpoch_;
 };
 
 inline bool operator==(const Date& a, const Date& b)
 {
-    if (a.isNull() == b.isNull()) {
-        return a.isNull() ? true : (a.getTime() == b.getTime());
-    }
-    return false;
+    return a.getTime() == b.getTime();
 }
 inline bool operator!=(const Date& a, const Date& b) { return !(a==b); }
-inline bool operator<(const Date& a, const Date& b) { assert(!a.isNull() && !b.isNull()); return a.getTime() < b.getTime(); }
+inline bool operator<(const Date& a, const Date& b) { return a.getTime() < b.getTime(); }
 inline bool operator>=(const Date& a, const Date& b) { return !(a < b); }
-inline bool operator>(const Date& a, const Date& b) { assert(!a.isNull() && !b.isNull()); return a.getTime() > b.getTime(); }
+inline bool operator>(const Date& a, const Date& b) { return a.getTime() > b.getTime(); }
 inline bool operator<=(const Date& a, const Date& b) { return !(a > b); }
 std::ostream & operator<<(std::ostream &os, const Date& p);
+std::ostream & operator<<(std::ostream &os, std::shared_ptr<Date> p);
 
 }} // namespace netflix::msl
 

--- a/core/src/main/cpp/msg/ErrorHeader.cpp
+++ b/core/src/main/cpp/msg/ErrorHeader.cpp
@@ -173,9 +173,9 @@ ErrorHeader::ErrorHeader(shared_ptr<MslContext> ctx, shared_ptr<ByteArray> error
     }
 }
 
-Date ErrorHeader::getTimestamp() const
+shared_ptr<Date> ErrorHeader::getTimestamp() const
 {
-    return (timestamp_ != -1) ? Date(timestamp_ * MILLISECONDS_PER_SECOND) : Date::null();
+    return (timestamp_ != -1) ? make_shared<Date>(timestamp_ * MILLISECONDS_PER_SECOND) : shared_ptr<Date>();
 }
 
 shared_ptr<ByteArray> ErrorHeader::toMslEncoding(shared_ptr<io::MslEncoderFactory> encoder, const io::MslEncoderFormat& format) const

--- a/core/src/main/cpp/msg/ErrorHeader.h
+++ b/core/src/main/cpp/msg/ErrorHeader.h
@@ -119,7 +119,7 @@ public:
     /**
      * @return the timestamp. May be null.
      */
-    Date getTimestamp() const;
+    std::shared_ptr<Date> getTimestamp() const;
 
     /**
      * @return the message ID.

--- a/core/src/main/cpp/msg/MessageHeader.cpp
+++ b/core/src/main/cpp/msg/MessageHeader.cpp
@@ -604,9 +604,9 @@ string MessageHeader::getRecipient() const
     return recipient;
 }
 
-Date MessageHeader::getTimestamp() const
+shared_ptr<Date> MessageHeader::getTimestamp() const
 {
-    return (timestamp != -1) ? Date(timestamp * MILLISECONDS_PER_SECOND) : Date::null();
+    return (timestamp != -1) ? make_shared<Date>(timestamp * MILLISECONDS_PER_SECOND) : shared_ptr<Date>();
 }
 
 int64_t MessageHeader::getMessageId() const

--- a/core/src/main/cpp/msg/MessageHeader.h
+++ b/core/src/main/cpp/msg/MessageHeader.h
@@ -239,7 +239,7 @@ public:
     /**
      * @return the timestamp. May be null.
      */
-    Date getTimestamp() const;
+    std::shared_ptr<Date> getTimestamp() const;
 
     /**
      * @return the message ID.

--- a/core/src/main/cpp/msg/MessageInputStream.cpp
+++ b/core/src/main/cpp/msg/MessageInputStream.cpp
@@ -233,7 +233,7 @@ MessageInputStream::MessageInputStream(shared_ptr<MslContext> ctx,
 			}
 
 			// If the master token is expired...
-			if (masterToken->isExpired()) {
+			if (masterToken->isExpired(shared_ptr<Date>())) {
 				// If the message is not renewable or does not contain key
 				// request data then reject the message.
 				if (!messageHeader->isRenewable() || messageHeader->getKeyRequestData().empty()) {

--- a/core/src/main/cpp/tokens/MasterToken.h
+++ b/core/src/main/cpp/tokens/MasterToken.h
@@ -150,8 +150,8 @@ public:
      * @throws MslCryptoException if there is an error encrypting or signing
      *         the token data or the crypto algorithms are not recognized.
      */
-    MasterToken(std::shared_ptr<util::MslContext> ctx, const Date& renewalWindow,
-            const Date& expiration, int64_t sequenceNumber, int64_t serialNumber,
+    MasterToken(std::shared_ptr<util::MslContext> ctx, std::shared_ptr<Date> renewalWindow,
+            std::shared_ptr<Date> expiration, int64_t sequenceNumber, int64_t serialNumber,
             std::shared_ptr<io::MslObject> issuerData, const std::string& identity,
             const crypto::SecretKey& encryptionKey,
             const crypto::SecretKey& signatureKey);
@@ -185,7 +185,7 @@ public:
     /**
      * @return the start of the renewal window.
      */
-    Date getRenewalWindow() const;
+    std::shared_ptr<Date> getRenewalWindow() const;
 
     /**
      * <p>Returns true if the master token renewal window has been entered.</p>
@@ -201,16 +201,15 @@ public:
      * issuing entity time.</li>
      * </ul>
      *
-     * @param now the time to compare against. May be omitted.
+     * @param now the time to compare against. May be {@code null}.
      * @return true if the renewal window has been entered.
      */
-    bool isRenewable(const Date& now) const;
-    bool isRenewable() const;
+    bool isRenewable(std::shared_ptr<Date> now = std::shared_ptr<Date>()) const;
 
     /**
      * @return the expiration.
      */
-    Date getExpiration() const;
+    std::shared_ptr<Date> getExpiration() const;
 
     /**
      * <p>Returns true if the master token is expired.</p>
@@ -226,11 +225,10 @@ public:
      * issuing entity time.</li>
      * </ul>
      *
-     * @param now the time to compare against. May be omitted.
+     * @param now the time to compare against. May be {@code null}.
      * @return true if expired.
      */
-    bool isExpired(const Date& now) const;
-    bool isExpired() const;
+    bool isExpired(std::shared_ptr<Date> now = std::shared_ptr<Date>()) const;
 
     /**
      * @return the sequence number.

--- a/core/src/main/cpp/tokens/UserIdToken.h
+++ b/core/src/main/cpp/tokens/UserIdToken.h
@@ -111,8 +111,8 @@ public:
      * @throws MslCryptoException if there is an error encrypting or signing
      *         the token data.
      */
-    UserIdToken(std::shared_ptr<util::MslContext> ctx, const Date& renewalWindow,
-            const Date& expiration, std::shared_ptr<MasterToken> masterToken, int64_t serialNumber,
+    UserIdToken(std::shared_ptr<util::MslContext> ctx, std::shared_ptr<Date> renewalWindow,
+            std::shared_ptr<Date> expiration, std::shared_ptr<MasterToken> masterToken, int64_t serialNumber,
             std::shared_ptr<io::MslObject> issuerData, std::shared_ptr<MslUser> user);
 
     /**
@@ -149,7 +149,7 @@ public:
     /**
      * @return the start of the renewal window.
      */
-    Date getRenewalWindow() const;
+    std::shared_ptr<Date> getRenewalWindow() const;
 
     /**
      * <p>Returns true if the user ID token renewal window has been entered.</p>
@@ -165,16 +165,15 @@ public:
      * issuing entity time.</li>
      * </ul>
      *
-     * @param now the time to compare against.
+     * @param now the time to compare against. May be {@code null}.
      * @return true if the renewal window has been entered.
      */
-    bool isRenewable(const Date& now) const;
-    bool isRenewable() const;
+    bool isRenewable(std::shared_ptr<Date> now = std::shared_ptr<Date>()) const;
 
     /**
      * @return the expiration.
      */
-    Date getExpiration() const;
+    std::shared_ptr<Date> getExpiration() const;
 
     /**
      * <p>Returns true if the user ID token is expired.</p>
@@ -190,11 +189,10 @@ public:
      * issuing entity time.</li>
      * </ul>
      *
-     * @param now the time to compare against.
+     * @param now the time to compare against. May be {@code null}.
      * @return true if expired.
      */
-    bool isExpired(const Date& now) const;
-    bool isExpired() const;
+    bool isExpired(std::shared_ptr<Date> now = std::shared_ptr<Date>()) const;
 
     /**
      * @return the user ID token issuer data or null if there is none or it is

--- a/core/src/main/cpp/util/MslContext.cpp
+++ b/core/src/main/cpp/util/MslContext.cpp
@@ -19,6 +19,7 @@
 #include <numerics/safe_math.h>
 #include <util/StaticMslMutex.h>
 
+using namespace std;
 using base::internal::CheckedNumeric;
 
 namespace netflix {
@@ -76,21 +77,20 @@ MslContext::MslContext() : id_(nextId())
 {
 }
 
-void MslContext::updateRemoteTime(const Date& time)
+void MslContext::updateRemoteTime(shared_ptr<Date> time)
 {
     const int64_t localSeconds = getTime() / MILLISECONDS_PER_SECOND;
-    const int64_t remoteSeconds = time.getTime() / MILLISECONDS_PER_SECOND;
+    const int64_t remoteSeconds = time->getTime() / MILLISECONDS_PER_SECOND;
     offset_ = remoteSeconds - localSeconds;
     synced_ = true;
 }
 
-bool MslContext::getRemoteTime(Date& date)
+shared_ptr<Date> MslContext::getRemoteTime()
 {
-    if (!synced_) return false;
+    if (!synced_) return shared_ptr<Date>();
     const int64_t localSeconds = getTime() / MILLISECONDS_PER_SECOND;
     const int64_t remoteSeconds = localSeconds + offset_;
-    date = Date(remoteSeconds * MILLISECONDS_PER_SECOND);
-    return true;
+    return make_shared<Date>(remoteSeconds * MILLISECONDS_PER_SECOND);
 }
 
 bool MslContext::equals(std::shared_ptr<const MslContext> other) const

--- a/core/src/main/cpp/util/MslContext.h
+++ b/core/src/main/cpp/util/MslContext.h
@@ -260,7 +260,7 @@ public:
      *
      * @param time remote entity time.
      */
-    void updateRemoteTime(const Date& time);
+    void updateRemoteTime(std::shared_ptr<Date> time);
 
     /**
      * <p>Return the expected remote entity time or {@code null} if the clock
@@ -271,7 +271,7 @@ public:
      *
      * @return the expected remote entity time or {@code null} if not known.
      */
-    bool getRemoteTime(Date& date);
+    std::shared_ptr<Date> getRemoteTime();
 
     bool equals(std::shared_ptr<const MslContext> other) const;
 

--- a/core/src/main/java/com/netflix/msl/tokens/UserIdToken.java
+++ b/core/src/main/java/com/netflix/msl/tokens/UserIdToken.java
@@ -285,7 +285,7 @@ public class UserIdToken implements MslEncodable {
      * issuing entity time.</li>
      * </ul>
      *
-     * @param now the time to compare against.
+     * @param now the time to compare against. May be {@code null}.
      * @return true if the renewal window has been entered.
      */
     public boolean isRenewable(final Date now) {

--- a/tests/src/main/cpp/tokens/MockTokenFactory.cpp
+++ b/tests/src/main/cpp/tokens/MockTokenFactory.cpp
@@ -126,8 +126,8 @@ shared_ptr<MasterToken> MockTokenFactory::createMasterToken(
         const SecretKey& encryptionKey, const SecretKey& hmacKey,
         shared_ptr<MslObject> issuerData)
 {
-    const Date renewalWindow(ctx->getTime() + RENEWAL_OFFSET);
-    const Date expiration(ctx->getTime() + EXPIRATION_OFFSET);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(ctx->getTime() + RENEWAL_OFFSET);
+    shared_ptr<Date> expiration = make_shared<Date>(ctx->getTime() + EXPIRATION_OFFSET);
     const int64_t sequenceNumber = 0;
     int64_t serialNumber = -1;
     do {
@@ -159,8 +159,8 @@ shared_ptr<MasterToken> MockTokenFactory::renewMasterToken(
     if (!masterToken->isDecrypted())
         throw MslMasterTokenException(MslError::MASTERTOKEN_UNTRUSTED, masterToken);
 
-    const Date renewalWindow(ctx->getTime() + RENEWAL_OFFSET);
-    const Date expiration(ctx->getTime() + EXPIRATION_OFFSET);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(ctx->getTime() + RENEWAL_OFFSET);
+    shared_ptr<Date> expiration = make_shared<Date>(ctx->getTime() + EXPIRATION_OFFSET);
     const int64_t oldSequenceNumber = masterToken->getSequenceNumber();
     int64_t sequenceNumber;
     if (this->sequenceNumber == -1) {
@@ -200,8 +200,8 @@ shared_ptr<UserIdToken> MockTokenFactory::createUserIdToken(shared_ptr<MslContex
         shared_ptr<MslUser> user, shared_ptr<MasterToken> masterToken)
 {
     shared_ptr<MslObject> issuerData;
-    const Date renewalWindow(ctx->getTime() + RENEWAL_OFFSET);
-    const Date expiration(ctx->getTime() + EXPIRATION_OFFSET);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(ctx->getTime() + RENEWAL_OFFSET);
+    shared_ptr<Date> expiration = make_shared<Date>(ctx->getTime() + EXPIRATION_OFFSET);
     int64_t serialNumber = -1;
     do {
         serialNumber = ctx->getRandom()->nextLong();
@@ -216,8 +216,8 @@ shared_ptr<UserIdToken> MockTokenFactory::renewUserIdToken(shared_ptr<MslContext
         throw MslUserIdTokenException(MslError::USERIDTOKEN_NOT_DECRYPTED, userIdToken).setMasterToken(masterToken);
 
     shared_ptr<MslObject> issuerData ;
-    const Date renewalWindow(ctx->getTime() + RENEWAL_OFFSET);
-    const Date expiration(ctx->getTime() + EXPIRATION_OFFSET);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(ctx->getTime() + RENEWAL_OFFSET);
+    shared_ptr<Date> expiration = make_shared<Date>(ctx->getTime() + EXPIRATION_OFFSET);
     const int64_t serialNumber = userIdToken->getSerialNumber();
     shared_ptr<MslUser> user = userIdToken->getUser();
     return make_shared<UserIdToken>(ctx, renewalWindow, expiration, masterToken, serialNumber, issuerData, user);

--- a/tests/src/main/cpp/util/MslTestUtils.cpp
+++ b/tests/src/main/cpp/util/MslTestUtils.cpp
@@ -181,8 +181,8 @@ shared_ptr<ByteArray> deriveWrappingKey(shared_ptr<ByteArray> encryptionKey, sha
 shared_ptr<MasterToken> getMasterToken(shared_ptr<MslContext> ctx,
         int64_t sequenceNumber, int64_t serialNumber)
 {
-    const Date renewalWindow(Date::now().getTime() + 10000);
-    const Date expiration(Date::now().getTime() + 20000);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 10000);
+    shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 20000);
     shared_ptr<EntityAuthenticationData> entityAuthData = ctx->getEntityAuthenticationData(MslContext::ReauthCode::ENTITYDATA_REAUTH);
     const string identity = entityAuthData->getIdentity();
     const SecretKey encryptionKey(MockPresharedAuthenticationFactory::KPE);
@@ -192,8 +192,8 @@ shared_ptr<MasterToken> getMasterToken(shared_ptr<MslContext> ctx,
 
 shared_ptr<MasterToken> getUntrustedMasterToken(shared_ptr<MslContext> ctx)
 {
-    const Date renewalWindow(Date::now().getTime() + 10000);
-    const Date expiration(Date::now().getTime() + 20000);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 10000);
+    shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 20000);
     shared_ptr<EntityAuthenticationData> entityAuthData = ctx->getEntityAuthenticationData(MslContext::ReauthCode::INVALID);
     const string identity = entityAuthData->getIdentity();
     const SecretKey encryptionKey = MockPresharedAuthenticationFactory::KPE;
@@ -210,8 +210,8 @@ shared_ptr<MasterToken> getUntrustedMasterToken(shared_ptr<MslContext> ctx)
 shared_ptr<UserIdToken> getUserIdToken(shared_ptr<MslContext> ctx, shared_ptr<MasterToken> masterToken,
         int64_t serialNumber, shared_ptr<MslUser> user)
 {
-    const Date renewalWindow(Date::now().getTime() + 10000);
-    const Date expiration(Date::now().getTime() + 20000);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 10000);
+    shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 20000);
     return make_shared<UserIdToken>(ctx, renewalWindow, expiration, masterToken, serialNumber, shared_ptr<MslObject>(), user);
 }
 
@@ -219,8 +219,8 @@ shared_ptr<UserIdToken> getUntrustedUserIdToken(shared_ptr<MslContext> ctx,
         shared_ptr<MasterToken> masterToken, int64_t serialNumber,
         shared_ptr<MslUser> user)
 {
-    const Date renewalWindow(Date::now().getTime() + 10000);
-    const Date expiration(Date::now().getTime() + 20000);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 10000);
+    shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 20000);
     shared_ptr<UserIdToken> userIdToken = make_shared<UserIdToken>(ctx, renewalWindow, expiration, masterToken, serialNumber, shared_ptr<MslObject>(), user);
     shared_ptr<MslEncoderFactory> encoder = ctx->getMslEncoderFactory();
     shared_ptr<MslObject> mo = toMslObject(encoder, userIdToken);

--- a/tests/src/test/cpp/DateTest.cpp
+++ b/tests/src/test/cpp/DateTest.cpp
@@ -18,6 +18,7 @@
 #include <Date.h>
 #include <sys/time.h>
 #include <iostream>
+#include <memory>
 
 using namespace std;
 
@@ -37,119 +38,48 @@ class DateTest : public ::testing::Test
 {
 };
 
-TEST_F(DateTest, createAndCopy)
-{
-    const Date nowDate = Date::now();
-    EXPECT_FALSE(nowDate.isNull());
-    const int64_t nowTime = now();
-
-    Date nowDate2(nowDate);  // copy ctor
-    EXPECT_EQ(nowDate, nowDate2);
-    EXPECT_TRUE(nowDate2 == nowDate);
-    nowDate2 = Date(nowTime); // ctor and operator=
-    EXPECT_EQ(nowDate, nowDate2);
-    EXPECT_TRUE(nowDate2 == nowDate);
-    nowDate2 = nowDate.clone(); // clone() and operator=
-    EXPECT_EQ(nowDate, nowDate2);
-    EXPECT_TRUE(nowDate2 == nowDate);
-    EXPECT_FALSE(nowDate2 != nowDate);
-    EXPECT_TRUE(nowDate2 <= nowDate);
-    EXPECT_TRUE(nowDate2 >= nowDate);
-    EXPECT_TRUE(nowDate2.equals(nowDate));
-    EXPECT_EQ(0, nowDate2.compareTo(nowDate));
-    EXPECT_EQ(nowTime, nowDate.getTime());
-}
-
 TEST_F(DateTest, comparison)
 {
-    const Date nowDate = Date::now();
+    shared_ptr<Date> nowDate = Date::now();
     const int64_t nowTime = now();
     const int64_t laterTime = nowTime + 1000;
-    const Date laterDate = Date(laterTime);
+    shared_ptr<Date> laterDate = make_shared<Date>(laterTime);
 
     // equality
-    EXPECT_TRUE(nowDate != laterDate);
-    EXPECT_FALSE(nowDate.equals(laterDate));
-    EXPECT_FALSE(nowDate == laterDate);
-    EXPECT_FALSE(nowDate.equals(laterDate));
+    EXPECT_TRUE(*nowDate == *nowDate);
+    EXPECT_FALSE(*nowDate == *laterDate);
+    EXPECT_TRUE(*nowDate != *laterDate);
 
     // less than
-    EXPECT_TRUE(nowDate < laterDate);
-    EXPECT_TRUE(nowDate <= laterDate);
+    EXPECT_TRUE(*nowDate < *laterDate);
+    EXPECT_TRUE(*nowDate <= *laterDate);
 
     // greater than
-    EXPECT_FALSE(nowDate > laterDate);
-    EXPECT_FALSE(nowDate >= laterDate);
+    EXPECT_FALSE(*nowDate > *laterDate);
+    EXPECT_FALSE(*nowDate >= *laterDate);
 
     // before / after
-    EXPECT_TRUE(nowDate.before(laterDate));
-    EXPECT_FALSE(nowDate.after(laterDate));
-    EXPECT_TRUE(laterDate.after(nowDate));
-    EXPECT_FALSE(laterDate.before(nowDate));
+    EXPECT_TRUE(nowDate->before(laterDate));
+    EXPECT_FALSE(nowDate->after(laterDate));
+    EXPECT_TRUE(laterDate->after(nowDate));
+    EXPECT_FALSE(laterDate->before(nowDate));
 
     // compareTo
-    EXPECT_EQ(1, laterDate.compareTo(nowDate));
-    EXPECT_EQ(-1, nowDate.compareTo(laterDate));
-    EXPECT_EQ(-1, nowDate.compareTo(laterDate));
-    EXPECT_EQ(1, laterDate.compareTo(nowDate));
-    EXPECT_EQ(0, nowDate.compareTo(nowDate));
+    EXPECT_EQ(1, laterDate->compareTo(nowDate));
+    EXPECT_EQ(-1, nowDate->compareTo(laterDate));
+    EXPECT_EQ(-1, nowDate->compareTo(laterDate));
+    EXPECT_EQ(1, laterDate->compareTo(nowDate));
+    EXPECT_EQ(0, nowDate->compareTo(nowDate));
 }
 
 TEST_F(DateTest, toString)
 {
     const int64_t dateVal = 1472833162115;
     const string dateStr = "Fri Sep  2 16:19:22 GMT 2016";
-    EXPECT_EQ(dateStr, Date(dateVal).toString());
+    EXPECT_EQ(dateStr, make_shared<Date>(dateVal)->toString());
     stringstream ss;
-    ss << Date(dateVal);
+    ss << make_shared<Date>(dateVal);
     EXPECT_EQ(dateStr, ss.str());
-
-    const Date nullDate = Date::null();
-    EXPECT_EQ("null", nullDate.toString());
-}
-
-TEST_F(DateTest, null)
-{
-    const Date date1(1234);
-    EXPECT_FALSE(date1.isNull());
-    EXPECT_EQ(1234, date1.getTime());
-    const Date date2(5678);
-    EXPECT_FALSE(date2.isNull());
-    EXPECT_EQ(5678, date2.getTime());
-    const Date nullDate1 = Date::null();
-    EXPECT_TRUE(nullDate1.isNull());
-    EXPECT_EQ(nullDate1.getTime(), -1);
-    const Date nullDate2(5678, true);
-    EXPECT_TRUE(nullDate2.isNull());
-    EXPECT_EQ(nullDate2.getTime(), 5678);
-
-    // operator==
-    // nonnull nonnull, different time, == false
-    EXPECT_FALSE(date1 == date2);
-    // nonnull nonnull, same time, == true
-    EXPECT_TRUE(date1 == date1);
-    // null nonnull, different time, == false
-    EXPECT_FALSE(nullDate1 == date1);
-    // null nonnull, same time, == false
-    EXPECT_FALSE(nullDate2 == date2);
-    // null null, different time, == true
-    EXPECT_TRUE(nullDate1 == nullDate2);
-    // null null, same time, == true
-    EXPECT_TRUE(nullDate1 == nullDate1);
-
-    // copy ctor
-    const Date nullDate22(nullDate2);
-    EXPECT_TRUE(nullDate22.isNull());
-    EXPECT_EQ(nullDate22.getTime(), 5678);
-    EXPECT_EQ(nullDate2, nullDate22);
-
-    // operator=
-    Date nullDate11;
-    EXPECT_NE(nullDate1, nullDate11);
-    nullDate11 = nullDate1;
-    EXPECT_TRUE(nullDate11.isNull());
-    EXPECT_EQ(nullDate11.getTime(), -1);
-    EXPECT_EQ(nullDate1, nullDate11);
 }
 
 } /* namespace msl */

--- a/tests/src/test/cpp/keyx/AsymmetricWrappedExchangeSuite.cpp
+++ b/tests/src/test/cpp/keyx/AsymmetricWrappedExchangeSuite.cpp
@@ -640,8 +640,8 @@ protected:
      */
     shared_ptr<MasterToken> getUntrustedMasterToken(shared_ptr<MslContext> ctx, const SecretKey& encryptionKey, const SecretKey& hmacKey)
     {
-        const Date renewalWindow(Date::now().getTime() + 1000);
-        const Date expiration(Date::now().getTime() + 2000);
+        shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 1000);
+        shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 2000);
         const string identity = MockPresharedAuthenticationFactory::PSK_ESN;
         shared_ptr<MasterToken>masterToken = make_shared<MasterToken>(ctx, renewalWindow, expiration, 1L, 1L, shared_ptr<MslObject>(), identity, encryptionKey, hmacKey);
         shared_ptr<MslObject> mo = MslTestUtils::toMslObject(encoder, masterToken);

--- a/tests/src/test/cpp/keyx/SymmetricWrappedExchangeSuite.cpp
+++ b/tests/src/test/cpp/keyx/SymmetricWrappedExchangeSuite.cpp
@@ -471,8 +471,8 @@ struct FakeKeyResponseData : public KeyResponseData
  */
 shared_ptr<MasterToken> getUntrustedMasterToken(shared_ptr<MslContext> ctx, const string& identity, const SecretKey& encryptionKey, const SecretKey& hmacKey)
 {
-    const Date renewalWindow(Date::now().getTime() + 1000);
-    const Date expiration(Date::now().getTime() + 2000);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 1000);
+    shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 2000);
     shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(ctx, renewalWindow, expiration, 1L, 1L, shared_ptr<MslObject>(), identity, encryptionKey, hmacKey);
     shared_ptr<MslObject> mo = MslTestUtils::toMslObject(ctx->getMslEncoderFactory(), masterToken);
     shared_ptr<ByteArray> signature = mo->getBytes("signature");

--- a/tests/src/test/cpp/msg/ErrorHeaderTest.cpp
+++ b/tests/src/test/cpp/msg/ErrorHeaderTest.cpp
@@ -86,10 +86,10 @@ const string USER_MSG = "User message.";
  * @param timestamp the timestamp to compare.
  * @return true if the timestamp is about now.
  */
-bool isAboutNow(const Date& timestamp)
+bool isAboutNow(shared_ptr<Date> timestamp)
 {
-    const int64_t now = Date::now().getTime();
-    const int64_t time = timestamp.getTime();
+    const int64_t now = Date::now()->getTime();
+    const int64_t time = timestamp->getTime();
     return (now - 1000 <= time && time <= now + 1000);
 }
 
@@ -101,7 +101,7 @@ bool isAboutNow(const Date& timestamp)
  */
 bool isAboutNowSeconds(int64_t seconds)
 {
-    const int64_t now = Date::now().getTime();
+    const int64_t now = Date::now()->getTime();
     const int64_t time = seconds * MILLISECONDS_PER_SECOND;
     return (now - 1000 <= time && time <= now + 1000);
 }
@@ -290,7 +290,7 @@ TEST_F(ErrorHeaderTest, parseHeader)
     shared_ptr<ErrorHeader> moErrorHeader = dynamic_pointer_cast<ErrorHeader>(header);
 
     EXPECT_EQ(*errorHeader->getEntityAuthenticationData(), *moErrorHeader->getEntityAuthenticationData());
-    EXPECT_EQ(errorHeader->getTimestamp(), moErrorHeader->getTimestamp());
+    EXPECT_EQ(*errorHeader->getTimestamp(), *moErrorHeader->getTimestamp());
     EXPECT_EQ(errorHeader->getErrorCode(), moErrorHeader->getErrorCode());
     EXPECT_EQ(errorHeader->getErrorMessage(), moErrorHeader->getErrorMessage());
     EXPECT_EQ(errorHeader->getInternalCode(), moErrorHeader->getInternalCode());

--- a/tests/src/test/cpp/msg/MessageBuilderSuite.cpp
+++ b/tests/src/test/cpp/msg/MessageBuilderSuite.cpp
@@ -2120,8 +2120,8 @@ TEST_F(MessageBuilderTest_CreateResponse, maxRequestMessageId)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewMasterToken)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
@@ -2146,9 +2146,9 @@ TEST_F(MessageBuilderTest_CreateResponse, renewMasterToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, peerRenewMasterToken)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expirationWindow(Date::now().getTime() + 10000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(p2pCtx, renewalWindow, expirationWindow, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(p2pCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(p2pCtx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
 	for (set<shared_ptr<KeyRequestData>>::iterator keyRequestData = KEY_REQUEST_DATA.begin();
@@ -2173,9 +2173,9 @@ TEST_F(MessageBuilderTest_CreateResponse, peerRenewMasterToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewMasterTokenMaxSequenceNumber)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expirationWindow(Date::now().getTime() + 10000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expirationWindow, MslConstants::MAX_LONG_VALUE, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, MslConstants::MAX_LONG_VALUE, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
 	for (set<shared_ptr<KeyRequestData>>::iterator keyRequestData = KEY_REQUEST_DATA.begin();
@@ -2202,9 +2202,9 @@ TEST_F(MessageBuilderTest_CreateResponse, renewMasterTokenMaxSequenceNumber)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewMasterTokenFutureRenewalWindow)
 {
-	Date renewalWindow(Date::now().getTime() + 10000);
-	Date expirationWindow(Date::now().getTime() + 20000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expirationWindow, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 20000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
 	for (set<shared_ptr<KeyRequestData>>::iterator keyRequestData = KEY_REQUEST_DATA.begin();
@@ -2227,9 +2227,9 @@ TEST_F(MessageBuilderTest_CreateResponse, renewMasterTokenFutureRenewalWindow)
 
 TEST_F(MessageBuilderTest_CreateResponse, expiredMasterToken)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expirationWindow(Date::now().getTime() - 10000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expirationWindow, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
 	for (set<shared_ptr<KeyRequestData>>::iterator keyRequestData = KEY_REQUEST_DATA.begin();
@@ -2253,9 +2253,9 @@ TEST_F(MessageBuilderTest_CreateResponse, expiredMasterToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, nonReplayableRequest)
 {
-	Date renewalWindow(Date::now().getTime() + 10000);
-	Date expirationWindow(Date::now().getTime() + 20000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expirationWindow, MslConstants::MAX_LONG_VALUE, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 20000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, MslConstants::MAX_LONG_VALUE, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setNonReplayable(true);
 	shared_ptr<MessageHeader> request = requestBuilder->getHeader();
@@ -2277,9 +2277,9 @@ TEST_F(MessageBuilderTest_CreateResponse, unsupportedKeyExchangeRenewMasterToken
 		ctx->removeKeyExchangeFactories(*scheme);
 	}
 
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expirationWindow(Date::now().getTime() + 10000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(ctx, renewalWindow, expirationWindow, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(ctx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, REQUEST_MESSAGE_ID, REPLAYABLE_ID, true, false, NULL_MSG_CAPS, KEY_REQUEST_DATA, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<MessageHeader> request = make_shared<MessageHeader>(trustedNetCtx, NULL_ENTITYAUTH_DATA, requestMasterToken, headerData, peerData);
@@ -2305,9 +2305,9 @@ TEST_F(MessageBuilderTest_CreateResponse, oneSupportedKeyExchangeRenewMasterToke
 	}
 	ctx->addKeyExchangeFactory(make_shared<SymmetricWrappedExchange>(make_shared<MockAuthenticationUtils>()));
 
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expirationWindow(Date::now().getTime() + 10000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(ctx, renewalWindow, expirationWindow, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(ctx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(ctx, requestMasterToken, NULL_USER_ID_TOKEN, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
 	// This should place the supported key exchange scheme in the
@@ -2333,9 +2333,9 @@ TEST_F(MessageBuilderTest_CreateResponse, untrustedMasterTokenRenewMasterToken)
 {
 	shared_ptr<MockMslContext> ctx = make_shared<MockMslContext>(EntityAuthenticationScheme::PSK, false);
 
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expirationWindow(Date::now().getTime() + 10000);
-	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(ctx, renewalWindow, expirationWindow, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
+	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(ctx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, REQUEST_MESSAGE_ID, REPLAYABLE_ID, true, false, NULL_MSG_CAPS, KEY_REQUEST_DATA, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<MessageHeader> request = make_shared<MessageHeader>(ctx, NULL_ENTITYAUTH_DATA, requestMasterToken, headerData, peerData);
@@ -2546,8 +2546,8 @@ TEST_F(MessageBuilderTest_CreateResponse, oneSupportedKeyExchangeEntityAuthData)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewUserIdToken)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
@@ -2566,8 +2566,8 @@ TEST_F(MessageBuilderTest_CreateResponse, renewUserIdToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewUserIdTokenNotRenewable)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, NULL_RECIPIENT);
 	shared_ptr<MessageHeader> request = requestBuilder->getHeader();
@@ -2580,14 +2580,14 @@ TEST_F(MessageBuilderTest_CreateResponse, renewUserIdTokenNotRenewable)
 	EXPECT_EQ(*requestUserIdToken->getUser(), *responseUserIdToken->getUser());
 	EXPECT_EQ(requestUserIdToken->getMasterTokenSerialNumber(), responseUserIdToken->getMasterTokenSerialNumber());
 	EXPECT_EQ(requestUserIdToken->getSerialNumber(), responseUserIdToken->getSerialNumber());
-	EXPECT_EQ(requestUserIdToken->getRenewalWindow(), responseUserIdToken->getRenewalWindow());
-	EXPECT_EQ(requestUserIdToken->getExpiration(), responseUserIdToken->getExpiration());
+	EXPECT_EQ(*requestUserIdToken->getRenewalWindow(), *responseUserIdToken->getRenewalWindow());
+	EXPECT_EQ(*requestUserIdToken->getExpiration(), *responseUserIdToken->getExpiration());
 }
 
 TEST_F(MessageBuilderTest_CreateResponse, peerRenewUserIdToken)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(p2pCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(p2pCtx, MASTER_TOKEN, requestUserIdToken, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
@@ -2607,8 +2607,8 @@ TEST_F(MessageBuilderTest_CreateResponse, peerRenewUserIdToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, expiredUserIdToken)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, NULL_RECIPIENT);
 	requestBuilder->setRenewable(true);
@@ -2627,8 +2627,8 @@ TEST_F(MessageBuilderTest_CreateResponse, expiredUserIdToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, expiredUserIdTokenNotRenewable)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, NULL_RECIPIENT);
 	shared_ptr<MessageHeader> request = requestBuilder->getHeader();
@@ -2648,8 +2648,8 @@ TEST_F(MessageBuilderTest_CreateResponse, expiredUserIdTokenServerMessage)
 {
 	shared_ptr<MockMslContext> ctx = make_shared<MockMslContext>(EntityAuthenticationScheme::PSK, false);
 
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(ctx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
 
 	// Change the MSL crypto context so the master token and user ID
@@ -2676,8 +2676,8 @@ TEST_F(MessageBuilderTest_CreateResponse, expiredUserIdTokenServerMessage)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewMasterTokenAndRenewUserIdToken)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(trustedNetCtx, renewalWindow, expiration, requestMasterToken, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, NULL_RECIPIENT);
@@ -2708,8 +2708,8 @@ TEST_F(MessageBuilderTest_CreateResponse, renewMasterTokenAndRenewUserIdToken)
 
 TEST_F(MessageBuilderTest_CreateResponse, renewTokensNoKeyRequestData)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(trustedNetCtx, renewalWindow, expiration, requestMasterToken, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, NULL_RECIPIENT);
@@ -2721,18 +2721,18 @@ TEST_F(MessageBuilderTest_CreateResponse, renewTokensNoKeyRequestData)
 	shared_ptr<MasterToken> responseMasterToken = response->getMasterToken();
 	shared_ptr<UserIdToken> responseUserIdToken = response->getUserIdToken();
 	EXPECT_EQ(requestMasterToken, responseMasterToken);
-	EXPECT_EQ(requestMasterToken->getRenewalWindow(), responseMasterToken->getRenewalWindow());
-	EXPECT_EQ(requestMasterToken->getExpiration(), responseMasterToken->getExpiration());
+	EXPECT_EQ(*requestMasterToken->getRenewalWindow(), *responseMasterToken->getRenewalWindow());
+	EXPECT_EQ(*requestMasterToken->getExpiration(), *responseMasterToken->getExpiration());
 	EXPECT_EQ(*requestUserIdToken, *responseUserIdToken);
-	EXPECT_FALSE(requestUserIdToken->getRenewalWindow().equals(responseUserIdToken->getRenewalWindow()));
-	EXPECT_FALSE(requestUserIdToken->getExpiration().equals(responseUserIdToken->getExpiration()));
+	EXPECT_NE(*requestUserIdToken->getRenewalWindow(), *responseUserIdToken->getRenewalWindow());
+	EXPECT_NE(*requestUserIdToken->getExpiration(), *responseUserIdToken->getExpiration());
 	EXPECT_FALSE(response->getKeyResponseData());
 }
 
 TEST_F(MessageBuilderTest_CreateResponse, peerRenewMasterTokenAndRenewUserIdToken)
 {
-	Date renewalWindow(Date::now().getTime() - 10000);
-	Date expiration(Date::now().getTime() + 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
 	shared_ptr<MasterToken> requestMasterToken = make_shared<MasterToken>(p2pCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<UserIdToken> requestUserIdToken = make_shared<UserIdToken>(p2pCtx, renewalWindow, expiration, requestMasterToken, 1L, ISSUER_DATA, USER);
 	shared_ptr<MessageBuilder> requestBuilder = MessageBuilder::createRequest(p2pCtx, requestMasterToken, requestUserIdToken, NULL_RECIPIENT);
@@ -3169,8 +3169,8 @@ TEST_F(MessageBuilderTest_CreateResponse, setMasterTokenHasKeyExchangeData)
 {
 	// The master token must be renewable to force a key exchange to
 	// happen.
-	Date renewalWindow(Date::now().getTime() - 1000);
-	Date expiration(Date::now().getTime() + 2000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 1000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 2000);
 	const string identity = MockPresharedAuthenticationFactory::PSK_ESN;
 	const SecretKey encryptionKey = MockPresharedAuthenticationFactory::KPE;
 	const SecretKey hmacKey = MockPresharedAuthenticationFactory::KPH;

--- a/tests/src/test/cpp/msg/MessageHeaderTest.cpp
+++ b/tests/src/test/cpp/msg/MessageHeaderTest.cpp
@@ -146,10 +146,10 @@ const bool HANDSHAKE = false;
  * @param timestamp the timestamp to compare.
  * @return true if the timestamp is about now.
  */
-bool isAboutNow(const Date& timestamp)
+bool isAboutNow(shared_ptr<Date> timestamp)
 {
-    const int64_t now = Date::now().getTime();
-    const int64_t time = timestamp.getTime();
+    const int64_t now = Date::now()->getTime();
+    const int64_t time = timestamp->getTime();
     return (now - 1000 <= time && time <= now + 1000);
 }
 
@@ -161,7 +161,7 @@ bool isAboutNow(const Date& timestamp)
  */
 bool isAboutNowSeconds(int64_t seconds)
 {
-    const int64_t now = Date::now().getTime() / MILLISECONDS_PER_SECOND;
+    const int64_t now = Date::now()->getTime() / MILLISECONDS_PER_SECOND;
     const int64_t time = seconds;
     return (now - 1 <= time && time <= now + 1);
 }
@@ -2530,8 +2530,8 @@ TEST_F(MessageHeaderTest, peerServiceTokenMismatchedPeerUserIdTokenParseHeader)
 
 TEST_F(MessageHeaderTest, differentMasterTokenSender)
 {
-    const Date renewalWindow(Date::now().getTime() - 10000);
-    const Date expiration(Date::now().getTime() + 10000);
+    shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 10000);
+    shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() + 10000);
     const SecretKey encryptionKey(make_shared<ByteArray>(16), JcaAlgorithm::AES);
     const SecretKey hmacKey(make_shared<ByteArray>(32), JcaAlgorithm::HMAC_SHA256);
     shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, shared_ptr<MslObject>(), "IDENTITY", encryptionKey, hmacKey);

--- a/tests/src/test/cpp/msg/MessageInputStreamTest.cpp
+++ b/tests/src/test/cpp/msg/MessageInputStreamTest.cpp
@@ -615,8 +615,8 @@ TEST_F(MessageInputStreamTest, oneCompatibleKeyRequestData)
 
 TEST_F(MessageInputStreamTest, expiredRenewableClientMessage)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, true, false, NULL_MSG_CAPS, KEY_REQUEST_DATA, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
@@ -629,8 +629,8 @@ TEST_F(MessageInputStreamTest, expiredRenewableClientMessage)
 
 TEST_F(MessageInputStreamTest, expiredRenewablePeerMessage)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(p2pCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, true, false, NULL_MSG_CAPS, KEY_REQUEST_DATA, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
@@ -645,8 +645,8 @@ TEST_F(MessageInputStreamTest, expiredNotRenewableClientMessage)
 {
 	// Expired messages received by a trusted network server should be
 	// rejected.
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, false, false, NULL_MSG_CAPS, EMPTY_KEYX_REQUESTS, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
@@ -666,8 +666,8 @@ TEST_F(MessageInputStreamTest, expiredNoKeyRequestDataClientMessage)
 {
 	// Expired renewable messages received by a trusted network server
 	// with no key request data should be rejected.
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(trustedNetCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, true, false, NULL_MSG_CAPS, EMPTY_KEYX_REQUESTS, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
@@ -689,8 +689,8 @@ TEST_F(MessageInputStreamTest, expiredNotRenewableServerMessage)
 
 	// Expired messages received by a trusted network client should not be
 	// rejected.
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(ctx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, false, false, NULL_MSG_CAPS, EMPTY_KEYX_REQUESTS, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
@@ -716,8 +716,8 @@ TEST_F(MessageInputStreamTest, expiredNotRenewableServerMessage)
 
 TEST_F(MessageInputStreamTest, expiredNoKeyRequestDataPeerMessage)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(p2pCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, true, false, NULL_MSG_CAPS, EMPTY_KEYX_REQUESTS, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
@@ -735,8 +735,8 @@ TEST_F(MessageInputStreamTest, expiredNoKeyRequestDataPeerMessage)
 
 TEST_F(MessageInputStreamTest, expiredNotRenewablePeerMessage)
 {
-	Date renewalWindow(Date::now().getTime() - 20000);
-	Date expiration(Date::now().getTime() - 10000);
+	shared_ptr<Date> renewalWindow = make_shared<Date>(Date::now()->getTime() - 20000);
+	shared_ptr<Date> expiration = make_shared<Date>(Date::now()->getTime() - 10000);
 	shared_ptr<MasterToken> masterToken = make_shared<MasterToken>(p2pCtx, renewalWindow, expiration, 1L, 1L, NULL_ISSUER_DATA, MockPresharedAuthenticationFactory::PSK_ESN, MockPresharedAuthenticationFactory::KPE, MockPresharedAuthenticationFactory::KPH);
 	shared_ptr<HeaderData> headerData = make_shared<HeaderData>(NULL_RECIPIENT, MSG_ID, REPLAYABLE_ID, false, false, NULL_MSG_CAPS, EMPTY_KEYX_REQUESTS, NULL_KEYX_RESPONSE, NULL_USERAUTH_DATA, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);
 	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, EMPTY_SERVICE_TOKENS);


### PR DESCRIPTION
Fixes #147. Use shared_ptr for all Date instances. Fix MslControl logic for token date logic based on the remote entity’s time.