### PR TITLE
Remove ciphertext envelope key ID verification.

### DIFF
--- a/core/src/main/java/com/netflix/msl/crypto/AsymmetricCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/AsymmetricCryptoContext.java
@@ -148,10 +148,6 @@ public abstract class AsymmetricCryptoContext implements ICryptoContext {
             final MslObject encryptionEnvelopeMo = encoder.parseObject(data);
             final MslCiphertextEnvelope encryptionEnvelope = new MslCiphertextEnvelope(encryptionEnvelopeMo, MslCiphertextEnvelope.Version.V1);
             
-            // Verify key ID.
-            if (!encryptionEnvelope.getKeyId().equals(id))
-                throw new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH);
-            
             // Decrypt ciphertext.
             final Cipher cipher = CryptoCache.getCipher(transform);
             cipher.init(Cipher.DECRYPT_MODE, privateKey, params);

--- a/core/src/main/java/com/netflix/msl/crypto/SymmetricCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/SymmetricCryptoContext.java
@@ -208,10 +208,6 @@ public class SymmetricCryptoContext implements ICryptoContext {
             final MslObject encryptionEnvelopeMo = encoder.parseObject(data);
             final MslCiphertextEnvelope encryptionEnvelope = new MslCiphertextEnvelope(encryptionEnvelopeMo, MslCiphertextEnvelope.Version.V1);
             
-            // Verify key ID.
-            if (!encryptionEnvelope.getKeyId().equals(id))
-                throw new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH);
-            
             // Decrypt ciphertext.
             final byte[] ciphertext = encryptionEnvelope.getCiphertext();
             if (ciphertext.length == 0)

