### PR TITLE
Prevent unencrypted message headers from containing user authentication data.

### DIFF
--- a/core/src/main/java/com/netflix/msl/MslError.java
+++ b/core/src/main/java/com/netflix/msl/MslError.java
@@ -237,6 +237,7 @@ public class MslError {
     public static final MslError MESSAGE_MASTERTOKENBASED_VERIFICATION_FAILED = new MslError(6039, ResponseCode.ENTITY_REAUTH, "Message header master token-based signature verification failed.");
     public static final MslError MESSAGE_REPLAYED_UNRECOVERABLE = new MslError(6040, ResponseCode.ENTITY_REAUTH, "Non-replayable message replayed with a sequence number that is too far out of sync to recover.");
     public static final MslError UNEXPECTED_LOCAL_MESSAGE_SENDER = new MslError(6041, ResponseCode.FAIL, "Message sender is equal to the local entity.");
+    public static final MslError UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA = new MslError(6042, ResponseCode.FAIL, "User authentication data included in unencrypted message header.");
 
     // 7 Key Exchange
     public static final MslError UNIDENTIFIED_KEYX_SCHEME = new MslError(7000, ResponseCode.FAIL, "Unable to identify key exchange scheme.");

--- a/core/src/main/java/com/netflix/msl/msg/Header.java
+++ b/core/src/main/java/com/netflix/msl/msg/Header.java
@@ -117,7 +117,8 @@ public abstract class Header implements MslEncodable {
      *         data.
      * @throws MslMessageException if the message does not contain an entity
      *         authentication data or a master token, the header data is
-     *         missing or invalid, or the message ID is negative.
+     *         missing or invalid, or the message ID is negative, or the
+     *         message is not encrypted and contains user authentication data.
      * @throws MslException if the message does not contain an entity
      *         authentication data or a master token or a token is improperly
      *         bound to another token.

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -278,6 +278,11 @@ public class MessageHeader extends Header {
             encrypted = scheme.encrypts();
         }
 
+        // Do not allow user authentication data to be included if the message
+        // will not be encrypted.
+        if (!encrypted && headerData.userAuthData != null)
+            throw new MslInternalException("User authentication data cannot be included if the message is not encrypted.");
+
         this.entityAuthData = (masterToken == null) ? entityAuthData : null;
         this.masterToken = masterToken;
         this.nonReplayableId = headerData.nonReplayableId;
@@ -457,7 +462,8 @@ public class MessageHeader extends Header {
      *         trusted and needs to be to accept this message header.
      * @throws MslMessageException if the message does not contain an entity
      *         authentication data or a master token, the header data is
-     *         missing or invalid, or the message ID is negative.
+     *         missing or invalid, or the message ID is negative, or the
+     *         message is not encrypted and contains user authentication data.
      * @throws MslException if a token is improperly bound to another token.
      */
     protected MessageHeader(final MslContext ctx, final byte[] headerdataBytes, final EntityAuthenticationData entityAuthData, final MasterToken masterToken, final byte[] signature, final Map<String,ICryptoContext> cryptoContexts) throws MslEncodingException, MslCryptoException, MslKeyExchangeException, MslUserAuthException, MslMasterTokenException, MslMessageException, MslEntityAuthException, MslException {
@@ -566,8 +572,20 @@ public class MessageHeader extends Header {
                 ? UserAuthenticationData.create(ctx, tokenVerificationMasterToken, headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder))
                 : null;
 
-            // Verify the user authentication data.
+            // Identify the user if any.
             if (this.userAuthData != null) {
+                // Reject unencrypted messages containing user authentication data.
+                final boolean encrypted;
+                if (masterToken != null) {
+                    encrypted = true;
+                } else {
+                    final EntityAuthenticationScheme scheme = entityAuthData.getScheme();
+                    encrypted = scheme.encrypts();
+                }
+                if (!encrypted)
+                    throw new MslMessageException(MslError.UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA).setUserIdToken(userIdToken).setUserAuthenticationData(userAuthData);
+
+                // Verify the user authentication data.
                 final UserAuthenticationScheme scheme = this.userAuthData.getScheme();
                 final UserAuthenticationFactory factory = ctx.getUserAuthenticationFactory(scheme);
                 if (factory == null)

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -575,13 +575,7 @@ public class MessageHeader extends Header {
             // Identify the user if any.
             if (this.userAuthData != null) {
                 // Reject unencrypted messages containing user authentication data.
-                final boolean encrypted;
-                if (masterToken != null) {
-                    encrypted = true;
-                } else {
-                    final EntityAuthenticationScheme scheme = entityAuthData.getScheme();
-                    encrypted = scheme.encrypts();
-                }
+                final boolean encrypted = (masterToken != null) ? true : entityAuthData.getScheme().encrypts();
                 if (!encrypted)
                     throw new MslMessageException(MslError.UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA).setUserIdToken(userIdToken).setUserAuthenticationData(userAuthData);
 

--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -194,8 +194,12 @@ public class MessageInputStream extends InputStream {
      * @throws MslKeyExchangeException if there is an error with the key
      *         request data or key response data or the key exchange scheme is
      *         not supported.
-     * @throws MslMessageException if the message master token is expired and
-     *         the message is not renewable.
+     * @throws MslMessageException if the message does not contain an entity
+     *         authentication data or a master token, the header data is
+     *         missing or invalid, or the message ID is negative, or the
+     *         message is not encrypted and contains user authentication data,
+     *         or if the message master token is expired and the message is not
+     *         renewable.
      * @throws MslException if the message does not contain an entity
      *         authentication data or a master token, or a token is improperly
      *         bound to another token.

--- a/core/src/main/java/com/netflix/msl/msg/MessageStreamFactory.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageStreamFactory.java
@@ -68,16 +68,18 @@ public class MessageStreamFactory {
      *         authentication data.
      * @throws MslUserAuthException if unable to create the user authentication
      *         data.
-     * @throws MslMessageException if the message master token is expired and
-     *         the message is not renewable.
      * @throws MslMasterTokenException if the master token is not trusted and
      *         needs to be or if it has been revoked.
      * @throws MslUserIdTokenException if the user ID token has been revoked.
      * @throws MslKeyExchangeException if there is an error with the key
      *         request data or key response data or the key exchange scheme is
      *         not supported.
-     * @throws MslMessageException if the message master token is expired and
-     *         the message is not renewable.
+     * @throws MslMessageException if the message does not contain an entity
+     *         authentication data or a master token, the header data is
+     *         missing or invalid, or the message ID is negative, or the
+     *         message is not encrypted and contains user authentication data,
+     *         or if the message master token is expired and the message is not
+     *         renewable.
      * @throws MslException if the message does not contain an entity
      *         authentication data or a master token, or a token is improperly
      *         bound to another token.

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -1653,19 +1653,22 @@ public class MslControl {
      *         authentication data.
      * @throws MslUserAuthException if unable to create the user authentication
      *         data.
-     * @throws MslMessageException if the message master token is expired and
-     *         the message is not renewable.
      * @throws MslMasterTokenException if the master token is not trusted and
      *         needs to be.
      * @throws MslKeyExchangeException if there is an error with the key
      *         request data or key response data or the key exchange scheme is
      *         not supported.
-     * @throws MslMessageException if the message master token is expired and
-     *         the message is not renewable.
      * @throws MslException if the message does not contain an entity
      *         authentication data or a master token, or a token is improperly
      *         bound to another token, or there is an error updating the
      *         service tokens.
+     * @throws MslMessageException if the message does not contain an entity
+     *         authentication data or a master token, or a token is improperly
+     *         bound to another token, or there is an error updating the
+     *         service tokens, or the header data is missing or invalid, or the
+     *         message ID is negative, or the message is not encrypted and
+     *         contains user authentication data, or if the message master
+     *         token is expired and the message is not renewable.
      * @throws InterruptedException if the thread is interrupted while trying
      *         to delete an old master token the received message is replacing.
      */
@@ -1857,7 +1860,9 @@ public class MslControl {
      * @throws MslMessageException if the message master token is expired and
      *         the message is not renewable, if there is an error building the
      *         request, or if the response message ID does not equal the
-     *         expected value.
+     *         expected value, or the header data is missing or invalid, or the
+     *         message ID is negative, or the message is not encrypted and
+     *         contains user authentication data.
      * @throws MslException if the message does not contain an entity
      *         authentication data or a master token, or a token is improperly
      *         bound to another token, or there is an error updating the
@@ -2657,7 +2662,8 @@ public class MslControl {
          *         or integrity protected when required, a user could not be
          *         attached due to lack of a master token, or if the maximum
          *         message count is hit.
-         * @throws MslException if there was an error creating the response.
+         * @throws MslException if there was an error creating or processing a
+         *         message.
          * @throws MslErrorResponseException if there was an error sending an
          *         automatically generated error response.
          * @throws IOException if there was an error writing the message.

--- a/core/src/main/javascript/MslError.js
+++ b/core/src/main/javascript/MslError.js
@@ -266,6 +266,7 @@
 	    MESSAGE_MASTERTOKENBASED_VERIFICATION_FAILED : new MslError(6039, MslConstants.ResponseCode.ENTITY_REAUTH, "Message header master token-based signature verification failed."),
 	    MESSAGE_REPLAYED_UNRECOVERABLE : new MslError(6040, MslConstants.ResponseCode.ENTITY_REAUTH, "Non-replayable message replayed with a sequence number that is too far out of sync to recover."),
 	    UNEXPECTED_LOCAL_MESSAGE_SENDER : new MslError(6041, MslConstants.ResponseCode.FAIL, "Message sender is equal to the local entity."),
+	    UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA : new MslError(6042, MslConstants.ResponseCode.FAIL, "User authentication data included in unencrypted message header."),
 
 	    // 7 Key Exchange
 	    UNIDENTIFIED_KEYX_SCHEME : new MslError(7000, MslConstants.ResponseCode.FAIL, "Unable to identify key exchange scheme."),

--- a/core/src/main/javascript/msg/Header.js
+++ b/core/src/main/javascript/msg/Header.js
@@ -127,7 +127,10 @@
      *         or key response data.
      * @throws MslUserAuthException if unable to create the user authentication
      *         data.
-     * @throws MslMessageException if the header signature is invalid.
+     * @throws MslMessageException if the message does not contain an entity
+     *         authentication data or a master token, the header data is
+     *         missing or invalid, or the message ID is negative, or the
+     *         message is not encrypted and contains user authentication data.
      * @throws MslException if the message does not contain an entity
      *         authentication data or a master token or a token is improperly
      *         bound to another token.

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -1334,13 +1334,7 @@
                                                     var user;
                                                     if (userAuthData) {
                                                         // Reject unencrypted messages containing user authentication data.
-                                                        var encrypted;
-                                                        if (masterToken) {
-                                                            encrypted = true;
-                                                        } else {
-                                                            var scheme = entityAuthData.scheme;
-                                                            encrypted = scheme.encrypts;
-                                                        }
+                                                        var encrypted = (masterToken) ? true : entityAuthData.scheme.encrypts;
                                                         if (!encrypted)
                                                             throw new MslMessageException(MslError.UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA).setUserIdToken(userIdToken).setUserAuthenticationData(userAuthData);
                                                         

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -188,8 +188,12 @@
          * @throws MslKeyExchangeException if there is an error with the key
          *         request data or key response data or the key exchange scheme is
          *         not supported.
-         * @throws MslMessageException if the message master token is expired and
-         *         the message is not renewable.
+         * @throws MslMessageException if the message does not contain an entity
+         *         authentication data or a master token, the header data is
+         *         missing or invalid, or the message ID is negative, or the
+         *         message is not encrypted and contains user authentication data,
+         *         or if the message master token is expired and the message is not
+         *         renewable.
          * @throws MslException if the message does not contain an entity
          *         authentication data or a master token, or a token is improperly
          *         bound to another token.

--- a/core/src/main/javascript/msg/MessageStreamFactory.js
+++ b/core/src/main/javascript/msg/MessageStreamFactory.js
@@ -58,15 +58,17 @@
 	     *         authentication data.
 	     * @throws MslUserAuthException if unable to create the user authentication
 	     *         data.
-	     * @throws MslMessageException if the message master token is expired and
-	     *         the message is not renewable.
 	     * @throws MslMasterTokenException if the master token is not trusted and
 	     *         needs to be.
 	     * @throws MslKeyExchangeException if there is an error with the key
 	     *         request data or key response data or the key exchange scheme is
 	     *         not supported.
-	     * @throws MslMessageException if the message master token is expired and
-	     *         the message is not renewable.
+	     * @throws MslMessageException if the message does not contain an entity
+	     *         authentication data or a master token, the header data is
+	     *         missing or invalid, or the message ID is negative, or the
+	     *         message is not encrypted and contains user authentication data,
+	     *         or if the message master token is expired and the message is not
+	     *         renewable.
 	     * @throws MslException if the message does not contain an entity
 	     *         authentication data or a master token, or a token is improperly
 	     *         bound to another token.

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -1683,12 +1683,17 @@
          * @throws MslKeyExchangeException if there is an error with the key
          *         request data or key response data or the key exchange scheme is
          *         not supported.
-         * @throws MslMessageException if the message master token is expired and
-         *         the message is not renewable.
          * @throws MslException if the message does not contain an entity
          *         authentication data or a master token, or a token is improperly
          *         bound to another token, or there is an error updating the
          *         service tokens.
+         * @throws MslMessageException if the message does not contain an entity
+         *         authentication data or a master token, or a token is improperly
+         *         bound to another token, or there is an error updating the
+         *         service tokens, or the header data is missing or invalid, or the
+         *         message ID is negative, or the message is not encrypted and
+         *         contains user authentication data, or if the message master
+         *         token is expired and the message is not renewable.
          * @throws InterruptedException if the thread is interrupted while trying
          *         to delete an old master token the received message is replacing.
          */
@@ -1905,7 +1910,9 @@
          * @throws MslMessageException if the message master token is expired and
          *         the message is not renewable, if there is an error building the
          *         request, or if the response message ID does not equal the
-         *         expected value.
+         *         expected value, or the header data is missing or invalid, or the
+         *         message ID is negative, or the message is not encrypted and
+         *         contains user authentication data.
          * @throws MslException if the message does not contain an entity
          *         authentication data or a master token, or a token is improperly
          *         bound to another token, or there is an error updating the
@@ -3372,7 +3379,8 @@
          *        protected when required, a user could not be attached due to
          *        lack of a master token, or if the maximum message count is
          *        hit; notified of timeout or any thrown exceptions.
-         * @throws MslException if there was an error creating the response.
+         * @throws MslException if there was an error creating or processing a
+         *         message.
          * @throws MslErrorResponseException if there was an error sending an
          *         automatically generated error response.
          * @throws IOException if there was an error writing the message.

--- a/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
@@ -3083,6 +3083,7 @@ public class MessageHeaderTest {
     @Test
     public void unencryptedUserAuthDataParseHeader() throws MslEncodingException, MslCryptoException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
+        thrown.expectMslError(MslError.UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA);
         thrown.expectMessageId(MESSAGE_ID);
 
         final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);

--- a/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
@@ -38,7 +38,6 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -1009,6 +1008,7 @@ public class MessageHeaderTest {
         final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
         
         final HeaderDataBuilder builder = new HeaderDataBuilder(x509Ctx, MASTER_TOKEN, USER_ID_TOKEN, false);
+        builder.set(KEY_USER_AUTHENTICATION_DATA, null);
         final HeaderData headerData = builder.build();
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = x509Ctx.getEntityAuthenticationData(null);
@@ -3067,6 +3067,48 @@ public class MessageHeaderTest {
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
+    }
+    
+    @Test(expected = MslInternalException.class)
+    public void unencryptedUserAuthDataCtor() throws MslEncodingException, MslCryptoException, MslException {
+        final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
+        
+        final HeaderDataBuilder builder = new HeaderDataBuilder(x509Ctx, null, null, false);
+        final HeaderData headerData = builder.build();
+        final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
+        final EntityAuthenticationData entityAuthData = x509Ctx.getEntityAuthenticationData(null);
+        new MessageHeader(x509Ctx, entityAuthData, null, headerData, peerData);
+    }
+    
+    @Test
+    public void unencryptedUserAuthDataParseHeader() throws MslEncodingException, MslCryptoException, MslException, MslEncoderException {
+        thrown.expect(MslMessageException.class);
+        thrown.expectMessageId(MESSAGE_ID);
+
+        final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
+
+        final HeaderDataBuilder builder = new HeaderDataBuilder(x509Ctx, null, null, true);
+        builder.set(KEY_USER_AUTHENTICATION_DATA, null);
+        final HeaderData headerData = builder.build();
+        final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
+        final EntityAuthenticationData entityAuthData = x509Ctx.getEntityAuthenticationData(null);
+        final MessageHeader messageHeader = new MessageHeader(x509Ctx, entityAuthData, null, headerData, peerData);
+        final MslObject messageHeaderMo = MslTestUtils.toMslObject(encoder, messageHeader);
+        
+        // The header data is not encrypted.
+        final byte[] plaintext = messageHeaderMo.getBytes(KEY_HEADERDATA);
+        final MslObject headerdataMo = encoder.parseObject(plaintext);
+        headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, USER_AUTH_DATA);
+        final byte[] headerdata = encoder.encodeObject(headerdataMo, ENCODER_FORMAT);
+        messageHeaderMo.put(KEY_HEADERDATA, headerdata);
+        
+        // The header data must be signed or it will not be processed.
+        final EntityAuthenticationFactory factory = x509Ctx.getEntityAuthenticationFactory(entityAuthData.getScheme());
+        final ICryptoContext cryptoContext = factory.getCryptoContext(x509Ctx, entityAuthData);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        messageHeaderMo.put(KEY_SIGNATURE, signature);
+        
+        Header.parseHeader(x509Ctx, messageHeaderMo, CRYPTO_CONTEXTS);
     }
     
     @Test(expected = UnsupportedOperationException.class)

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -6587,7 +6587,7 @@ describe("MessageHeader", function() {
         
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslMessageException(MslError.NONE), MESSAGE_ID);
+            expect(f).toThrow(new MslMessageException(MslError.UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA), MESSAGE_ID);
         });
 	});
 

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -1637,6 +1637,7 @@ describe("MessageHeader", function() {
         
 		var messageHeader;
 		runs(function() {
+	        builder.set(KEY_USER_AUTHENTICATION_DATA, null);
 			var headerData = builder.build();
 			var peerData = new HeaderPeerData(null, null, null);
 			MessageHeader.create(rsaCtx, entityAuthData, null, headerData, peerData, {
@@ -1673,7 +1674,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1701,7 +1702,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1738,7 +1739,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1766,7 +1767,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1792,9 +1793,11 @@ describe("MessageHeader", function() {
                 error: function(err) { exception = err; },
             });
         });
+		waitsFor(function() { return exception; }, "exception", MslTestConstants.TIMEOUT);
+		
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1821,9 +1824,10 @@ describe("MessageHeader", function() {
             });
         });
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
+        
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1858,7 +1862,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1883,9 +1887,11 @@ describe("MessageHeader", function() {
                 error: function(err) { exception = err; },
             });
         });
+        waitsFor(function() { return exception; }, "exception", MslTestConstants.TIMEOUT);
+        
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1922,7 +1928,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1959,7 +1965,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -1996,7 +2002,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -2033,7 +2039,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -2076,7 +2082,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -2113,7 +2119,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED, MESSAGE_ID));
+			expect(f).toThrow(new MslMasterTokenException(MslError.MASTERTOKEN_UNTRUSTED), MESSAGE_ID);
 		});
 	});
 
@@ -2152,7 +2158,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslEntityAuthException(MslError.ENTITYAUTH_FACTORY_NOT_FOUND, MESSAGE_ID));
+			expect(f).toThrow(new MslEntityAuthException(MslError.ENTITYAUTH_FACTORY_NOT_FOUND), MESSAGE_ID);
 		});
 	});
 
