### PR TITLE
When parsing the stream encoding identifier, expose any thrown IOExceptions.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -178,6 +178,7 @@ public class MessageInputStream extends InputStream {
      *        response data.
      * @param cryptoContexts the map of service token names onto crypto
      *        contexts used to decrypt and verify service tokens.
+     * @throws IOException if there is a problem reading from the input stream.
      * @throws MslEncodingException if there is an error parsing the message.
      * @throws MslCryptoException if there is an error decrypting or verifying
      *         the header or creating the message payload crypto context.
@@ -199,7 +200,7 @@ public class MessageInputStream extends InputStream {
      *         authentication data or a master token, or a token is improperly
      *         bound to another token.
      */
-    public MessageInputStream(final MslContext ctx, final InputStream source, final Set<KeyRequestData> keyRequestData, final Map<String,ICryptoContext> cryptoContexts) throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
+    public MessageInputStream(final MslContext ctx, final InputStream source, final Set<KeyRequestData> keyRequestData, final Map<String,ICryptoContext> cryptoContexts) throws IOException, MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
         // Parse the header.
         this.ctx = ctx;
         this.source = source;

--- a/core/src/main/java/com/netflix/msl/msg/MessageStreamFactory.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageStreamFactory.java
@@ -60,6 +60,7 @@ public class MessageStreamFactory {
      *        response data.
      * @param cryptoContexts the map of service token names onto crypto
      *        contexts used to decrypt and verify service tokens.
+     * @throws IOException if there is a problem reading from the input stream.
      * @throws MslEncodingException if there is an error parsing the message.
      * @throws MslCryptoException if there is an error decrypting or verifying
      *         the header or creating the message payload crypto context.
@@ -81,7 +82,7 @@ public class MessageStreamFactory {
      *         authentication data or a master token, or a token is improperly
      *         bound to another token.
      */
-    public MessageInputStream createInputStream(final MslContext ctx, final InputStream source, final Set<KeyRequestData> keyRequestData, final Map<String,ICryptoContext> cryptoContexts) throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
+    public MessageInputStream createInputStream(final MslContext ctx, final InputStream source, final Set<KeyRequestData> keyRequestData, final Map<String,ICryptoContext> cryptoContexts) throws IOException, MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
         return new MessageInputStream(ctx, source, keyRequestData, cryptoContexts);
     }
 

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -2318,7 +2318,7 @@ public class MslControl {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
                     
-                    throw new MslErrorResponseException("Error sending an automatic handshake response.", rt, e);
+                    throw new MslErrorResponseException("Error receiving the message header.", rt, e);
                 }
                 throw e;
             } catch (final Throwable t) {

--- a/core/src/main/javascript/io/MslEncoderFactory.js
+++ b/core/src/main/javascript/io/MslEncoderFactory.js
@@ -110,37 +110,47 @@
          *        callback the callback that will receive the
          *        {@link MslTokenizer}, be notified of timeouts, or any thrown
          *        exceptions.
-         * @throws MslEncoderException if there is a problem reading the byte
-         *         stream identifier or if the encoding format is not supported.
+         * @throws IOException if there is a problem reading the byte stream
+         *         identifier.
+         * @throws MslEncoderException if the encoder format is not recognized or
+         *         is not supported.
          */
         createTokenizer: function createTokenizer(source, format, timeout, callback) {
-        	var self = this;
-        	
+            var self = this;
+            
             AsyncExecutor(callback, function() {
-                // Identify the encoding format.
-                if (!format) {
-                	var bufferedSource = source.markSupported() ? source : new BufferedInputStream(source);
-                    bufferedSource.mark();
-                    bufferedSource.read(1, timeout, {
-                        result: function(bytes) {
-                            AsyncExecutor(callback, function() {
-                                if (bytes == null || bytes.length < 1)
-                                    throw new new MslEncoderException("Failure reading the byte stream identifier.");
-                                var id = bytes[0];
-                                format = MslEncoderFormat.getFormat(id);
-                                bufferedSource.reset();
-                                return this.generateTokenizer(bufferedSource, format);
-                            }, self);
-                        },
-                        timeout: callback.timeout,
-                        error: function(e) {
-                            callback.error(new MslEncoderException("Failure reading the byte stream identifier.", e));
-                        }
-                    });
-                } else {
+                // If the format was provided, return the tokenizer directly.
+                if (format)
                     return this.generateTokenizer(source, format);
-                }
+                
+                // Read the byte stream identifier.
+                var bufferedSource = source.markSupported() ? source : new BufferedInputStream(source);
+                bufferedSource.mark();
+                bufferedSource.read(1, timeout, {
+                    result: function(bytes) {
+                        AsyncExecutor(callback, function() {
+                            if (bytes == null || bytes.length < 1)
+                                throw new MslEncoderException("End of stream reached when attempting to read the byte stream identifier.");
+                            var id = bytes[0];
+                            identify(bufferedSource, id);
+                        }, self);
+                    },
+                    timeout: callback.timeout,
+                    error: callback.error,
+                });
             }, self);
+            
+            function identify(bufferedSource, id) {
+                AsyncExecutor(callback, function() {
+                    format = MslEncoderFormat.getFormat(id);
+                    if (!format)
+                        throw new MslEncoderException("Unidentified encoder format ID: (byte)" + id + ".");
+                    
+                    // Reset the input stream and return the tokenizer.
+                    bufferedSource.reset();
+                    return this.generateTokenizer(bufferedSource, format);
+                }, self);
+            }
         },
 
         /**

--- a/core/src/main/javascript/io/MslEncoderFactory.js
+++ b/core/src/main/javascript/io/MslEncoderFactory.js
@@ -26,18 +26,18 @@
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 (function(require, module) {
-	"use strict";
-	
-	const Base64 = require('../util/Base64.js');
-	const MslObject = require('../io/MslObject.js');
-	const MslArray = require('../io/MslArray.js');
-	const Class = require('../util/Class.js');
-	const MslEncoderFormat = require('../io/MslEncoderFormat.js');
-	const AsyncExecutor = require('../util/AsyncExecutor.js');
-	const MslEncoderException = require('../io/MslEncoderException.js');
-	const JsonMslTokenizer = require('../io/JsonMslTokenizer.js');
-	const JsonMslObject = require('../io/JsonMslObject.js');
-	const JsonMslArray = require('../io/JsonMslArray.js');
+    "use strict";
+    
+    const Base64 = require('../util/Base64.js');
+    const MslObject = require('../io/MslObject.js');
+    const MslArray = require('../io/MslArray.js');
+    const Class = require('../util/Class.js');
+    const MslEncoderFormat = require('../io/MslEncoderFormat.js');
+    const AsyncExecutor = require('../util/AsyncExecutor.js');
+    const MslEncoderException = require('../io/MslEncoderException.js');
+    const JsonMslTokenizer = require('../io/JsonMslTokenizer.js');
+    const JsonMslObject = require('../io/JsonMslObject.js');
+    const JsonMslArray = require('../io/JsonMslArray.js');
     
     /**
      * Escape a string to be output as a single line of text.
@@ -65,22 +65,22 @@
      * @return {string} the string.
      */
     var MslEncoderFactory$stringify = function MslEncoderFactory$stringify(v) {
-    	if (v instanceof MslObject || v instanceof MslArray) {
-    		return v.toString();
-    	} else if (v instanceof Uint8Array) {
-    	    return Base64.encode(v);
-    	} else {
-    		var json = JSON.stringify(v);
-    		return json
-    			.replace(/[\"]/g, '\\"')
-    			.replace(/[\\]/g, '\\\\')
-    			.replace(/[\/]/g, '\\/')
-    			.replace(/[\b]/g, '\\b')
-    			.replace(/[\f]/g, '\\f')
-    			.replace(/[\n]/g, '\\n')
-    			.replace(/[\r]/g, '\\r')
-    			.replace(/[\t]/g, '\\t');
-    	}
+        if (v instanceof MslObject || v instanceof MslArray) {
+            return v.toString();
+        } else if (v instanceof Uint8Array) {
+            return Base64.encode(v);
+        } else {
+            var json = JSON.stringify(v);
+            return json
+                .replace(/[\"]/g, '\\"')
+                .replace(/[\\]/g, '\\\\')
+                .replace(/[\/]/g, '\\/')
+                .replace(/[\b]/g, '\\b')
+                .replace(/[\f]/g, '\\f')
+                .replace(/[\n]/g, '\\n')
+                .replace(/[\r]/g, '\\r')
+                .replace(/[\t]/g, '\\t');
+        }
     };
     
     var MslEncoderFactory = module.exports = Class.create({

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -172,6 +172,7 @@
          * @param {{result: function(MessageInputStream), timeout: function(), error: function(Error)}}
          *        callback the callback that will receive the message input
          *        stream, or any thrown exceptions.
+         * @throws IOException if there is a problem reading from the input stream.
          * @throws MslEncodingException if there is an error parsing the message.
          * @throws MslCryptoException if there is an error decrypting or verifying
          *         the header or creating the message payload crypto context.
@@ -1291,6 +1292,7 @@
      * @param {{result: function(MessageInputStream), timeout: function(), error: function(Error)}}
      *        callback the callback that will receive the message input
      *        stream, or any thrown exceptions.
+     * @throws IOException if there is a problem reading from the input stream.
      * @throws MslEncodingException if there is an error parsing the message.
      * @throws MslCryptoException if there is an error decrypting or verifying
      *         the header or creating the message payload crypto context.

--- a/core/src/main/javascript/msg/MessageStreamFactory.js
+++ b/core/src/main/javascript/msg/MessageStreamFactory.js
@@ -50,6 +50,7 @@
 	     * @param {{result: function(MessageInputStream), timeout: function(), error: function(Error)}}
 	     *        callback the callback that will receive the message input
 	     *        stream, or any thrown exceptions.
+	     * @throws IOException if there is a problem reading from the input stream.
 	     * @throws MslEncodingException if there is an error parsing the message.
 	     * @throws MslCryptoException if there is an error decrypting or verifying
 	     *         the header or creating the message payload crypto context.

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -1666,6 +1666,7 @@
          * @param {{result: function(MessageInputStream), timeout: function(), error: function(Error)}}
          *        callback the callback returned the received message, timeouts,
          *        or any thrown exceptions.
+         * @throws IOException if there is a problem reading from the input stream.
          * @throws MslEncodingException if there is an error parsing the message.
          * @throws MslCryptoException if there is an error decrypting or verifying
          *         the header or creating the message payload crypto context.
@@ -2891,6 +2892,12 @@
                                 requestMessageId = e.messageId;
                                 mslError = e.error;
                                 userMessage = this._ctrl.messageRegistry.getUserMessage(mslError, null);
+                                toThrow = e;
+                            } else if (e instanceof MslIoException) {
+                                recipient = null;
+                                requestMessageId = null;
+                                mslError = MslError.MSL_COMMS_FAILURE;
+                                userMessage = null;
                                 toThrow = e;
                             } else {
                                 recipient = null;

--- a/examples/burp/src/main/java/burp/MSLHttpListener.java
+++ b/examples/burp/src/main/java/burp/MSLHttpListener.java
@@ -218,6 +218,8 @@ public class MSLHttpListener implements IHttpListener {
         try {
             final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(body.getBytes());
             mis = new WiretapMessageInputStream(this.ctx, byteArrayInputStream, this.msgCtx.getKeyRequestData(), this.msgCtx.getCryptoContexts());
+        } catch (final IOException e) {
+            throw new WiretapException(e.getMessage(), e);
         } catch (final MslException e) {
             throw new WiretapException(e.getMessage(), e);
         }

--- a/examples/burp/src/main/java/burp/msl/msg/WiretapMessageInputStream.java
+++ b/examples/burp/src/main/java/burp/msl/msg/WiretapMessageInputStream.java
@@ -15,6 +15,7 @@
  */
 package burp.msl.msg;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +68,7 @@ public class WiretapMessageInputStream extends MessageInputStream {
      *        response data.
      * @param cryptoContexts the map of service token names onto crypto
      *        contexts used to decrypt and verify service tokens.
+     * @throws IOException if there is a problem reading from the input stream.
      * @throws MslEncodingException if there is an error parsing the message.
      * @throws MslCryptoException if there is an error decrypting or verifying
      *         the header or creating the message payload crypto context.
@@ -88,7 +90,7 @@ public class WiretapMessageInputStream extends MessageInputStream {
      *         authentication data or a master token, or a token is improperly
      *         bound to another token.
      */
-    public WiretapMessageInputStream(final MslContext ctx, final InputStream source, final Set<KeyRequestData> keyRequestData, final Map<String, ICryptoContext> cryptoContexts) throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
+    public WiretapMessageInputStream(final MslContext ctx, final InputStream source, final Set<KeyRequestData> keyRequestData, final Map<String, ICryptoContext> cryptoContexts) throws IOException, MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslUserIdTokenException, MslMessageException, MslException {
         super(ctx, source, keyRequestData, cryptoContexts);
         this.ctx = ctx;
     }

--- a/tests/src/test/java/com/netflix/msl/io/DefaultMslEncoderFactorySuite.java
+++ b/tests/src/test/java/com/netflix/msl/io/DefaultMslEncoderFactorySuite.java
@@ -496,7 +496,7 @@ public class DefaultMslEncoderFactorySuite {
         }
         
         @Test
-        public void detectTokenizer() throws MslEncoderException, MslEncodingException, MslEntityAuthException, MslCryptoException, MslKeyExchangeException, MslUserAuthException, MslMessageException, MslException {
+        public void detectTokenizer() throws IOException, MslEncoderException, MslEncodingException, MslEntityAuthException, MslCryptoException, MslKeyExchangeException, MslUserAuthException, MslMessageException, MslException {
             if (exceptionClass != null)
                 thrown.expect(exceptionClass);
             


### PR DESCRIPTION
Fixes #188.
Do not catch IOExceptions in `MslEncoderFactory.createTokenizer()`.
Explicitly check for end-of-stream when reading, instead of relying upon the format to fail identification.