### PR TITLE
Allow missing sender identity

### DIFF
--- a/core/src/main/cpp/msg/MessageHeader.cpp
+++ b/core/src/main/cpp/msg/MessageHeader.cpp
@@ -408,7 +408,7 @@ MessageHeader::MessageHeader(shared_ptr<MslContext> ctx,
 
     try {
         // If the message was sent with a master token pull the sender.
-        sender = (masterToken) ? headerdata->getString(KEY_SENDER) : string();
+        sender = (masterToken && headerdata->has(KEY_SENDER)) ? headerdata->getString(KEY_SENDER) : string();
         recipient = (headerdata->has(KEY_RECIPIENT)) ? headerdata->getString(KEY_RECIPIENT) : string();
         timestamp = (headerdata->has(KEY_TIMESTAMP)) ? headerdata->getLong(KEY_TIMESTAMP) : -1;
 

--- a/core/src/main/cpp/util/GzipCompression.cpp
+++ b/core/src/main/cpp/util/GzipCompression.cpp
@@ -65,7 +65,7 @@ void compress_gzip(const vector<uint8_t>& in, vector<uint8_t>& out,
     // retrieve the compressed bytes blockwise
     do {
         zs.next_out = reinterpret_cast<Bytef*>(&tmpBuf[0]);
-        zs.avail_out = sizeof(uint8_t) * tmpBuf.size();
+        zs.avail_out = (uInt)(sizeof(uint8_t) * tmpBuf.size());
 
         ret = deflate(&zs, Z_FINISH);
 
@@ -104,7 +104,7 @@ void decompress_gzip(const vector<uint8_t>& in, vector<uint8_t>& out)
     // get the decompressed bytes blockwise using repeated calls to inflate
     do {
         zs.next_out = reinterpret_cast<Bytef*>(&tmpBuf[0]);
-        zs.avail_out = sizeof(uint8_t) * tmpBuf.size();
+        zs.avail_out = (uInt)(sizeof(uint8_t) * tmpBuf.size());
 
         ret = inflate(&zs, 0);
 

--- a/tests/src/test/cpp/crypto/RandomTest.cpp
+++ b/tests/src/test/cpp/crypto/RandomTest.cpp
@@ -112,7 +112,7 @@ TEST_F(RandomTest, nextIntRange)
     for (int i=0; i<NITERATIONS; ++i)
         values.insert(random->nextInt(rangeMax));
     EXPECT_LE(0, *values.begin());
-    EXPECT_GE(rangeMax-1, *values.rbegin());
+    EXPECT_GE(rangeMax-1, (unsigned)(*values.rbegin()));
 }
 
 TEST_F(RandomTest, nextLongRange)
@@ -123,7 +123,7 @@ TEST_F(RandomTest, nextLongRange)
     for (int i=0; i<NITERATIONS; ++i)
         values.insert(random->nextLong(rangeMax));
     EXPECT_LE(0, *values.begin());
-    EXPECT_GE(rangeMax-1, *values.rbegin());
+    EXPECT_GE(rangeMax-1, (unsigned)(*values.rbegin()));
 }
 
 }}} // namespace netflix::msl::crypto


### PR DESCRIPTION
Handle the case where the sender does not have an available identity. This is required for DRM-based entity auth schemes.