### PR TITLE
throw exception if window.crypto exists, but not window.crypto.subtle

### DIFF
--- a/core/src/main/javascript/crypto/WebCryptoAdapter.js
+++ b/core/src/main/javascript/crypto/WebCryptoAdapter.js
@@ -90,6 +90,9 @@ var MslCrypto$setCryptoSubtle;
             } else if (window.crypto.subtle) {
                 nfCryptoSubtle = window.crypto.subtle;
             }
+            else{
+                throw new Error("window.crypto is defined, but not window.crypto.subtle.  If window.crypto.subtle is undefined, things aren't going to work. Note that window.crypto.subtle will be undefined, as per sepc, if the app in running in an insecure context, e.g. http and not https.  See https://github.com/w3c/webcrypto/issues/28 for historical details.");
+            }
         }
     }
 


### PR DESCRIPTION
This can happen when testing over http.  This message can save a developer some time if they encounter this situation.