### PR TITLE
Use a bitmask to clamp random long values to MslConstants.MAX_LONG_VALUE when possible.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -57,6 +57,7 @@ import com.netflix.msl.userauth.UserAuthenticationData;
 import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
 import com.netflix.msl.util.MslContext;
+import com.netflix.msl.util.MslUtils;
 
 /**
  * <p>A message builder provides methods for building messages.</p>
@@ -208,11 +209,7 @@ public class MessageBuilder {
      *         corresponding master token.
      */
     public static MessageBuilder createRequest(final MslContext ctx, final MasterToken masterToken, final UserIdToken userIdToken, final String recipient) throws MslException {
-        long messageId = -1;
-        final Random random = ctx.getRandom();
-        do {
-            messageId = random.nextLong();
-        } while (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE);
+        final long messageId = MslUtils.getRandomLong(ctx);
         final MessageCapabilities capabilities = ctx.getMessageCapabilities();
         return new MessageBuilder(ctx, recipient, messageId, capabilities, masterToken, userIdToken, null, null, null, null, null);
     }
@@ -390,10 +387,7 @@ public class MessageBuilder {
         }
         // Otherwise use a random message ID.
         else {
-            final Random random = ctx.getRandom();
-            do {
-                messageId = random.nextLong();
-            } while (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE);
+            messageId = MslUtils.getRandomLong(ctx);
         }
         final ResponseCode errorCode = error.getResponseCode();
         final int internalCode = error.getInternalCode();

--- a/core/src/main/java/com/netflix/msl/util/MslUtils.java
+++ b/core/src/main/java/com/netflix/msl/util/MslUtils.java
@@ -18,9 +18,11 @@ package com.netflix.msl.util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Random;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslConstants.CompressionAlgorithm;
 import com.netflix.msl.MslError;
 import com.netflix.msl.MslException;
@@ -131,8 +133,8 @@ public class MslUtils {
             throw new MslException(MslError.UNCOMPRESSION_ERROR, "algo " + compressionAlgo.name() + " data " + dataB64, e);
         }
     }
-    
-     /**
+
+    /**
      * Safely compares two byte arrays to prevent timing attacks.
      * 
      * @param a first array for the comparison.
@@ -147,5 +149,50 @@ public class MslUtils {
        for (int i = 0; i < a.length; ++i)
           result |= a[i] ^ b[i];
        return result == 0;
+    }
+    
+    /**
+     * Return true if the number is a non-negative power of two. Zero is
+     * considered a power of two and will return true.
+     * 
+     * @param n the number to test.
+     * @return true if the number is a non-negative power of two.
+     */
+    private static boolean isPowerOf2(final long n) {
+    		// If the number is a power of two, a binary AND operation between
+    		// the number and itself minus one will equal zero.
+    		if (n < 0) return false;
+    		if (n == 0) return true;
+    		return (n & (n - 1)) == 0;
+    }
+    
+    /**
+     * Returns a random number between zero and the maximum long value as
+     * defined by {@link MslConstants#MAX_LONG_VALUE}, inclusive.
+     * 
+     * @param ctx MSL context.
+     * @return a random number between zero and the maximum long value,
+     *         inclusive.
+     */
+    public static long getRandomLong(final MslContext ctx) {
+    		// If the maximum long value is a power of 2, then we can perform a
+    		// bitmask on the randomly generated long value to restrict to our
+    		// target number space.
+    		final boolean isPowerOf2 = MslUtils.isPowerOf2(MslConstants.MAX_LONG_VALUE);
+    		
+    		// Generate the random value.
+    		final Random r = ctx.getRandom();
+    		long n = -1;
+    		do {
+    			n = r.nextLong();
+    			
+    			// Perform a bitmask if permitted, which will force this loop
+    			// to exit immediately.
+    			if (isPowerOf2)
+    				n &= (MslConstants.MAX_LONG_VALUE - 1);
+    		} while (n < 0 || n > MslConstants.MAX_LONG_VALUE);
+    		
+    		// Return the random value.
+    		return n;
     }
 }

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -36,6 +36,7 @@
 	const MessageHeader = require('../msg/MessageHeader.js');
 	const ServiceToken = require('../tokens/ServiceToken.js');
 	const NullCryptoContext = require('../crypto/NullCryptoContext.js');