@@ -2841,7 +2847,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslUserAuthException(MslError.USERAUTH_FACTORY_NOT_FOUND, MESSAGE_ID));
+			expect(f).toThrow(new MslUserAuthException(MslError.USERAUTH_FACTORY_NOT_FOUND), MESSAGE_ID);
 		});
 	});
 
@@ -5027,7 +5033,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -5056,7 +5062,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", MslTestConstants.TIMEOUT);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslInternalException(MslError.NONE));
+			expect(f).toThrow(new MslInternalException());
 		});
 	});
 
@@ -5299,7 +5305,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", 300);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR, MESSAGE_ID));
+			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR), MESSAGE_ID);
 		});
 	});
 
@@ -5380,7 +5386,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", 300);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR, MESSAGE_ID));
+			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR), MESSAGE_ID);
 		});
 	});
 
@@ -5461,7 +5467,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", 300);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR, MESSAGE_ID));
+			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR), MESSAGE_ID);
 		});
 	});
 
@@ -5546,7 +5552,7 @@ describe("MessageHeader", function() {
         
         runs(function() {
             //var f = function() { throw exception; };
-            //expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR, MESSAGE_ID));
+            //expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR), MESSAGE_ID);
             expect(header.isHandshake()).toBeFalsy();
         });
 	});
