### PR TITLE
Compute proper length Diffie-Hellman keyx shared secret.

### DIFF
--- a/core/src/main/javascript/keyx/DiffieHellmanExchange.js
+++ b/core/src/main/javascript/keyx/DiffieHellmanExchange.js
@@ -20,7 +20,6 @@
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 var DiffieHellmanExchange;
-var DiffieHellmanExchange$DhParameterSpec;
 var DiffieHellmanExchange$RequestData;
 var DiffieHellmanExchange$RequestData$parse;
 var DiffieHellmanExchange$ResponseData;
@@ -236,17 +235,6 @@ var DiffieHellmanExchange$ResponseData$parse;
             throw e;
         }
     };
-
-    /**
-     * Diffie-Hellman parameter specification.
-     *
-     * @param {BigInteger} p prime number.
-     * @param {BigInteger} g generator.
-     */
-    DiffieHellmanExchange$DhParameterSpec = function DhParameterSpec(p, g) {
-        this.p = p;
-        this.g = g;
-    };
     
     /**
      * If the provided byte array begins with one and only one null byte this
@@ -324,6 +312,7 @@ var DiffieHellmanExchange$ResponseData$parse;
             
             AsyncExecutor(callback, function() {
                 // Compute Diffie-Hellman shared secret.
+            	var bitlen = params.p.length * 8;
                 var oncomplete = computeSha384;
                 var onerror = function(e) {
                     callback.error(new MslCryptoException(MslError.DERIVEKEY_ERROR, "Error deriving Diffie-Hellman shared secret.", e));
@@ -331,7 +320,7 @@ var DiffieHellmanExchange$ResponseData$parse;
                 mslCrypto['deriveBits']({
                     'name': WebCryptoAlgorithm.DIFFIE_HELLMAN['name'],
                     'public': publicKey.getEncoded(),
-                }, privateKey, 48).then(oncomplete, onerror);
+                }, privateKey, bitlen).then(oncomplete, onerror);
             }, self);
             
             function computeSha384(sharedSecret) {

--- a/core/src/main/javascript/keyx/DiffieHellmanParameters.js
+++ b/core/src/main/javascript/keyx/DiffieHellmanParameters.js
@@ -22,8 +22,8 @@ var DHParameterSpec = util.Class.create({
      * Create a new Diffie-Hellman parameter specification with the provided
      * prime modulus and base generator.
      * 
-     * @param {Uint8Array} p prime modulus.
-     * @param {Uint8Array} g base generator.
+     * @param {Uint8Array} p prime modulus (big-endian).
+     * @param {Uint8Array} g base generator (big-endian).
      */
     init: function init(p, g) {
         // Set properties.

--- a/tests/src/test/javascript/keyx/DiffieHellmanExchangeSuite.js
+++ b/tests/src/test/javascript/keyx/DiffieHellmanExchangeSuite.js
@@ -111,7 +111,6 @@ xdescribe("DiffieHellmanExchangeSuite", function() {
     });
     
     // Shortcuts.
-    var DhParameterSpec = DiffieHellmanExchange$DhParameterSpec;
     var RequestData = DiffieHellmanExchange$RequestData;
     var RequestData$parse = DiffieHellmanExchange$RequestData$parse;
     var ResponseData = DiffieHellmanExchange$ResponseData;
@@ -681,7 +680,9 @@ xdescribe("DiffieHellmanExchangeSuite", function() {
 
         /** Diffie-Hellman parameter specifications. */
 	    var paramSpecs = {};
-	    paramSpecs['1'] = new DhParameterSpec(new BigInteger('23', 10), new BigInteger('5', 10));
+	    var twentyThree = new Uint8Array([23]);
+	    var five = new Uint8Array([5]);
+	    paramSpecs['1'] = new DhParameterSpec(twentyThree, five);
         
         /** Key exchange factory. */
         var factory = new DiffieHellmanExchange(paramSpecs);


### PR DESCRIPTION
Fixes #162. Use Diffie-Hellman parameters modulus bit length when deriving shared secret.
Remove (old) DiffieHellmanExchange$DhParameterSpec in favor of (new) DhParameterSpec.