### PR TITLE
Add understandable toString to MslError

### DIFF
--- a/core/src/main/java/com/netflix/msl/MslError.java
+++ b/core/src/main/java/com/netflix/msl/MslError.java
@@ -313,7 +313,12 @@ public class MslError {
     public String getMessage() {
         return msg;
     }
-    
+
+    @Override
+    public String toString() {
+        return "MslError{" + internalCode + "," + msg + "}";
+    }
+
     /**
      * @param o the reference object with which to compare.
      * @return true if the internal code and response code are equal.


### PR DESCRIPTION
This would be instead of relying on default memory location toString.