### PR TITLE
Add MslError.toString().

### DIFF
--- a/core/src/main/cpp/MslError.cpp
+++ b/core/src/main/cpp/MslError.cpp
@@ -310,4 +310,9 @@ MslError& MslError::operator=(const MslError& other)
     return *this;
 }
 
+std::ostream & operator<<(std::ostream& os, const MslError& me)
+{
+    return os << "MslError{" << me.internalCode_ << "," << me.responseCode_.intValue() << "," << me.msg_ << "}";
+}
+
 }} // namespace netflix::msl

--- a/core/src/main/cpp/MslError.h
+++ b/core/src/main/cpp/MslError.h
@@ -310,6 +310,11 @@ public:
      */
     inline bool operator!=(const MslError& rhs) const { return !(*this == rhs); }
 
+    // operator<< for easier use with output
+    friend inline std::ostream & operator<<(std::ostream& os, const MslError& me) {
+        return os << "MslError{" << me.internalCode_ << "," << me.responseCode_.intValue() << "," << me.msg_ << "}";
+    }
+
     MslError(const MslError& other);
     MslError& operator=(const MslError& other);
 

--- a/core/src/main/cpp/MslError.h
+++ b/core/src/main/cpp/MslError.h
@@ -311,9 +311,7 @@ public:
     inline bool operator!=(const MslError& rhs) const { return !(*this == rhs); }
 
     // operator<< for easier use with output
-    friend inline std::ostream & operator<<(std::ostream& os, const MslError& me) {
-        return os << "MslError{" << me.internalCode_ << "," << me.responseCode_.intValue() << "," << me.msg_ << "}";
-    }
+    friend std::ostream & operator<<(std::ostream& os, const MslError& me);
 
     MslError(const MslError& other);
     MslError& operator=(const MslError& other);
@@ -346,6 +344,8 @@ protected:
 
     friend class MslErrorTest_DuplicateConstruction_Test;  // For testing only
 };
+
+std::ostream & operator<<(std::ostream& os, const MslError& me);
 
 }} //namespace netflix::msl
 

--- a/tests/src/test/cpp/MslErrorTest.cpp
+++ b/tests/src/test/cpp/MslErrorTest.cpp
@@ -16,11 +16,13 @@
 
 #include <gtest/gtest.h>
 #include "MslError.h"
+#include <string>
+#include <sstream>
 
-namespace netflix
-{
-namespace msl
-{
+using namespace std;
+
+namespace netflix {
+namespace msl {
 
 using namespace netflix::msl::MslConstants;
 
@@ -47,5 +49,12 @@ TEST_F(MslErrorTest, DuplicateConstruction)
     EXPECT_THROW(MslError(0, ResponseCode::FAIL, "foo"), std::exception);
 }
 
-} /* namespace msl */
-} /* namespace netflix */
+TEST_F(MslErrorTest, ToString)
+{
+    string expected = "MslError{100000,1,Error parsing MSL encodable.}";
+    stringstream ss;
+    ss << MslError::MSL_PARSE_ERROR;
+    EXPECT_EQ(ss.str(), expected);
+}
+
+}} // namespace netflix::msl


### PR DESCRIPTION
Returns the internal code, response code integer value, and message.
Credit to @quidryan from #203.