### PR TITLE
Ensure proper static initialization order in MslCompression.

### DIFF
--- a/core/src/main/java/com/netflix/msl/util/MslCompression.java
+++ b/core/src/main/java/com/netflix/msl/util/MslCompression.java
@@ -38,6 +38,9 @@ import com.netflix.msl.io.LZWOutputStream;
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class MslCompression {
+    /** Registered compression implementations. */
+    private static Map<CompressionAlgorithm,CompressionImpl> impls = new ConcurrentHashMap<CompressionAlgorithm,CompressionImpl>();
+    
     /**
      * <p>A data compression implementation. Implementations must be thread-
      * safe.</p>
@@ -202,7 +205,4 @@ public class MslCompression {
             throw new MslException(MslError.UNCOMPRESSION_ERROR, "algo " + compressionAlgo.name(), e);
         }
     }
-    
-    /** Registered compression implementations. */
-    private static Map<CompressionAlgorithm,CompressionImpl> impls = new ConcurrentHashMap<CompressionAlgorithm,CompressionImpl>();
 }


### PR DESCRIPTION
* Use MSL encoder in JsonWebEncryptionCryptoContextSuite unit tests instead of org.json.