### PR TITLE
Various improvements; support Netflix JavaScript Web Crypto API.

### DIFF
--- a/core/src/main/javascript/MslError.js
+++ b/core/src/main/javascript/MslError.js
@@ -43,17 +43,9 @@
 	    /** Internal error code base value. */
 	    var BASE = 100000;
 	
-	    // There is no way to make the constructor private, so only add BASE if the
-	    // internal error code is less than BASE, as a safety check. In this way a
-	    // MslError could be created directly that is not one of the defined
-	    // constants.
-	    if (internalCode < BASE){
-	        internalCode = BASE + internalCode;
-	    }
-	
 	    // The properties.
 	    var props = {
-	        internalCode: { value: internalCode, writable: false, configurable: false },
+	        internalCode: { value: BASE + internalCode, writable: false, configurable: false },
 	        responseCode: { value: responseCode, writable: false, configurable: false },
 	        message: { value: msg, writable: false, configurable: false }
 	    };

--- a/core/src/main/javascript/crypto/MslCrypto.js
+++ b/core/src/main/javascript/crypto/MslCrypto.js
@@ -50,6 +50,8 @@
          * converted to JWK for key import and vice versa for key export.
          */
         V2014_02_SAFARI: 4,
+        /** Netflix JavaScript Web Crypto API. */
+        NRDJS: 5,
         /** Latest (most compatible) version. */
         LATEST: 3,
     };
@@ -145,17 +147,17 @@
 
     // If the native operation type is not a Promise, wrap it inside one.
     function promisedOperation(op) {
-    	if (!op.then) {
-    		return new Promise(function(resolve, reject) {
-    			op.oncomplete = function(e) {
-    				resolve(e.target.result);
-    			};
-    			op.onerror = function(e) {
-    				reject(e);
-    			};
-    		});
-    	}
-    	return op;
+        if (!op.then) {
+            return new Promise(function(resolve, reject) {
+                op.oncomplete = function(e) {
+                    resolve(e.target.result);
+                };
+                op.onerror = function(e) {
+                    reject(e);
+                };
+            });
+        }
+        return op;
     }
 
     var MslCrypto = module.exports = {
@@ -165,6 +167,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                 	var op = nfCryptoSubtle.encrypt(algorithm, key, buffer);
                     return promisedOperation(op);
                 default:
@@ -178,6 +181,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.decrypt(algorithm, key, buffer);
                     return promisedOperation(op);
                default:
@@ -191,6 +195,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.sign(algorithm, key, buffer);
                     return promisedOperation(op);
                 default:
@@ -204,6 +209,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.verify(algorithm, key, signature, buffer);
                     return promisedOperation(op);
                 default:
@@ -217,6 +223,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.digest(algorithm, buffer);
                     return promisedOperation(op);
                 default:
@@ -232,6 +239,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.generateKey(algorithm, ext, ku);
                     return promisedOperation(op);
                 default:
@@ -247,6 +255,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.deriveKey(algorithm, baseKey, derivedKeyAlgorithm, ext, ku);
                     return promisedOperation(op);
                 default:
@@ -260,6 +269,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var op = nfCryptoSubtle.deriveBits(algorithm, baseKey, length);
                     return promisedOperation(op);
                 default:
@@ -275,6 +285,7 @@
                 case WebCryptoVersion.LEGACY:
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
+                case WebCryptoVersion.NRDJS:
                     op = nfCryptoSubtle.importKey(format, keyData, algorithm, ext, ku);
                     return promisedOperation(op);
                 case WebCryptoVersion.V2014_02_SAFARI:
@@ -303,6 +314,7 @@
                 case WebCryptoVersion.LEGACY:
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
+                case WebCryptoVersion.NRDJS:
                     op = nfCryptoSubtle.exportKey(format, key);
                     return promisedOperation(op);
                 case WebCryptoVersion.V2014_02_SAFARI:
@@ -329,6 +341,7 @@
             var op;
             switch (mslCrypto$version) {
                 case WebCryptoVersion.LEGACY:
+                case WebCryptoVersion.NRDJS:
                     op = nfCryptoSubtle.wrapKey(keyToWrap, wrappingKey, wrappingAlgorithm);
                     break;
                 case WebCryptoVersion.V2014_01:
@@ -351,6 +364,7 @@
                 case WebCryptoVersion.V2014_01:
                 case WebCryptoVersion.V2014_02:
                 case WebCryptoVersion.V2014_02_SAFARI:
+                case WebCryptoVersion.NRDJS:
                     var ext = normalizeExtractable(extractable);
                     var ku = normalizeKeyUsage(usage);
                     op = nfCryptoSubtle.unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgorithm, unwrappedKeyAlgorithm, ext, ku);

--- a/core/src/main/javascript/io/Url.js
+++ b/core/src/main/javascript/io/Url.js
@@ -263,6 +263,21 @@
                 return this._buffer.markSupported();
         },
 
+        /**
+         * <p>Returns the already-parsed JSON if it exists. This function will
+         * return undefined until read() is first called, and may still return
+         * undefined afterwards if the JSON cannot be accessed in this
+         * manner.</p>
+         * 
+         * <p>If read() does result in JSON becoming available via this method,
+         * then read() will return zero bytes of data.</p>
+         * 
+         * @return {?Array{*}} an array of JSON values or undefined.
+         */
+        getJSON: function getJSON() {
+            return this._json;
+        }
+
         /** @inheritDoc */
         read: function read(len, timeout, callback) {
             var self = this;
@@ -327,11 +342,10 @@
                                 // stream to return already-parsed JSON.
                                 //
                                 // Return zero bytes immediately. If the caller
-                                // knows about this function, it will ignore
-                                // the zero byte return value.
+                                // knows about this, it will ignore the zero
+                                // byte return value.
                                 if (result.response.json !== undefined) {
                                     this._json = result.response.json;
-                                    this.getJSON = function () { return self._json; };
                                     return new Uint8Array(0);
                                 }
                                 

--- a/core/src/main/javascript/io/Url.js
+++ b/core/src/main/javascript/io/Url.js
@@ -276,7 +276,7 @@
          */
         getJSON: function getJSON() {
             return this._json;
-        }
+        },
 
         /** @inheritDoc */
         read: function read(len, timeout, callback) {

--- a/core/src/main/javascript/io/Url.js
+++ b/core/src/main/javascript/io/Url.js
@@ -341,12 +341,14 @@
                                 // This is a platform hack that allows the
                                 // stream to return already-parsed JSON.
                                 //
-                                // Return zero bytes immediately. If the caller
-                                // knows about this, it will ignore the zero
-                                // byte return value.
+                                // Return null immediately to indicate no data
+                                // is available (end-of-stream). If the caller
+                                // knows about this hack, it will ignore the
+                                // null return value and check for the JSON
+                                // first.
                                 if (result.response.json !== undefined) {
                                     this._json = result.response.json;
-                                    return new Uint8Array(0);
+                                    return null;
                                 }
                                 
                                 // Retrieve the raw bytes if available,


### PR DESCRIPTION
* Add `WebCryptoVersion.NRDJS` for Netflix JavaScript Web Crypto API.
* Exit `HttpOutputStream.close()` early if `.close()` was already called or the if the operation was already aborted.
* Optimize `HttpOutputStream.read()` by avoiding unnecessary parsing if JSON is provided by the platform and by moving `getJSON()` onto the class definition proper.
* Remove unwarranted protection against unexpected creation of MslError definitions.