+	const MslUtils = require('../util/MslUtils.js');
 	
     /**
      * Empty service token data.
@@ -240,10 +241,7 @@
     var MessageBuilder$createRequest = function MessageBuilder$createRequest(ctx, masterToken, userIdToken, recipient, messageId, callback) {
         AsyncExecutor(callback, function() {
             if (messageId == undefined || messageId == null) {
-                var random = ctx.getRandom();
-                do {
-                    messageId = random.nextLong();
-                } while (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE);
+                messageId = MslUtils.getRandomLong(ctx);
             } else {
                 if (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE)
                     throw new MslInternalException("Message ID " + messageId + " is outside the valid range.");
@@ -469,10 +467,7 @@
                         }
                         // Otherwise use a random message ID.
                         else {
-                            var random = ctx.getRandom();
-                            do {
-                                messageId = random.nextLong();
-                            } while (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE);
+                            messageId = MslUtils.getRandomLong(ctx);
                         }
                         var errorCode = error.responseCode;
                         var internalCode = error.internalCode;

--- a/core/src/main/javascript/util/MslUtils.js
+++ b/core/src/main/javascript/util/MslUtils.js
@@ -105,24 +105,70 @@
     };
     
     /**
-    * Safely compares two byte arrays to prevent timing attacks.
-    * 
-    * @param {Uint8Array} a first array for the comparison.
-    * @param {Uint8Array} b second array for the comparison.
-    * @return {boolean} true if the arrays are equal, false if they are not.
-    */
-   function MslUtils$safeEquals(a, b) {
-      if (a.length != b.length)
-         return false;
-      
-      var result = 0;
-      for (var i = 0; i < a.length; ++i)
-         result |= a[i] ^ b[i];
-      return result == 0;
-   }
+     * Safely compares two byte arrays to prevent timing attacks.
+     * 
+     * @param {Uint8Array} a first array for the comparison.
+     * @param {Uint8Array} b second array for the comparison.
+     * @return {boolean} true if the arrays are equal, false if they are not.
+     */
+    function MslUtils$safeEquals(a, b) {
+        if (a.length != b.length)
+            return false;
+
+        var result = 0;
+        for (var i = 0; i < a.length; ++i)
+            result |= a[i] ^ b[i];
+        return result == 0;
+    }
+
+    /**
+     * Return true if the number is a non-negative power of two. Zero is
+     * considered a power of two and will return true.
+     * 
+     * @param {number} n the number to test.
+     * @return {boolean} true if the number is a non-negative power of two.
+     */
+    function MslUtils$isPowerOf2(n) {
+        // If the number is a power of two, a binary AND operation between
+        // the number and itself minus one will equal zero.
+        if (!Number.isSafeInteger(n) || n < 0) return false;
+        if (n == 0) return true;
+        return (n & (n - 1)) == 0;
+    }
     
+    /**
+     * Returns a random number between zero and the maximum long value as
+     * defined by {@link MslConstants#MAX_LONG_VALUE}, inclusive.
+     * 
+     * @param {MslContext} ctx MSL context.
+     * @return {number} a random number between zero and the maximum long value,
+     *         inclusive.
+     */
+    function MslUtils$getRandomLong(ctx) {
+        // If the maximum long value is a power of 2, then we can perform a
+        // bitmask on the randomly generated long value to restrict to our
+        // target number space.
+        var isPowerOf2 = MslUtils$isPowerOf2(MslConstants.MAX_LONG_VALUE);
+
+        // Generate the random value.
+        var r = ctx.getRandom();
+        var n = -1;
+        do {
+            n = r.nextLong();
+
+            // Perform a bitmask if permitted, which will force this loop
+            // to exit immediately.
+            if (isPowerOf2)
+                n &= (MslConstants.MAX_LONG_VALUE - 1);
+        } while (n < 0 || n > MslConstants.MAX_LONG_VALUE);
+
+        // Return the random value.
+        return n;
+    }
+
     // Exports.
     module.exports.compress = MslUtils$compress;
     module.exports.uncompress = MslUtils$uncompress;
     module.exports.safeEquals = MslUtils$safeEquals;