@@ -5628,7 +5634,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", 300);
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR, MESSAGE_ID));
+            expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR), MESSAGE_ID);
         });
 	});
 	
@@ -5709,7 +5715,7 @@ describe("MessageHeader", function() {
         waitsFor(function() { return exception; }, "exception not received", 300);
 		runs(function() {
 			var f = function() { throw exception; };
-			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR, MESSAGE_ID));
+			expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR), MESSAGE_ID);
 		});
 	});
 
@@ -6445,6 +6451,144 @@ describe("MessageHeader", function() {
 			var f = function() { throw exception; };
 			expect(f).toThrow(new MslEncodingException(MslError.NONE), MESSAGE_ID);
 		});
+	});
+	
+	it("ctor with unencrypted user authentication data", function() {
+	    var rsaCtx;
+        runs(function() {
+            MockMslContext.create(EntityAuthenticationScheme.RSA, false, {
+                result: function(c) { rsaCtx = c; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return rsaCtx; }, "rsaCtx", MslTestConstants.TIMEOUT);
+	    
+        var entityAuthData;
+        runs(function() {
+            rsaCtx.getEntityAuthenticationData(null, {
+                result: function(x) { entityAuthData = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return entityAuthData; }, "entityAuthData", MslTestConstants.TIMEOUT);
+        
+        var builder;
+        runs(function() {
+            HeaderDataBuilder$create(rsaCtx, null, null, false, {
+                result: function(x) { builder = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
+        
+        var exception;
+        runs(function() {
+            var headerData = builder.build();
+            var peerData = new HeaderPeerData(null, null, null);
+            MessageHeader.create(rsaCtx, entityAuthData, null, headerData, peerData, {
+                result: function() {},
+                error: function(e) { exception = e; }
+            });
+        });
+        waitsFor(function() { return exception; }, "exception", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            var f = function() { throw exception; };
+            expect(f).toThrow(new MslInternalException());
+        });
+	});
+
+	it("parseHeader with unencrypted user authentication data", function() {
+        var rsaCtx;
+        runs(function() {
+            MockMslContext.create(EntityAuthenticationScheme.RSA, false, {
+                result: function(c) { rsaCtx = c; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return rsaCtx; }, "rsaCtx", MslTestConstants.TIMEOUT);
+        
+        var entityAuthData;
+        runs(function() {
+            rsaCtx.getEntityAuthenticationData(null, {
+                result: function(x) { entityAuthData = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return entityAuthData; }, "entityAuthData", MslTestConstants.TIMEOUT);
+        
+        var builder;
+        runs(function() {
+            HeaderDataBuilder$create(rsaCtx, null, null, false, {
+                result: function(x) { builder = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
+        
+        var messageHeader;
+        runs(function() {
+            builder.set(KEY_USER_AUTHENTICATION_DATA, null);
+            var headerData = builder.build();
+            var peerData = new HeaderPeerData(null, null, null);
+            MessageHeader.create(rsaCtx, entityAuthData, null, headerData, peerData, {
+                result: function(x) { messageHeader = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return messageHeader; }, "messageHeader", MslTestConstants.TIMEOUT);
+        
+        var messageHeaderMo;
+        runs(function() {
+            MslTestUtils.toMslObject(encoder, messageHeader, {
+                result: function(x) { messageHeaderMo = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return messageHeaderMo; }, "messageHeaderMo", MslTestConstants.TIMEOUT);
+        
+        var headerdata;
+        runs(function() {
+            // The header data is not encrypted.
+            var plaintext = messageHeaderMo.getBytes(KEY_HEADERDATA);
+            var headerdataMo = encoder.parseObject(plaintext);
+            headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, USER_AUTH_DATA);
+            encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                result: function(x) { headerdata = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return headerdata; }, "headerdata", MslTestConstants.TIMEOUT);
+        
+        var signature;
+        runs(function() {
+            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
+
+            // The header data must be signed or it will not be processed.
+            var factory = rsaCtx.getEntityAuthenticationFactory(entityAuthData.scheme);
+            var cryptoContext = factory.getCryptoContext(rsaCtx, entityAuthData);
+            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+                result: function(x) { signature = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return signature; }, "signature", MslTestConstants.TIMEOUT);
+        
+        var exception;
+        runs(function() {
+            messageHeaderMo.put(KEY_SIGNATURE, signature);
+            
+            Header.parseHeader(rsaCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
+                result: function() {},
+                error: function(e) { exception = e; }
+            });
+        });
+        waitsFor(function() { return exception; }, "exception", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            var f = function() { throw exception; };
+            expect(f).toThrow(new MslMessageException(MslError.NONE), MESSAGE_ID);
+        });
 	});
 
 	xit("equals master token", function() {


### PR DESCRIPTION
Resolves #202.
* Throw MslInternalException if an attempt is made to include user authentication data when the message header will not be encrypted.
* Throw MslMessageException when parsing a message header if the header was not encrypted and contains user authentication data.