### PR TITLE
Only perform sender and recipient verifications if the local entity identity is known.

### DIFF
--- a/core/src/main/java/com/netflix/msl/entityauth/EccAuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/EccAuthenticationData.java
@@ -73,9 +73,9 @@ public class EccAuthenticationData extends EntityAuthenticationData {
             throw new MslEncodingException(MslError.MSL_PARSE_ERROR, "ECC authdata " + eccAuthMo, e);
         }
     }
-    
-    /**
-     * @return the entity identity.
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#getIdentity()
      */
     @Override
     public String getIdentity() {

--- a/core/src/main/java/com/netflix/msl/entityauth/EntityAuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/EntityAuthenticationData.java
@@ -107,7 +107,7 @@ public abstract class EntityAuthenticationData implements MslEncodable {
     }
     
     /**
-     * @return the entity identity.
+     * @return the entity identity. May be {@code null} if unknown.
      * @throws MslCryptoException if there is a crypto error accessing the
      *         entity identity.
      */

--- a/core/src/main/java/com/netflix/msl/entityauth/PresharedAuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/PresharedAuthenticationData.java
@@ -67,9 +67,9 @@ public class PresharedAuthenticationData extends EntityAuthenticationData {
             throw new MslEncodingException(MslError.MSL_PARSE_ERROR, "psk authdata " + presharedAuthMo, e);
         }
     }
-    
-    /**
-     * @return the entity identity.
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#getIdentity()
      */
     @Override
     public String getIdentity() {

--- a/core/src/main/java/com/netflix/msl/entityauth/RsaAuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/RsaAuthenticationData.java
@@ -75,9 +75,9 @@ public class RsaAuthenticationData extends EntityAuthenticationData {
             throw new MslEncodingException(MslError.MSL_PARSE_ERROR, "RSA authdata " + rsaAuthMo, e);
         }
     }
-    
-    /**
-     * @return the entity identity.
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#getIdentity()
      */
     @Override
     public String getIdentity() {

--- a/core/src/main/java/com/netflix/msl/entityauth/UnauthenticatedAuthenticationData.java
+++ b/core/src/main/java/com/netflix/msl/entityauth/UnauthenticatedAuthenticationData.java
@@ -69,9 +69,9 @@ public class UnauthenticatedAuthenticationData extends EntityAuthenticationData 
             throw new MslEncodingException(MslError.MSL_PARSE_ERROR, "unauthenticated authdata " + unauthenticatedAuthMo, e);
         }
     }
-    
-    /**
-     * @return the entity identity.
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.entityauth.EntityAuthenticationData#getIdentity()
      */
     @Override
     public String getIdentity() {

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -1732,13 +1732,13 @@ public class MslControl {
                 final String sender = (masterToken != null) ? responseHeader.getSender() : entityAuthData.getIdentity();
                 if (masterToken != null && masterToken.isDecrypted() && !masterToken.getIdentity().equals(sender))
                     throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, "sender " + sender + "; master token " + masterToken.getIdentity());
-                if (localIdentity.equals(sender))
+                if (localIdentity != null && localIdentity.equals(sender))
                     throw new MslMessageException(MslError.UNEXPECTED_LOCAL_MESSAGE_SENDER, sender + " == " + localIdentity);
 
                 // Reject messages if the message recipient is specified and not
                 // equal to the local entity.
                 final String recipient = responseHeader.getRecipient();
-                if (recipient != null && !recipient.equals(localIdentity))
+                if (recipient != null && localIdentity != null && !recipient.equals(localIdentity))
                     throw new MslMessageException(MslError.MESSAGE_RECIPIENT_MISMATCH, recipient + " != " + localIdentity);
 
                 // If there is a request update the stored crypto contexts.
@@ -1773,7 +1773,7 @@ public class MslControl {
             } else {
                 // Reject errors if the sender is equal to this entity.
                 final String sender = errorHeader.getEntityAuthenticationData().getIdentity();
-                if (localIdentity.equals(sender))
+                if (localIdentity != null && localIdentity.equals(sender))
                     throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, sender);
             }
             

--- a/core/src/main/javascript/entityauth/EntityAuthenticationData.js
+++ b/core/src/main/javascript/entityauth/EntityAuthenticationData.js
@@ -73,7 +73,7 @@
         },
 
         /**
-         * @return {string} the entity identity.
+         * @return {string} the entity identity. May be {@code null} if unknown.
          * @throws MslCryptoException if there is a crypto error accessing the
          *         entity identity.
          */

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -1777,13 +1777,13 @@
                                                         sender = (masterToken) ? responseHeader.sender : entityAuthData.getIdentity();
                                                         if ((masterToken && masterToken.isDecrypted() && masterToken.identity != sender))
                                                             throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, "sender " + sender + "; master token " + masterToken.identity);
-                                                        if (localIdentity == sender)
+                                                        if (localIdentity && localIdentity == sender)
                                                             throw new MslMessageException(MslError.UNEXPECTED_LOCAL_MESSAGE_SENDER, sender + " == " + localIdentity);
 
                                                         // Reject messages if the message recipient is specified and not
                                                         // equal to the local entity.
                                                         var recipient = responseHeader.recipient;
-                                                        if (recipient && recipient != localIdentity)
+                                                        if (recipient && localIdentity && recipient != localIdentity)
                                                             throw new MslMessageException(MslError.MESSAGE_RECIPIENT_MISMATCH, recipient);
 
                                                         // If there is a request update the stored crypto contexts.
@@ -1818,7 +1818,7 @@
                                                     } else {
                                                         // Reject errors if the sender is equal to this entity.
                                                         sender = errorHeader.entityAuthenticationData.getIdentity();
-                                                        if (localIdentity == sender)
+                                                        if (localIdentity && localIdentity == sender)
                                                             throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, sender);
                                                     }
 


### PR DESCRIPTION
Addresses #216, allowing null to be returned from EntityAuthenticationData.getIdentity() if the local entity does not know its own entity identity.