+    module.exports.getRandomLong = MslUtils$getRandomLong;
 })(require, (typeof module !== 'undefined') ? module : mkmodule('MslUtils'));

--- a/core/src/main/javascript/util/Random.js
+++ b/core/src/main/javascript/util/Random.js
@@ -118,17 +118,17 @@
          * @return {number} a random number.
          */
         nextDouble: function nextDouble() {
-        	// Ask for 64 random bits, but we will only use 53 of them to
-        	// compute the number.
-        	var b = new Uint32Array(2);
-        	nfCrypto.getRandomValues(b);
-        	// Use the least significant bit for the sign.
-        	var sign = b[1] & 0x1;
-        	// Use the top 52 bits for the mantissa.
-        	var mantissa = b[0] * SHIFT_20 + b[1] >> 12;
-        	// Convert to a number between [0,1).
-        	var multiplier = mantissa * POW_NEGATIVE_52;
-        	return ((sign) ? 1 : -1) * multiplier * Number.MAX_VALUE;
+            // Ask for 64 random bits, but we will only use 53 of them to
+            // compute the number.
+            var b = new Uint32Array(2);
+            nfCrypto.getRandomValues(b);
+            // Use the least significant bit for the sign.
+            var sign = b[1] & 0x1;
+            // Use the top 52 bits for the mantissa.
+            var mantissa = b[0] * SHIFT_20 + b[1] >> 12;
+            // Convert to a number between [0,1).
+            var multiplier = mantissa * POW_NEGATIVE_52;
+            return ((sign) ? 1 : -1) * multiplier * Number.MAX_VALUE;
         },
 
         /**

--- a/examples/kancolle/src/main/java/kancolle/tokens/KanColleTokenFactory.java
+++ b/examples/kancolle/src/main/java/kancolle/tokens/KanColleTokenFactory.java
@@ -41,6 +41,7 @@ import com.netflix.msl.tokens.MslUser;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.util.MslContext;
+import com.netflix.msl.util.MslUtils;
 
 /**
  * <p>The KanColle token factory.</p>
@@ -161,10 +162,7 @@ public class KanColleTokenFactory implements TokenFactory {
         final Date renewal = new Date(ctx.getTime() + mtRenewalOffset);
         final Date expiration = new Date(ctx.getTime() + mtExpirationOffset);
         final long sequenceNumber = 0;
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         final String identity = entityAuthData.getIdentity();
         return new MasterToken(ctx, renewal, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
     }
@@ -247,10 +245,7 @@ public class KanColleTokenFactory implements TokenFactory {
         final long now = ctx.getTime();
         final Date renewal = new Date(now + uitRenewalOffset);
         final Date expiration = new Date(now + uitExpirationOffset);
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         final MslObject issuerData = null;
         return new UserIdToken(ctx, renewal, expiration, masterToken, serialNumber, issuerData, user);
     }

--- a/examples/simple/src/main/java/server/userauth/SimpleTokenFactory.java
+++ b/examples/simple/src/main/java/server/userauth/SimpleTokenFactory.java
@@ -36,6 +36,7 @@ import com.netflix.msl.tokens.MslUser;
 import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.util.MslContext;
+import com.netflix.msl.util.MslUtils;
 
 /**
  * <p>A memory-backed token factory.</p>
@@ -133,10 +134,7 @@ public class SimpleTokenFactory implements TokenFactory {
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long sequenceNumber = 0;
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         final String identity = entityAuthData.getIdentity();
         final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
         
@@ -211,10 +209,7 @@ public class SimpleTokenFactory implements TokenFactory {
         final MslObject issuerData = null;
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         return new UserIdToken(ctx, renewalWindow, expiration, masterToken, serialNumber, issuerData, user);
     }
 

--- a/integ-tests/src/main/java/com/netflix/msl/server/configuration/tokens/ServerTokenFactory.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/configuration/tokens/ServerTokenFactory.java
@@ -30,6 +30,7 @@ import com.netflix.msl.io.MslObject;
 import com.netflix.msl.tokens.MasterToken;
 import com.netflix.msl.tokens.MockTokenFactory;
 import com.netflix.msl.util.MslContext;
+import com.netflix.msl.util.MslUtils;
 
 /**
  * User: skommidi
@@ -76,10 +77,7 @@ public class ServerTokenFactory extends MockTokenFactory {
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         this.sequenceNumber++;
         final long sequenceNumber = this.sequenceNumber;
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         final String identity = entityAuthData.getIdentity();
         return new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, null, identity, encryptionKey, hmacKey);
     }

--- a/tests/src/main/java/com/netflix/msl/tokens/MockTokenFactory.java
+++ b/tests/src/main/java/com/netflix/msl/tokens/MockTokenFactory.java
@@ -31,6 +31,7 @@ import com.netflix.msl.io.MslEncoderException;
 import com.netflix.msl.io.MslEncoderUtils;
 import com.netflix.msl.io.MslObject;
 import com.netflix.msl.util.MslContext;
+import com.netflix.msl.util.MslUtils;
 
 /**
  * Token factory for unit tests.
@@ -127,10 +128,7 @@ public class MockTokenFactory implements TokenFactory {
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
         final long sequenceNumber = 0;
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         final String identity = entityAuthData.getIdentity();
         return new MasterToken(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey);
     }
@@ -208,10 +206,7 @@ public class MockTokenFactory implements TokenFactory {
         final MslObject issuerData = null;
         final Date renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
         final Date expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
-        long serialNumber = -1;
-        do {
-            serialNumber = ctx.getRandom().nextLong();
-        } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+        final long serialNumber = MslUtils.getRandomLong(ctx);
         return new UserIdToken(ctx, renewalWindow, expiration, masterToken, serialNumber, issuerData, user);
     }
 

--- a/tests/src/main/javascript/tokens/MockTokenFactory.js
+++ b/tests/src/main/javascript/tokens/MockTokenFactory.js
@@ -34,6 +34,7 @@
     const MasterToken = require('../../../../../core/src/main/javascript/tokens/MasterToken.js');
     const MslUserIdTokenException = require('../../../../../core/src/main/javascript/MslUserIdTokenException.js');
     const UserIdToken = require('../../../../../core/src/main/javascript/tokens/UserIdToken.js');
+    const MslUtils = require('../../../../../core/src/main/javascript/util/MslUtils.js');
     
     const MockMslUser = require('../tokens/MockMslUser.js');
 
@@ -142,10 +143,7 @@
                 var renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
                 var expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
                 var sequenceNumber = 0;
-                var serialNumber = -1;
-                do {
-                    serialNumber = ctx.getRandom().nextLong();
-                } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+                var serialNumber = MslUtils.getRandomLong(ctx);
                 var identity = entityAuthData.getIdentity();
                 MasterToken.create(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey, callback);
             }, this);
@@ -208,10 +206,7 @@
                 var issuerData = null;
                 var renewalWindow = new Date(ctx.getTime() + RENEWAL_OFFSET);
                 var expiration = new Date(ctx.getTime() + EXPIRATION_OFFSET);
-                var serialNumber = -1;
-                do {
-                    serialNumber = ctx.getRandom().nextLong();
-                } while (serialNumber < 0 || serialNumber > MslConstants.MAX_LONG_VALUE);
+                var serialNumber = MslUtils.getRandomLong(ctx);
                 UserIdToken.create(ctx, renewalWindow, expiration, masterToken, serialNumber, issuerData, user, callback);
             }, this);
         },


### PR DESCRIPTION
Resolves #185.