--- a/core/src/main/javascript/crypto/RsaCryptoContext.js
+++ b/core/src/main/javascript/crypto/RsaCryptoContext.js
@@ -180,10 +180,6 @@ var RsaCryptoContext$Mode;
                 MslCiphertextEnvelope$parse(encryptionEnvelopeMo, MslCiphertextEnvelope$Version.V1, {
                     result: function(envelope) {
                         try {
-                            // Verify key ID.
-                            if (envelope.keyId != self.id)
-                                throw new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH);
-
                             // Decrypt ciphertext.
                             var oncomplete = function(plaintext) {
                                 callback.result(new Uint8Array(plaintext));

--- a/core/src/main/javascript/crypto/SymmetricCryptoContext.js
+++ b/core/src/main/javascript/crypto/SymmetricCryptoContext.js
@@ -125,10 +125,6 @@ var SymmetricCryptoContext;
                 MslCiphertextEnvelope$parse(encryptionEnvelopeMo, MslCiphertextEnvelope$Version.V1, {
                     result: function(envelope) {
                         try {
-                            // Verify key ID.
-                            if (envelope.keyId != self.id)
-                                throw new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH);
-
                             // Decrypt ciphertext.
                             var oncomplete = function(plaintext) {
                                 callback.result(new Uint8Array(plaintext));

--- a/tests/src/test/java/com/netflix/msl/crypto/RsaCryptoContextSuite.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/RsaCryptoContextSuite.java
@@ -192,17 +192,18 @@ public class RsaCryptoContextSuite{
         
         @Test
         public void encryptDecryptIdMismatch() throws MslCryptoException {
-            thrown.expect(MslCryptoException.class);
-            thrown.expectMslError(MslError.ENVELOPE_KEY_ID_MISMATCH);
-
             final byte[] message = new byte[messageSize];
             random.nextBytes(message);
             
             final RsaCryptoContext cryptoContextA = new RsaCryptoContext(ctx, KEYPAIR_ID + "A", privateKeyA, publicKeyA, mode);
             final byte[] ciphertext = cryptoContextA.encrypt(message, encoder, ENCODER_FORMAT);
+            assertNotNull(ciphertext);
+            assertThat(message, is(not(ciphertext)));
             
             final RsaCryptoContext cryptoContextB = new RsaCryptoContext(ctx, KEYPAIR_ID + "B", privateKeyA, publicKeyA, mode);
-            cryptoContextB.decrypt(ciphertext, encoder);
+            final byte[] plaintext = cryptoContextB.decrypt(ciphertext, encoder);
+            assertNotNull(plaintext);
+            assertArrayEquals(message, plaintext);
         }
         
         @Test

--- a/tests/src/test/java/com/netflix/msl/crypto/SessionCryptoContextTest.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/SessionCryptoContextTest.java
@@ -335,9 +335,6 @@ public class SessionCryptoContextTest {
     
     @Test
     public void encryptDecryptIdMismatch() throws MslEncoderException, MslException {
-        thrown.expect(MslCryptoException.class);
-        thrown.expectMslError(MslError.ENVELOPE_KEY_ID_MISMATCH);
-
         final String identity = MockPresharedAuthenticationFactory.PSK_ESN;
         final SecretKey encryptionKey = MockPresharedAuthenticationFactory.KPE;
         final SecretKey signatureKey = MockPresharedAuthenticationFactory.KPH;
@@ -359,15 +356,13 @@ public class SessionCryptoContextTest {
         final byte[] message = new byte[32];
         random.nextBytes(message);
         
-        final byte[] ciphertext;
-        try {
-            ciphertext = cryptoContextA.encrypt(message, encoder, ENCODER_FORMAT);
-        } catch (final MslCryptoException e) {
-            fail(e.getMessage());
-            return;
-        }
+        final byte[] ciphertext = cryptoContextA.encrypt(message, encoder, ENCODER_FORMAT);
+        assertNotNull(ciphertext);
+        assertThat(message, is(not(ciphertext)));
         
-        cryptoContextB.decrypt(ciphertext, encoder);
+        final byte[] plaintext = cryptoContextB.decrypt(ciphertext, encoder);
+        assertNotNull(plaintext);
+        assertArrayEquals(message, plaintext);
     }
     
     @Test

--- a/tests/src/test/java/com/netflix/msl/crypto/SymmetricCryptoContextTest.java
+++ b/tests/src/test/java/com/netflix/msl/crypto/SymmetricCryptoContextTest.java
@@ -273,24 +273,19 @@ public class SymmetricCryptoContextTest {
     
     @Test
     public void encryptDecryptIdMismatch() throws MslEncodingException, MslCryptoException, MslEncoderException {
-        thrown.expect(MslCryptoException.class);
-        thrown.expectMslError(MslError.ENVELOPE_KEY_ID_MISMATCH);
-
-        final ICryptoContext cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID + "A", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
+    	final ICryptoContext cryptoContextA = new SymmetricCryptoContext(ctx, KEYSET_ID + "A", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
         final ICryptoContext cryptoContextB = new SymmetricCryptoContext(ctx, KEYSET_ID + "B", MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH, MockPresharedAuthenticationFactory.KPW);
         
         final byte[] message = new byte[32];
         random.nextBytes(message);
         
-        final byte[] ciphertext;
-        try {
-            ciphertext = cryptoContextA.encrypt(message, encoder, ENCODER_FORMAT);
-        } catch (final MslCryptoException e) {
-            fail(e.getMessage());
-            return;
-        }
+        final byte[] ciphertext = cryptoContextA.encrypt(message, encoder, ENCODER_FORMAT);
+        assertNotNull(ciphertext);
+        assertThat(ciphertext, is(not(message)));
         
-        cryptoContextB.decrypt(ciphertext, encoder);
+        final byte[] plaintext = cryptoContextB.decrypt(ciphertext, encoder);
+        assertNotNull(plaintext);
+        assertArrayEquals(message, plaintext);
     }
     
     @Test

--- a/tests/src/test/java/com/netflix/msl/msg/PayloadChunkTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/PayloadChunkTest.java
@@ -353,14 +353,22 @@ public class PayloadChunkTest {
         assertArrayEquals(DATA, plaintext);
     }
     
-    @Test(expected = MslCryptoException.class)
     public void mismatchedCryptoContextId() throws MslEncodingException, MslCryptoException, MslException, MslEncoderException {
         final ICryptoContext cryptoContextA = new SymmetricCryptoContext(ctx, CRYPTO_CONTEXT_ID + "A", ENCRYPTION_KEY, HMAC_KEY, null);
         final ICryptoContext cryptoContextB = new SymmetricCryptoContext(ctx, CRYPTO_CONTEXT_ID + "B", ENCRYPTION_KEY, HMAC_KEY, null);
         
         final PayloadChunk chunk = new PayloadChunk(ctx, SEQ_NO, MSG_ID, END_OF_MSG, CompressionAlgorithm.GZIP, DATA, cryptoContextA);
         final MslObject mo = MslTestUtils.toMslObject(encoder, chunk);
-        new PayloadChunk(ctx, mo, cryptoContextB);
+        
+        final PayloadChunk moChunk = new PayloadChunk(ctx, mo, cryptoContextB);
+        assertEquals(chunk.isEndOfMessage(), moChunk.isEndOfMessage());
+        assertArrayEquals(chunk.getData(), moChunk.getData());
+        assertEquals(chunk.getMessageId(), moChunk.getMessageId());
+        assertEquals(chunk.getSequenceNumber(), moChunk.getSequenceNumber());
+        final byte[] moEncode = moChunk.toMslEncoding(encoder, ENCODER_FORMAT);
+        assertNotNull(moEncode);
+        // The two payload chunk encodings will not be equal because the
+        // ciphertext and signature will be generated on-demand.
     }
     
     @Test(expected = MslCryptoException.class)

--- a/tests/src/test/javascript/crypto/RsaCryptoContextSuite.js
+++ b/tests/src/test/javascript/crypto/RsaCryptoContextSuite.js
@@ -184,7 +184,7 @@ describe("RsaCryptoContext", function() {
             random.nextBytes(messageB);
     		
     		var cryptoContext = new RsaCryptoContext(ctx, KEYPAIR_ID, privateKeyA, publicKeyA, mode);
-    		var ciphertextA = undefined, ciphertextB;
+    		var ciphertextA, ciphertextB;
     		runs(function() {
     			cryptoContext.encrypt(messageA, encoder, ENCODER_FORMAT, {
     				result: function(c) { ciphertextA = c; },
@@ -206,7 +206,7 @@ describe("RsaCryptoContext", function() {
 	            expect(ciphertextB).not.toEqual(ciphertextA);
     		});
     		
-    		var plaintextA = undefined, plaintextB;
+    		var plaintextA, plaintextB;
     		runs(function() {
     			cryptoContext.decrypt(ciphertextA, encoder, {
     				result: function(p) { plaintextA = p; },
@@ -285,18 +285,21 @@ describe("RsaCryptoContext", function() {
     		});
     		waitsFor(function() { return ciphertext; }, "ciphertext", 300);
     		
-    		var exception;
+    		var plaintext;
     		runs(function() {
+    			expect(ciphertext).not.toBeNull();
+    			expect(ciphertext).not.toEqual(message);
+    			
     			cryptoContextB.decrypt(ciphertext, encoder, {
-    				result: function() {},
-    				error: function(err) { exception = err; }
+    				result: function() { plaintext = p; },
+    				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     			});
     		});
-    		waitsFor(function() { return exception; }, "exception", 300);
+    		waitsFor(function() { return plaintext; }, "plaintext", 300);
     		
     		runs(function() {
-    			var f = function() { throw exception; };
-    			expect(f).toThrow(new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH));
+    			expect(plaintext).not.toBeNull();
+    			expect(plaintext).toEqual(message);
     		});
     	});
 

--- a/tests/src/test/javascript/crypto/SessionCryptoContextTest.js
+++ b/tests/src/test/javascript/crypto/SessionCryptoContextTest.js
@@ -587,18 +587,21 @@ describe("SessionCryptoContext", function() {
     	});
     	waitsFor(function() { return ciphertext; }, "ciphertext not received", 100);
     	
-    	var exception;
+    	var plaintext;
     	runs(function() {
+    		expect(ciphertext).not.toBeNull();
+    		expect(ciphertext).not.toEqual(message);
+    		
     		cryptoContextB.decrypt(ciphertext, encoder, {
-    			result: function() {},
-    			error: function(err) { exception = err; },
+    			result: function(p) { plaintext = p; },
+    			error: function(e) { expect(function() { throw e; }).not.toThrow(); },
     		});
     	});
-    	waitsFor(function() { return exception; }, "exception not received", 100);
+    	waitsFor(function() { return plaintext; }, "plaintext not received", 100);
 
     	runs(function() {
-    		var f = function() { throw exception; };
-    		expect(f).toThrow(new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH));
+    		expect(plaintext).not.toBeNull();
+    		expect(plaintext).toEqual(message);
     	});
     });
 

--- a/tests/src/test/javascript/crypto/SymmetricCryptoContextTest.js
+++ b/tests/src/test/javascript/crypto/SymmetricCryptoContextTest.js
@@ -429,18 +429,21 @@ describe("SymmetricCryptoContext", function() {
             });
             waitsFor(function() { return ciphertext; }, "ciphertext", 100);
 
-            var exception;
+            var plaintext;
             runs(function() {
+            	expect(ciphertext).not.toBeNull();
+            	expect(ciphertext).not.toEqual(message);
+            	
                 cryptoContextB.decrypt(ciphertext, encoder, {
-                    result: function() {},
-                    error: function(e) { exception = e; },
+                    result: function(p) { plaintext = p; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
                 });
             });
-            waitsFor(function() { return exception; }, "exception", 100);
+            waitsFor(function() { return plaintext; }, "plaintext", 100);
 
             runs(function() {
-                var f = function() { throw exception; };
-                expect(f).toThrow(new MslCryptoException(MslError.ENVELOPE_KEY_ID_MISMATCH));
+            	expect(plaintext).not.toBeNull();
+            	expect(plaintext).toEqual(message);
             });
         });
 

--- a/tests/src/test/javascript/msg/PayloadChunkTest.js
+++ b/tests/src/test/javascript/msg/PayloadChunkTest.js
@@ -551,18 +551,32 @@ describe("PayloadChunk", function() {
         });
         waitsFor(function() { return mo; }, "mo", 100);
         
-        var exception;
+        var moChunk;
         runs(function() {
 	        PayloadChunk$parse(ctx, mo, cryptoContextB, {
-	        	result: function() {},
-	        	error: function(e) { exception = e; }
+	        	result: function(x) { moChunk = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 	        });
         });
-        waitsFor(function() { return exception; }, "exception", 100);
+        waitsFor(function() { return moChunk; }, "moChunk", 100);
+        
+        var moEncode;
+        runs(function() {
+	        expect(moChunk.isEndOfMessage()).toEqual(chunk.isEndOfMessage());
+	        expect(moChunk.data).toEqual(chunk.data);
+	        expect(moChunk.messageId).toEqual(chunk.messageId);
+	        expect(moChunk.sequenceNumber).toEqual(chunk.sequenceNumber);
+	        moChunk.toMslEncoding(encoder, ENCODER_FORMAT, {
+	            result: function(x) { moEncode = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+	        });
+        });
+        waitsFor(function() { return moEncode; }, "moEncode", 100);
         
         runs(function() {
-            var f = function() { throw exception; };
-            expect(f).toThrow(new MslCryptoException(MslError.NONE));
+	        expect(moEncode).not.toBeNull();
+	        // The two payload chunk encodings will not be equal because the
+	        // ciphertext and signature will be generated on-demand.
         });
     });
     


### PR DESCRIPTION
Remove relatively low value key ID verification from symmetric and asymmetric (RSA) crypto contexts.

This will also allow crypto contexts to be used between client and server where the client is unaware of its entity identity.