### PR TITLE
Allow missing sender identity

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -542,7 +542,7 @@ public class MessageHeader extends Header {
 
         try {
             // If the message was sent with a master token pull the sender.
-            this.sender = (this.masterToken != null) ? headerdata.getString(KEY_SENDER) : null;
+            this.sender = (this.masterToken != null && headerdata.has(KEY_SENDER)) ? headerdata.getString(KEY_SENDER) : null;
             this.recipient = (headerdata.has(KEY_RECIPIENT)) ? headerdata.getString(KEY_RECIPIENT) : null;
             this.timestamp = (headerdata.has(KEY_TIMESTAMP)) ? headerdata.getLong(KEY_TIMESTAMP) : null;
 

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -1264,7 +1264,7 @@
                 var keyResponseDataMo, userIdTokenMo, userAuthDataMo, tokensMa;
                 try {
                     // If the message was sent with a master token pull the sender.
-                    sender = (masterToken) ? headerdata.getString(KEY_SENDER) : null;
+                    sender = (masterToken && headerdata.has(KEY_SENDER)) ? headerdata.getString(KEY_SENDER) : null;
                     recipient = (headerdata.has(KEY_RECIPIENT)) ? headerdata.getString(KEY_RECIPIENT) : null;
                     timestamp = (headerdata.has(KEY_TIMESTAMP)) ? headerdata.getLong(KEY_TIMESTAMP) : null;
                 


### PR DESCRIPTION
Handle the case where the sender does not have an available identity. This is required for DRM-based entity auth schemes.