### PR TITLE
Add MslControl.send() function.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/ServerReceiveMessageContext.java
+++ b/core/src/main/java/com/netflix/msl/msg/ServerReceiveMessageContext.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.msg;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.keyx.KeyRequestData;
+import com.netflix.msl.tokens.MslUser;
+import com.netflix.msl.userauth.UserAuthenticationData;
+
+/**
+ * <p>A trusted services network message context used to receive client
+ * messages suitable for use with
+ * {@link MslControl#receive(com.netflix.msl.util.MslContext, MessageContext, java.io.InputStream, java.io.OutputStream, int)}.
+ * Since this message context is only used for receiving messages, it cannot be
+ * used to send application data back to the client and does not require
+ * encryption or integrity protection.</p>
+ * 
+ * <p>The application may wish to override
+ * {@link #updateServiceTokens(MessageServiceTokenBuilder, boolean)} to
+ * modify any service tokens sent in handshake responses.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class ServerReceiveMessageContext extends PublicMessageContext {
+    /**
+     * <p>Create a new receive message context.</p>
+     * 
+     * @param cryptoContexts service token crypto contexts. May be
+     *        {@code null}.
+     * @param dbgCtx optional message debug context. May be {@code null}.
+     */
+    public ServerReceiveMessageContext(final Map<String,ICryptoContext> cryptoContexts, final MessageDebugContext dbgCtx) {
+        this.cryptoContexts = (cryptoContexts != null) ? new HashMap<String,ICryptoContext>(cryptoContexts) : new HashMap<String,ICryptoContext>();
+        this.dbgCtx = dbgCtx;
+    }
+
+    @Override
+    public Map<String, ICryptoContext> getCryptoContexts() {
+        return Collections.unmodifiableMap(cryptoContexts);
+    }
+
+    @Override
+    public String getRecipient() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestingTokens() {
+        return false;
+    }
+
+    @Override
+    public String getUserId() {
+        return null;
+    }
+
+    @Override
+    public UserAuthenticationData getUserAuthData(final ReauthCode reauthCode, final boolean renewable, final boolean required) {
+        return null;
+    }
+
+    @Override
+    public MslUser getUser() {
+        return null;
+    }
+
+    @Override
+    public Set<KeyRequestData> getKeyRequestData() throws MslKeyExchangeException {
+        return Collections.emptySet();
+    }
+    
+    @Override
+    public void updateServiceTokens(final MessageServiceTokenBuilder builder, final boolean handshake) {
+    }
+
+    @Override
+    public void write(final MessageOutputStream output) throws IOException {
+    }
+
+    @Override
+    public MessageDebugContext getDebugContext() {
+        return dbgCtx;
+    }
+    
+    /** Service token crypto contexts. */
+    protected final Map<String,ICryptoContext> cryptoContexts;
+    /** Message debug context. */
+    protected final MessageDebugContext dbgCtx;
+}

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -406,6 +406,28 @@
             nextChunk(0);
         }
     });
+    
+    /**
+     * This message context is used to send messages that will not expect a
+     * response.
+     */
+    var SendMessageContext = FilterMessageContext.extend({
+        /**
+         * Creates a message context used to send messages that do not expect a
+         * response by ensuring that the message context conforms to those
+         * expectations.
+         * 
+         * @param {MessageContext} appCtx the application's message context.
+         */
+        init: function init(appCtx) {
+            init.base.call(this, appCtx);
+        },
+
+        /** @inheritDoc */
+        isRequestingTokens: function isRequestingTokens() {
+            return false;
+        },
+    });
 
     /**
      * This message context is used to send a handshake response.
@@ -503,6 +525,18 @@
         };
         Object.defineProperties(this, props);
     }
+    
+    /**
+     * Indicates response expectations for a specific request.
+     */
+    var Receive = {
+        /** A response is always expected. */
+        ALWAYS: 0,
+        /** A response is only expected if tokens are being renewed. */
+        RENEWING: 1,
+        /** A response is never expected. */
+        NEVER: 2
+    };
 
     /**
      * The result of sending and receiving messages.
@@ -1882,7 +1916,9 @@
          * @param {{builder: MessageBuilder, tokenTicket: ?TokenTicket}}
          *        builderTokenTicket request message builder and master token /
          *        lock ticket.
-         * @param {boolean} receive if a response is expected.
+         * @param {Receive} receive indicates if a response should always be expected, should
+         *        only be expected if the master token or user ID token will be
+         *        renewed, or should never be expected. 
          * @param {boolean} closeStreams true if the remote entity input and output streams
          *        must be closed when the constructed message input and output
          *        streams are closed.
@@ -1969,12 +2005,15 @@
                         result: function(sent) {
                             InterruptibleExecutor(callback, function sendrecv_receive() {
                                 // Receive the response if expected, if we sent a handshake request,
-                                // if key request data was included, or if a master token and user
+                                // or if we expect a response when renewing tokens and either key
+                                // request data was included or a master token and user
                                 // authentication data was included in a renewable message.
                                 var requestHeader = sent.request.getMessageHeader();
                                 var keyRequestData = requestHeader.keyRequestData;
-                                if (receive || sent.handshake || !keyRequestData.isEmpty() ||
-                                    (requestHeader.isRenewable() && requestHeader.masterToken && requestHeader.userAuthenticationData))
+                                if (receive == Receive.ALWAYS || sent.handshake ||
+                                    (receive == Receive.RENEWING &&
+                                     (!keyRequestData.isEmpty() ||
+                                      (requestHeader.isRenewable() && requestHeader.masterToken && requestHeader.userAuthenticationData))))
                                 {
                                     this.receive(service, ctx, msgCtx, input, requestHeader, timeout, {
                                         result: function(response) {
@@ -2474,17 +2513,133 @@
         shutdown: function shutdown() {
             this._shutdown = true;
         },
+        
+        /**
+         * <p>Use of this method is not recommended as it does not confirm delivery
+         * or acceptance of the message. Establishing a MSL channel to send
+         * application data without requiring the remote entity to acknowledge
+         * receipt in the response application data is the recommended approach.
+         * Only use this method if guaranteed receipt is not required.</p>
+         * 
+         * <p>This method has two acceptable parameter lists. Both forms should
+         * only be used by trusted network clients and peer-to-peer entities
+         * when no response is expected from the remote entity.</p>
+         * 
+         * <p>The first form accepts a remote entity URL and will send a
+         * message to the remote entity at the provided URL.</p>
+         * 
+         * @param {MslContext} ctx MSL context.
+         * @param {MessageContext} msgCtx message context.
+         * @param {Url} remoteEntity remote entity URL.
+         * @param {number} timeout connect, read, and renewal lock acquisition timeout in
+         *        milliseconds.
+         * @param {{result: function(MessageOutputStream), timeout: function(), error: function(Error)}}
+         *        callback the callback that will be used for the operation.
+         * @return {function()} a function which if called will cancel the
+         *         operation.
+         * 
+         * <p>The caller must close the returned message output stream.</p>
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts an InputStream and OutputStream and will
+         * send a message to the remote entity over the provided output
+         * stream.</p>
+         * 
+         * @param {MslContext} ctx MSL context.
+         * @param {MessageContext} msgCtx message context.
+         * @param {InputStream} in remote entity input stream.
+         * @param {OutputStream} out remote entity output stream.
+         * @param {number} timeout connect, read, and renewal lock acquisition timeout in
+         *        milliseconds.
+         * @param {{result: function(MessageOutputStream), timeout: function(), error: function(Error)}}
+         *        callback the callback that will be used for the operation.
+         * @return {function()} a function which if called will cancel the
+         *         operation.
+         *         
+         * <p>The caller must close the returned message output stream. The
+         * remote entity output stream will not be closed when the message
+         * output stream is closed, in case the caller wishes to reuse
+         * them.</p>
+         * 
+         * TODO once Java supports the WebSocket protocol we can remove this method
+         * in favor of the one accepting a URL parameter. (Or is it the other way
+         * around?)
+         * 
+         * <hr>
+         * 
+         * <p>In either case the remote entity should be using
+         * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
+         * and should not attempt to send a response.</p>
+         * 
+         * 
+         * <p>The returned {@code Future} will return a {@code MessageOutputStream}
+         * containing the final {@code MessageOutputStream} that should be used to
+         * send any additional application data not already sent via
+         * {@link MessageContext#write(MessageOutputStream)}.</p>
+         * 
+         * <p>The returned {@code Future} will return {@code null} if
+         * {@link #cancelled(Throwable) cancelled or interrupted}, if an error
+         * response was received resulting in a failure to send the message, or if
+         * the maximum number of messages is hit without sending the message.</p>
+         * 
+         * <p>The {@code Future} may throw an {@code ExecutionException} whose
+         * cause is a {@code MslException}, {@code IOException}, or
+         * {@code TimeoutException}.</p>
+         */
+        send: function send(ctx, msgCtx /* variable arguments */) {
+            if (this._shutdown)
+                throw new MslException('MslControl is shutdown.');
+            
+            var remoteEntity,
+                input,
+                output,
+                timeout,
+                callback;
+            
+            // Handle the first form.
+            if (arguments.length == 5) {
+                remoteEntity = arguments[2];
+                input = null;
+                output = null;
+                timeout = arguments[3];
+                callback = arguments[4];
+            }
+            
+            // Handle the second form.
+            else if (arguments.length == 6) {
+                remoteEntity = null;
+                input = arguments[2];
+                output = arguments[3];
+                timeout = arguments[4];
+                callback = arguments[5];
+            }
+            
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
+            var sendMsgCtx = new SendMessageContext(msgCtx);
+            var service = new SendService(this._impl, ctx, msgCtx, remoteEntity, input, output, timeout);
+            setTimeout(function() { service.call(callback); }, 0);
+            return CancellationFunction(service);
+        },
+        
+        // FIXME: need a push method for use by trusted network servers.
 
         /**
          * <p>Receive a request over the provided input stream.</p>
          *
          * <p>If there is an error with the message an error response will be sent
          * over the provided output stream.</p>
-         *
-         * <p>This method should only be used by trusted network servers and peer-
-         * to-peer entities to receive a request initiated by the remote entity.
-         * The remote entity should have used
-         * {@link #request(MslContext, MessageContext, Url, int)}.<p>
+         * 
+         * <p>This method should only be used to receive a request initiated by the
+         * remote entity. The remote entity should have used one of the request
+         * methods
+         * {@link #request(MslContext, MessageContext, Url, int)} or
+         * {@link #request(MslContext, MessageContext, InputStream, OutputStream, int)}
+         * or one of the send methods
+         * {@link #send(MslContext, MessageContext, Url, int)} or
+         * {@link #send(MslContext, MessageContext, InputStream, OutputStream, int)}.<p>
          *
          * <p>The returned {@code Future} will return the received
          * {@code MessageInputStream} on completion or {@code null} if a reply was
@@ -2523,12 +2678,13 @@
 
         /**
          * <p>Send a response over the provided output stream.</p>
-         *
+         * 
          * <p>This method should only be used by trusted network servers and peer-
          * to-peer entities after receiving a request via
          * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.
-         * The remote entity should have used
-         * {@link #request(MslContext, MessageContext, URL, int)}.</p>
+         * The remote entity should have used one of the request methods
+         * {@link #request(MslContext, MessageContext, Url, int)} or
+         * {@link #request(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
          *
          * <p>The returned {@code Future} will return a {@code MslChannel}
          * containing the final {@code MessageOutputStream} that should be used to
@@ -2647,7 +2803,7 @@
          *         down. This exception is not delivered to the callback.
          *
          * <p>The caller must close the returned message input stream and message
-         * outut stream.</p>
+         * output stream.</p>
          *
          * <hr>
          *
@@ -2742,7 +2898,7 @@
             // Malformed arguments are not explicitly handled, just as with any
             // other function.
 
-            var service = new RequestService(this._impl, ctx, msgCtx, remoteEntity, input, output, null, 0, timeout);
+            var service = new RequestService(this._impl, ctx, msgCtx, remoteEntity, input, output, null, Receive.ALWAYS, 0, timeout);
             setTimeout(function() { service.call(callback); }, 0);
             return CancellationFunction(service);
         }
@@ -2806,6 +2962,58 @@
             error: callback.error,
         });
     }
+    
+    /**
+     * <p>This service sends a message to a remote entity.</p>
+     *
+     * <p>This class is only used from trusted network clients and peer-to-peer
+     * entities.</p>
+     */
+    var SendService = Class.create({
+        /**
+         * Create a new message send service.
+         *
+         * @param {MslControlImpl} ctrl parent MSL control.
+         * @param {MslContext} ctx MSL context.
+         * @param {MessageContext} msgCtx message context.
+         * @param {?Url} remoteEntity remote entity URL.
+         * @param {?InputStream} input remote entity input stream.
+         * @param {?OutputStream} output remote entity output stream.
+         * @param {number} timeout connect, read/write, and renewal lock
+         *        acquisition timeout in milliseconds.
+         */
+        init: function init(ctrl, ctx, msgCtx, remoteEntity, input, output, timeout) {
+            var requestService = new RequestService(ctrl, ctx, msgCtx, remoteEntity, input, output, null, Receive.NEVER, 0, timeout);
+            
+            // The properties.
+            var props = {
+                _requestService: { value: requestService, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+
+        /**
+         * @param {{result: function(MessageOutputStream), timeout: function(), error: function(Error)}}
+         *        callback the callback will be given the established message
+         *        output stream or {@code null} if cancelled or interrupted;
+         *        notified of timeout or any thrown exceptions.
+         * @throws MslException if there was an error creating or processing
+         *         a message.
+         * @throws IOException if there was an error reading or writing a
+         *         message.
+         */
+        call: function call(callback){
+            this._requestService.call({
+                result: function(channel) {
+                    AsyncExecutor(callback, function() {
+                        return (channel) ? channel.output : null;
+                    });
+                },
+                timeout: callback.timeout,
+                error: callback.error,
+            });
+        },
+    });
 
     /**
      * <p>This service receives a request from a remote entity, and either
@@ -3432,7 +3640,7 @@
                 // This adds two to our message count.
                 //
                 // This will release the master token lock.
-                this._ctrl.sendReceive(this._ctx, msgCtx, this._input, this._output, builderTokenTicket, false, false, this._timeout, {
+                this._ctrl.sendReceive(this._ctx, msgCtx, this._input, this._output, builderTokenTicket, Receive.RENEWING, false, this._timeout, {
                     result: function(result) {
                         InterruptibleExecutor(callback, function() {
                             var response = result.response;
@@ -3894,12 +4102,13 @@
          * @param {?InputStream} input remote entity input stream.
          * @param {?OutputStream} output remote entity output stream.
          * @param {?{builder: MessageBuilder, tokenTicket: ?TokenTicket}} builderTokenTicket request message builder.
+         * @param {Receive} expectResponse response expectation.
          * @param {number} msgCount number of messages that have already been
          *        sent or received.
          * @param {number} timeout connect, read/write, and renewal lock
          *        acquisition timeout in milliseconds.
          */
-        init: function init(ctrl, ctx, msgCtx, remoteEntity, input, output, builderTokenTicket, msgCount, timeout) {
+        init: function init(ctrl, ctx, msgCtx, remoteEntity, input, output, builderTokenTicket, expectResponse, msgCount, timeout) {
             var builder, tokenTicket;
             if (builderTokenTicket) {
                 builder = builderTokenTicket.builder;
@@ -3920,6 +4129,7 @@
                 _openedStreams: { value: false, writable: true, enumerable: false, configurable: false },
                 _builder: { value: builder, writable: true, enumerable: false, configurable: false },
                 _tokenTicket: { value: tokenTicket, writable: true, enumerable: false, configurable: false },
+                _expectResponse: { value: expectResponse, writable: false, enumerable: false, configurable: false },
                 _timeout: { value: timeout, writable: false, enumerable: false, configurable: false },
                 _msgCount: { value: msgCount, writable: false, enumerable: false, configurable: false },
                 _maxMessagesHit: { value: false, writable: true, enumerable: false, configurable: false },
@@ -3980,7 +4190,7 @@
          */
         execute: function execute(msgCtx, builderTokenTicket, timeout, msgCount, callback) {
             var self = this;
-
+            
             InterruptibleExecutor(callback, function() {
                 // Do not do anything if cannot send and receive two more messages.
                 //
@@ -3996,26 +4206,31 @@
                 // message count.
                 //
                 // This will release the master token lock.
-                this._ctrl.sendReceive(this, this._ctx, msgCtx, this._input, this._output, builderTokenTicket, true, this._openedStreams, timeout, {
+                this._ctrl.sendReceive(this, this._ctx, msgCtx, this._input, this._output, builderTokenTicket, this._expectResponse, this._openedStreams, timeout, {
                     result: function(result) {
                         InterruptibleExecutor(callback, function() {
                             if (!result)
                                 return null;
+                            var request = result.request;
                             var response = result.response;
                             msgCount += 2;
 
+                            // If we did not receive a response then we're done. Return the
+                            // new message output stream.
+                            if (!response)
+                                return new MslChannel(response, request);
+                            
                             // If the response is an error see if we can handle the error and
                             // retry.
                             var responseHeader = response.getMessageHeader();
-                            if (!responseHeader) {
+                            if (!responseHeader)
                                 prepareError(result);
-                            } else {
+                            else
                                 processResponse(result);
-                            }
                         }, self);
                     },
-                    timeout: function() { callback.timeout(); },
-                    error: function(e) { callback.error(e); }
+                    timeout: callback.timeout,
+                    error: callback.error,
                 });
             }, self);
 
@@ -4120,7 +4335,7 @@
                                 if (!this._ctx.isPeerToPeer()) {
                                     // The master token lock acquired from buildErrorResponse()
                                     // will be released when the service executes.
-                                    var service = new RequestService(this._ctrl, this._ctx, resendMsgCtx, this._remoteEntity, null, null, builderTokenTicket, msgCount, this._timeout);
+                                    var service = new RequestService(this._ctrl, this._ctx, resendMsgCtx, this._remoteEntity, null, null, builderTokenTicket, this._expectResponse, msgCount, this._timeout);
                                     // Set the abort function to abort the new service before executing
                                     // the service.
                                     this.setAbort(function() { service.abort(); });
@@ -4218,7 +4433,7 @@
                                 this._ctrl.buildResponse(this, this._ctx, msgCtx, responseHeader, timeout, {
                                     result: function(builderTokenTicket) {
                                         InterruptibleExecutor(callback, function() {
-                                            var service = new RequestService(this._ctrl, this._ctx, resendMsgCtx, this._remoteEntity, null, null, builderTokenTicket, msgCount, this._timeout);
+                                            var service = new RequestService(this._ctrl, this._ctx, resendMsgCtx, this._remoteEntity, null, null, builderTokenTicket, this._expectResponse, msgCount, this._timeout);
                                             // Set the abort function to abort the new service before executing
                                             // the service.
                                             this.setAbort(function() { service.abort(); });
@@ -4393,7 +4608,7 @@
         },
 
         /**
-         * @param {{result: function(MessageInputStream), timeout: function(), error: function(Error)}}
+         * @param {{result: function(MslChannel), timeout: function(), error: function(Error)}}
          *        callback the callback will be given the established MSL
          *        channel or {@code null} if cancelled or interrupted; notified
          *        of timeout or any thrown exceptions.
@@ -4404,7 +4619,7 @@
          */
         call: function call(callback) {
             var self = this;
-
+            
             InterruptibleExecutor(callback, function() {
                 // If we do not already have a connection then establish one.
                 var lockTimeout = this._timeout;
@@ -4494,6 +4709,15 @@
                                 // If the channel was established clear the cached payloads.
                                 if (channel && channel.output)
                                     channel.output.stopCaching();
+                                
+                                // Close the input stream if we opened it and there is no
+                                // response. This may be necessary to transmit data
+                                // buffered in the output stream, and the caller will not
+                                // be given a message input stream by which to close it.
+                                //
+                                // We don't care about an I/O exception on close.
+                                if (this._openedStreams && (!channel || !channel.input))
+                                    this._input.close(lockTimeout, NULL_CLOSE_HANDLER);
 
                                 // Return the established channel.
                                 return channel;

--- a/core/src/main/javascript/msg/ServerReceiveMessageContext.js
+++ b/core/src/main/javascript/msg/ServerReceiveMessageContext.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>A trusted services network message context used to receive client
+ * messages suitable for use with
+ * {@link MslControl#receive(com.netflix.msl.util.MslContext, MessageContext, java.io.InputStream, java.io.OutputStream, int)}.
+ * Since this message context is only used for receiving messages, it cannot be
+ * used to send application data back to the client and does not require
+ * encryption or integrity protection.</p>
+ * 
+ * <p>The application may wish to override
+ * {@link #updateServiceTokens(MessageServiceTokenBuilder, boolean)} to
+ * modify any service tokens sent in handshake responses.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+(function(require, module) {
+    "use strict";
+    
+    var PublicMessageContext = require('../msg/PublicMessageContext.js');
+    
+    var ServerReceiveMessageContext = module.exports = PublicMessageContext.extend({
+        /**
+         * <p>Create a new receive message context.</p>
+         * 
+         * @param {Object<string,ICryptoContext>} cryptoContexts service token crypto contexts. May be
+         *        {@code null}.
+         * @param {MessageDebugContext} dbgCtx optional message debug context. May be {@code null}.
+         */
+        init: function init(cryptoContexts, dbgCtx) {
+            init.base.call(this);
+            
+            // Make a shallow copy of the crypto contexts.
+            var contexts = {};
+            if (cryptoContexts) {
+                for (var name in cryptoContexts)
+                    contexts[name] = cryptoContexts[name];
+            }
+            
+            // The properties.
+            var props = {
+                cryptoContexts: { value: contexts, writable: true, enumerable: false, configurable: false },
+                dbgCtx: { value: dbgCtx, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+
+        /** @inheritDoc */
+        getCryptoContexts: function getCryptoContexts() {
+            return {};
+        },
+
+        /** @inheritDoc */
+        getRecipient: function getRecipient() {
+            return null;
+        },
+
+        /** @inheritDoc */
+        isRequestingTokens: function isRequestingTokens() {
+            return false;
+        },
+
+        /** @inheritDoc */
+        getUserId: function getUserId() {
+            return null;
+        },
+
+        /** @inheritDoc */
+        getUserAuthData: function getUserAuthData(reauthCode, renewable, required, callback) {
+            callback.result(null);
+        },
+
+        /** @inheritDoc */
+        getUser: function getUser() {
+            return null;
+        },
+
+        /** @inheritDoc */
+        getKeyRequestData: function getKeyRequestData(callback) {
+            callback.result([]);
+        },
+        
+        /** @inheritDoc */
+        updateServiceTokens: function updateServiceTokens(builder, handshake, callback) {
+            callback.result(true);
+        },
+
+        /** @inheritDoc */
+        write: function write(output, timeout, callback) {
+            callback.result(true);
+        },
+
+        /** @inheritDoc */
+        getDebugContext: function getDebugContext() {
+            return this.dbgCtx;
+        },
+    });
+})(require, (typeof module !== 'undefined') ? module : mkmodule('ServerReceiveMessageContext'));

--- a/integ-tests/src/main/java/com/netflix/msl/server/common/ReceiveServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/common/ReceiveServlet.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MessageDebugContext;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.ServerReceiveMessageContext;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.userauth.UserAuthenticationScheme;
+
+/**
+ * <p>A servlet that accepts POST requests but does not send a response.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public abstract class ReceiveServlet extends BaseServlet {
+    private static final long serialVersionUID = 849604555205123832L;
+
+    /**
+     * @param entityAuthScheme server entity authentication scheme.
+     * @param type server token factory type.
+     * @param seqno initial master token sequence number.
+     * @param unsupportedEntityAuthSchemes unsupported entity authentication
+     *        schemes. May be {@code null}.
+     * @param unsupportedUserAuthSchemes unsupported user authentication
+     *        schemes. May be {@code null}.
+     * @param unsupportedKeyxSchemes unsupported key exchange schemes. May be
+     *        {@code null}.
+     * @param cryptoContexts service token crypto contexts.
+     * @param dbgCtx optional message debug context. May be {@code null}.
+     * @param nullCryptoContext true if the server MSL crypto context should
+     *        not perform encryption or integrity protection.
+     * @param console true message data should be written out to the console.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public ReceiveServlet(final EntityAuthenticationScheme entityAuthScheme, final TokenFactoryType type,
+        final long seqno,
+        final List<EntityAuthenticationScheme> unsupportedEntityAuthSchemes,
+        final List<UserAuthenticationScheme> unsupportedUserAuthSchemes,
+        final List<KeyExchangeScheme> unsupportedKeyxSchemes,
+        final Map<String,ICryptoContext> cryptoContexts, final MessageDebugContext dbgCtx,
+        final boolean nullCryptoContext, final boolean console) throws Exception
+    {
+        super(0, entityAuthScheme, type, seqno, unsupportedEntityAuthSchemes, unsupportedUserAuthSchemes, unsupportedKeyxSchemes, nullCryptoContext, console);
+        msgCtx = new ServerReceiveMessageContext(cryptoContexts, dbgCtx);
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        final InputStream in = req.getInputStream();
+        final OutputStream out = resp.getOutputStream();
+        
+        // Receive the message.
+        final Future<MessageInputStream> future = mslCtrl.receive(mslCtx, msgCtx, in, out, TIMEOUT);
+        final MessageInputStream mis;
+        try {
+            mis = future.get();
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            if (debug) e.printStackTrace(System.out);
+            return;
+        }
+        
+        // If the message input stream is null, clean up and return.
+        if (mis == null) {
+            try { in.close(); } catch (final IOException e) {}
+            try { out.close(); } catch (final IOException e) {}
+            return;
+        }
+        
+        // Deliver the message input stream for processing.
+        receive(mis);
+        
+        // Clean up.
+        try { in.close(); } catch (final IOException e) {}
+        try { out.close(); } catch (final IOException e) {}
+    }
+    
+    /**
+     * Called when a message input stream is received for further processing.
+     * 
+     * @param mis the message input stream.
+     */
+    protected abstract void receive(final MessageInputStream mis);
+    
+    /** Message context. */
+    protected MessageContext msgCtx;
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/common/RespondServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/common/RespondServlet.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslConstants;
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.server.configuration.msg.ServerMessageContext;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.userauth.UserAuthenticationScheme;
+
+/**
+ * <p>A servlet that accepts POST requests in order to send a response.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class RespondServlet extends BaseServlet {
+    private static final long serialVersionUID = -167726318549015539L;
+    
+    protected static final String payload = "Hello";
+    protected static final String error = "Error";
+    
+    /**
+     * @param numThreads
+     * @param entityAuthScheme
+     * @param tokenFactoryType
+     * @param initialSequenceNum
+     * @param isMessageEncrypted
+     * @param isIntegrityProtected
+     * @param unSupportedEntityAuthFactories
+     * @param unSupportedUserAuthFactories
+     * @param unSupportedKeyxFactories
+     * @param isNullCryptoContext
+     * @param setConsoleFilterStreamFactory
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data.
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws Exception if there is an error configuring the servlet.
+     */
+    public RespondServlet(final int numThreads, final EntityAuthenticationScheme entityAuthScheme, final TokenFactoryType tokenFactoryType,
+        final long initialSequenceNum, final boolean isMessageEncrypted, final boolean isIntegrityProtected,
+        final List<EntityAuthenticationScheme> unSupportedEntityAuthFactories,
+        final List<UserAuthenticationScheme> unSupportedUserAuthFactories,
+        final List<KeyExchangeScheme> unSupportedKeyxFactories,
+        final boolean isNullCryptoContext, final boolean setConsoleFilterStreamFactory) throws Exception
+    {
+        super(numThreads, entityAuthScheme, tokenFactoryType, initialSequenceNum,
+            unSupportedEntityAuthFactories, unSupportedUserAuthFactories, unSupportedKeyxFactories,
+            isNullCryptoContext, setConsoleFilterStreamFactory);
+        this.encrypted = isMessageEncrypted;
+        this.integrityProtected = isIntegrityProtected;
+    }
+    
+    /**
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data.
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws Exception if there is an error configuring the servlet.
+     */
+    @Override
+    protected void configure() throws Exception {
+        super.configure();
+        
+        /**
+         * Message Context Configuration
+         */
+        msgCtx = new ServerMessageContext(mslCtx, payload.getBytes(MslConstants.DEFAULT_CHARSET), encrypted);
+        msgCtx.setIntegrityProtected(integrityProtected);
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        final InputStream inStream = request.getInputStream();
+        final OutputStream outStream = response.getOutputStream();
+        InputStream mslInputStream = null;
+
+        final byte[] buffer = new byte[5];
+
+        try {
+            final Future<MessageInputStream> msgInputStream = mslCtrl.receive(mslCtx, msgCtx, inStream, outStream, TIMEOUT);
+
+            mslInputStream = msgInputStream.get();
+            if (mslInputStream == null) return;
+
+            do {
+                final int bytesRead = mslInputStream.read(buffer);
+                if (bytesRead == -1) break;
+            } while (true);
+
+            //Checking the the received payload is the same as the one the client sent
+            if (!Arrays.equals(payload.getBytes(MslConstants.DEFAULT_CHARSET), buffer)) {
+                msgCtx.setBuffer(error.getBytes(MslConstants.DEFAULT_CHARSET));
+                mslCtrl.respond(mslCtx, msgCtx, inStream, outStream, msgInputStream.get(), TIMEOUT);
+                throw new IllegalStateException("PayloadBytes is not as expected: " + Arrays.toString(buffer));
+            }
+            msgCtx.setBuffer(buffer);
+            mslCtrl.respond(mslCtx, msgCtx, inStream, outStream, msgInputStream.get(), TIMEOUT);
+
+        } catch (final Exception ex) {
+            if (debug)
+                ex.printStackTrace(System.out);
+        } finally {
+            if (mslInputStream != null) {
+                mslInputStream.close();
+            }
+        }
+    }
+    
+    @Override
+    protected void setPrivateVariable(final PrintWriter out, final String key, final String[] values) throws Exception {
+        if (key.equals("encrypted")) {
+            this.encrypted = Boolean.parseBoolean(values[0]);
+            out.println(key + ": " + values[0]);
+        } else if (key.equals("intProtected")) {
+            this.integrityProtected = Boolean.parseBoolean(values[0]);
+            out.println(key + ": " + values[0]);
+        } else {
+            super.setPrivateVariable(out, key, values);
+        }
+    }
+    
+    /** Message context. */
+    protected ServerMessageContext msgCtx;
+    /** Application data encrypted. */
+    protected boolean encrypted;
+    /** Application data integrity protected. */
+    protected boolean integrityProtected;
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/configuration/msg/ServerMessageContext.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/configuration/msg/ServerMessageContext.java
@@ -15,18 +15,17 @@
  */
 package com.netflix.msl.server.configuration.msg;
 
-import com.netflix.msl.MslCryptoException;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashSet;
+
 import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.keyx.KeyRequestData;
 import com.netflix.msl.msg.MessageOutputStream;
 import com.netflix.msl.msg.MockMessageContext;
 import com.netflix.msl.server.configuration.util.ServerMslContext;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
-
-import java.io.IOException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
-import java.util.HashSet;
 
 /**
  * User: skommidi
@@ -38,8 +37,18 @@ public class ServerMessageContext extends MockMessageContext {
 
     /**
      * Create a new test message context.
+     * 
+     * @param mslCtx MSL context.
+     * @param payloadBytes application data to write.
+     * @param messageEncrypted true if the message must be encrypted.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
      */
-    public ServerMessageContext(ServerMslContext mslCtx, byte[] payloadBytes, boolean messageEncrypted) throws MslCryptoException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public ServerMessageContext(final ServerMslContext mslCtx, final byte[] payloadBytes, final boolean messageEncrypted) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, MslKeyExchangeException {
         super(mslCtx, null, UserAuthenticationScheme.EMAIL_PASSWORD);
         super.setUserAuthData(null);
         super.setKeyRequestData(new HashSet<KeyRequestData>());
@@ -47,10 +56,11 @@ public class ServerMessageContext extends MockMessageContext {
         this.buffer = payloadBytes;
     }
 
-    public void setBuffer(byte[] buffer) {
+    public void setBuffer(final byte[] buffer) {
         this.buffer = buffer;
     }
 
+    @Override
     public void write(final MessageOutputStream output) throws IOException {
         output.write(buffer);
         output.flush();

--- a/integ-tests/src/main/java/com/netflix/msl/server/configuration/util/ServerMslContext.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/configuration/util/ServerMslContext.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.msl.server.configuration.util;
 
+import java.util.List;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.crypto.NullCryptoContext;
@@ -26,8 +28,6 @@ import com.netflix.msl.tokens.MockTokenFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
 import com.netflix.msl.util.MockMslContext;
 
-import java.util.List;
-
 /**
  * User: skommidi
  * Date: 7/21/14
@@ -35,6 +35,11 @@ import java.util.List;
 public class ServerMslContext extends MockMslContext {
     /**
      * Create a new Server MSL context.
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data.
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
      */
     public ServerMslContext(final EntityAuthenticationScheme entityAuthScheme, final boolean peerToPeer,
                             final TokenFactoryType tokenFactoryType, final long initialSequenceNum,
@@ -44,7 +49,7 @@ public class ServerMslContext extends MockMslContext {
                             final boolean isNullCryptoContext) throws MslEncodingException, MslCryptoException {
         super(entityAuthScheme, peerToPeer);
         //Set Server TokenFactory with initialSequenceNumber
-        MockTokenFactory tokenFactory = new ServerTokenFactory(tokenFactoryType);
+        final MockTokenFactory tokenFactory = new ServerTokenFactory(tokenFactoryType);
         tokenFactory.setNewestMasterToken(initialSequenceNum);
         super.setTokenFactory(tokenFactory);
 
@@ -53,17 +58,17 @@ public class ServerMslContext extends MockMslContext {
         }
 
         if (unSupportedEntityAuthFactories != null) {
-            for (EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
+            for (final EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
                 super.removeEntityAuthenticationFactory(scheme);
             }
         }
         if (unSupportedUserAuthFactories != null) {
-            for (UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
+            for (final UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
                 super.removeUserAuthenticationFactory(scheme);
             }
         }
         if (unSupportedKeyxFactories != null) {
-            for (KeyExchangeScheme scheme : unSupportedKeyxFactories) {
+            for (final KeyExchangeScheme scheme : unSupportedKeyxFactories) {
                 super.removeKeyExchangeFactories(scheme);
             }
         }

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/EchoServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/EchoServlet.java
@@ -15,40 +15,35 @@
  */
 package com.netflix.msl.server.servlet;
 
-import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEncodingException;
-import com.netflix.msl.MslKeyExchangeException;
-import com.netflix.msl.entityauth.EntityAuthenticationScheme;
-import com.netflix.msl.server.common.BaseServlet;
-import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
+
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.server.common.RespondServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
 
 /**
  * User: skommidi
  * Date: 7/24/14
  */
-public class EchoServlet extends BaseServlet {
-
-    private static final long serialVersionUID = 1L;
-
+public class EchoServlet extends RespondServlet {
+    private static final long serialVersionUID = 3781170196441547122L;
+    
     private static final long SEQUENCE_NUMBER = 8L;
     private static final int NUM_THREADS = 0;
 
-    public EchoServlet() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public EchoServlet() throws Exception {
         super(NUM_THREADS, EntityAuthenticationScheme.NONE, TokenFactoryType.NOT_ACCEPT_NON_REPLAYABLE_ID,
                 SEQUENCE_NUMBER, false, false, null, null, null, false, false);
         System.out.println("======================>> Echo Servlet Initialization Ended <<======================");
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        final PrintWriter out = response.getWriter();
         //Doing raw output of request
         out.println("<<<<Start>>>>\n" + getBody(request) + "\n<<<<End>>>>");
         out.close();

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/LogServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/LogServlet.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.servlet;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Writer;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.msg.MessageHeader;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.server.common.ReceiveServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+
+/**
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class LogServlet extends ReceiveServlet {
+    private static final long serialVersionUID = 1030383316461016611L;
+    
+    /** Report the log message query string. */
+    public static final String REPORT = "report";
+    
+    /** Most recently received log message. */
+    private static String message = "";
+    
+    /**
+     * <p>Create a new log servlet that will log any received application data
+     * to stdout.</p>
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public LogServlet() throws Exception {
+        super(EntityAuthenticationScheme.RSA, TokenFactoryType.ACCEPT_NON_REPLAYABLE_ID, 0,
+            null, null, null, null, null, false, false);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.server.common.BaseServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        final String query = request.getQueryString();
+        if (REPORT.equals(query)) {
+            response.setContentType("text/plain");
+            final Writer out = response.getWriter();
+            out.write(message);
+            out.close();
+        } else {
+            super.doGet(request, response);
+        }
+    }
+
+    @Override
+    protected void receive(final MessageInputStream mis) {
+        // Ignore error messages.
+        final MessageHeader header = mis.getMessageHeader();
+        if (header == null) return;
+        
+        try {
+            // Log the application data.
+            final InputStreamReader reader = new InputStreamReader(mis);
+            final StringBuffer sb = new StringBuffer();
+            final char[] buffer = new char[1 << 16];
+            while (true) {
+                final int count = reader.read(buffer);
+                if (count == -1) break;
+                sb.append(buffer, 0, count);
+            }
+            message = sb.toString();
+            System.out.println("LOG: [" + message + "]");
+        } catch (final IOException e) {
+            if (debug) e.printStackTrace(System.out);
+        } finally {
+            if (mis != null)
+                try { mis.close(); } catch (final IOException e) {}
+        }
+    }
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/NullServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/NullServlet.java
@@ -15,28 +15,21 @@
  */
 package com.netflix.msl.server.servlet;
 
-import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEncodingException;
-import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
-import com.netflix.msl.server.common.BaseServlet;
+import com.netflix.msl.server.common.RespondServlet;
 import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
-
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * User: skommidi
  * Date: 8/27/14
  */
-public class NullServlet extends BaseServlet {
-
-    private static final long serialVersionUID = 1L;
-
+public class NullServlet extends RespondServlet {
+    private static final long serialVersionUID = -2879936348232394823L;
+    
     private static final long SEQUENCE_NUMBER = 8L;
     private static final int NUM_THREADS = 0;
 
-    public NullServlet() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public NullServlet() throws Exception {
         super(NUM_THREADS, EntityAuthenticationScheme.NONE, TokenFactoryType.NOT_ACCEPT_NON_REPLAYABLE_ID,
                 SEQUENCE_NUMBER, false, false, null, null, null, true, true);
         System.out.println("======================>> Null Servlet Initialization Ended <<======================");

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/TestServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/TestServlet.java
@@ -15,28 +15,21 @@
  */
 package com.netflix.msl.server.servlet;
 
-import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEncodingException;
-import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
-import com.netflix.msl.server.common.BaseServlet;
+import com.netflix.msl.server.common.RespondServlet;
 import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
-
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * User: skommidi
  * Date: 7/21/14
  */
-public class TestServlet extends BaseServlet {
-
-    private static final long serialVersionUID = 1L;
-
+public class TestServlet extends RespondServlet {
+    private static final long serialVersionUID = 3747351784182184977L;
+    
     private static final long SEQUENCE_NUMBER = 8L;
     private static final int NUM_THREADS = 0;
 
-    public TestServlet() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public TestServlet() throws Exception {
         super(NUM_THREADS, EntityAuthenticationScheme.NONE, TokenFactoryType.NOT_ACCEPT_NON_REPLAYABLE_ID,
                 SEQUENCE_NUMBER, false, false, null, null, null, false, false);
         System.out.println("======================>> Test Servlet Initialization Ended <<======================");

--- a/integ-tests/src/main/webapp/WEB-INF/web.xml
+++ b/integ-tests/src/main/webapp/WEB-INF/web.xml
@@ -31,4 +31,13 @@
         <servlet-name>EchoServlet</servlet-name>
         <url-pattern>/echo</url-pattern>
     </servlet-mapping>
+    
+    <servlet>
+        <servlet-name>LogServlet</servlet-name>
+        <servlet-class>com.netflix.msl.server.servlet.LogServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>LogServlet</servlet-name>
+        <url-pattern>/log</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
@@ -25,19 +25,19 @@ import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.client.configuration.entityauth.TestEccAuthenticationFactory;
 import com.netflix.msl.client.configuration.entityauth.TestPresharedAuthenticationFactory;
 import com.netflix.msl.client.configuration.entityauth.TestRsaAuthenticationFactory;
-import com.netflix.msl.client.configuration.entityauth.TestEccAuthenticationFactory;
 import com.netflix.msl.client.configuration.entityauth.TestX509AuthenticationFactory;
 import com.netflix.msl.client.configuration.msg.ClientMessageContext;
 import com.netflix.msl.client.configuration.msg.InvalidUserAuthScheme;
 import com.netflix.msl.client.configuration.util.ClientMslContext;
+import com.netflix.msl.entityauth.EccAuthenticationData;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.entityauth.EntityAuthenticationFactory;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.entityauth.PresharedAuthenticationData;
 import com.netflix.msl.entityauth.RsaAuthenticationData;
-import com.netflix.msl.entityauth.EccAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationFactory;
 import com.netflix.msl.entityauth.X509AuthenticationData;
@@ -68,7 +68,7 @@ public class ClientConfiguration {
     private String scheme = "http";
     private String remoteHost = "localhost";
     private String path = "";
-    private static final String USER_ID = "userid";
+    private String userId = null;
     private boolean isPeerToPeer = false;
     private EntityAuthenticationScheme entityAuthenticationScheme = EntityAuthenticationScheme.PSK;
     private UserAuthenticationScheme userAuthenticationScheme = UserAuthenticationScheme.EMAIL_PASSWORD;
@@ -86,31 +86,36 @@ public class ClientConfiguration {
     private boolean isIntegrityProtected = true;
     private boolean clearKeyRequestData = false;
 
-    public ClientConfiguration setEntityAuthenticationScheme(EntityAuthenticationScheme scheme) {
+    public ClientConfiguration setEntityAuthenticationScheme(final EntityAuthenticationScheme scheme) {
         entityAuthenticationScheme = scheme;
         return this;
     }
 
 
 
-    public ClientConfiguration setUserAuthenticationScheme(UserAuthenticationScheme scheme) {
+    public ClientConfiguration setUserAuthenticationScheme(final UserAuthenticationScheme scheme) {
         userAuthenticationScheme = scheme;
+        return this;
+    }
+    
+    public ClientConfiguration setUserId(final String userId) {
+        this.userId = userId;
         return this;
     }
 
 
-    public ClientConfiguration setIsMessageEncrypted(boolean messageEncrypted) {
+    public ClientConfiguration setIsMessageEncrypted(final boolean messageEncrypted) {
         this.isMessageEncrypted = messageEncrypted;
         return this;
     }
 
 
-    public ClientConfiguration setIsIntegrityProtected(boolean integrityProtected) {
+    public ClientConfiguration setIsIntegrityProtected(final boolean integrityProtected) {
         this.isIntegrityProtected = integrityProtected;
         return this;
     }
 
-    public ClientConfiguration setKeyRequestData(KeyExchangeScheme scheme) {
+    public ClientConfiguration setKeyRequestData(final KeyExchangeScheme scheme) {
         keyExchangeScheme = scheme;
         return this;
     }
@@ -123,12 +128,12 @@ public class ClientConfiguration {
         return this;
     }
 
-    public ClientConfiguration setInvalidUserAuthData(InvalidUserAuthScheme scheme) {
+    public ClientConfiguration setInvalidUserAuthData(final InvalidUserAuthScheme scheme) {
         setInvalidUserAuthData = scheme;
         return this;
     }
 
-    public ClientConfiguration setMaxEntityAuthRetryCount(int value) {
+    public ClientConfiguration setMaxEntityAuthRetryCount(final int value) {
         this.entityAuthRetryCount = value;
         return this;
     }
@@ -139,7 +144,7 @@ public class ClientConfiguration {
         return this;
     }
 
-    public ClientConfiguration setMaxUserAuthRetryCount(int value) {
+    public ClientConfiguration setMaxUserAuthRetryCount(final int value) {
         this.userAuthRetryCount = value;
         return this;
     }
@@ -149,32 +154,32 @@ public class ClientConfiguration {
         return this;
     }
 
-    public ClientConfiguration setScheme(String scheme) {
+    public ClientConfiguration setScheme(final String scheme) {
         this.scheme = scheme;
         return this;
     }
 
-    public ClientConfiguration setHost(String remoteHost) {
+    public ClientConfiguration setHost(final String remoteHost) {
         this.remoteHost = remoteHost;
         return this;
     }
 
-    public ClientConfiguration setPath(String path) {
+    public ClientConfiguration setPath(final String path) {
         this.path = path;
         return this;
     }
 
-    public ClientConfiguration setIsPeerToPeer(boolean isPeerToPeer) {
+    public ClientConfiguration setIsPeerToPeer(final boolean isPeerToPeer) {
         this.isPeerToPeer = isPeerToPeer;
         return this;
     }
 
-    public ClientConfiguration setMessageNonReplayable(boolean nonReplayable) {
+    public ClientConfiguration setMessageNonReplayable(final boolean nonReplayable) {
         this.nonReplayable = nonReplayable;
         return this;
     }
 
-    public ClientConfiguration setIsNullCryptoContext(boolean isNullCryptoContext) {
+    public ClientConfiguration setIsNullCryptoContext(final boolean isNullCryptoContext) {
         this.isNullCryptoContext = isNullCryptoContext;
         return this;
     }
@@ -230,7 +235,7 @@ public class ClientConfiguration {
         }
 
         /** create message context and configure */
-        messageContext = new ClientMessageContext(mslContext, USER_ID, userAuthenticationScheme, isMessageEncrypted, isIntegrityProtected);
+        messageContext = new ClientMessageContext(mslContext, userId, userAuthenticationScheme, isMessageEncrypted, isIntegrityProtected);
         messageContext.resetKeyRequestData(keyExchangeScheme);
         if(this.clearKeyRequestData) {
             messageContext.clearKeyRequestData();
@@ -273,7 +278,7 @@ public class ClientConfiguration {
         }
     }
 
-    public ClientConfiguration setNumThreads(int numThreads) {
+    public ClientConfiguration setNumThreads(final int numThreads) {
         mslControl = new MslControl(numThreads);
         //mslControl.setFilterFactory(new TestConsoleFilterStreamFactory());
         return this;

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/ServerConfiguration.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/ServerConfiguration.java
@@ -36,7 +36,7 @@ import com.netflix.msl.userauth.UserAuthenticationScheme;
  */
 public class ServerConfiguration {
     private static class NameValuePair {
-        public NameValuePair(String name, String value) {
+        public NameValuePair(final String name, final String value) {
             try {
                 this.name = URLEncoder.encode(name, "UTF-8");
                 this.value = URLEncoder.encode(value, "UTF-8");
@@ -49,7 +49,7 @@ public class ServerConfiguration {
         private final String value;
     }
     
-    private String scheme = "http";
+    private final String scheme = "http";
     private String path;
     private String host;
     private int numThreads;
@@ -63,7 +63,7 @@ public class ServerConfiguration {
     private List<EntityAuthenticationScheme> unSupportedEntityAuthFactories;
     private List<UserAuthenticationScheme> unSupportedUserAuthFactories;
     private List<KeyExchangeScheme> unSupportedKeyxFactories;
-    private List<NameValuePair> nvps;
+    private final List<NameValuePair> nvps;
 
     private static final String NUM_THREADS = "numthreads";
     private static final String ENTITY_AUTH_SCHEME = "entityauthscheme";
@@ -108,89 +108,89 @@ public class ServerConfiguration {
         nvps.add(new NameValuePair(NULL_CRYPTO_CONTEXT, String.valueOf(isNullCryptoContext)));
         nvps.add(new NameValuePair(CONSOLE_FILTER_STREAM_FACTORY, String.valueOf(setConsoleFilterStreamFactory)));
         if(unSupportedEntityAuthFactories!=null) {
-            for(EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
+            for(final EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_ENTITY_SCHEMES, String.valueOf(scheme)));
             }
         }
         if(unSupportedUserAuthFactories!=null) {
-            for(UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
+            for(final UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_USER_SCHEMES, String.valueOf(scheme)));
             }
         }
         if(unSupportedKeyxFactories!=null) {
-            for(KeyExchangeScheme scheme : unSupportedKeyxFactories) {
+            for(final KeyExchangeScheme scheme : unSupportedKeyxFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_KEY_EXCHANGE_SCHEMES, String.valueOf(scheme)));
             }
         }
     }
 
-    public ServerConfiguration isMessageEncrypted(boolean isMessageEncrypted) {
+    public ServerConfiguration isMessageEncrypted(final boolean isMessageEncrypted) {
         this.isMessageEncrypted = isMessageEncrypted;
         setParameter(ENCRYPTED, String.valueOf(this.isMessageEncrypted));
         return this;
     }
 
-    public ServerConfiguration isIntegrityProtected(boolean isIntegrityProtected) {
+    public ServerConfiguration isIntegrityProtected(final boolean isIntegrityProtected) {
         this.isIntegrityProtected = isIntegrityProtected;
         setParameter(INTEGRITY_PROTECTED, String.valueOf(this.isIntegrityProtected));
         return this;
     }
 
-    public ServerConfiguration setHost(String host) {
+    public ServerConfiguration setHost(final String host) {
         this.host = host;
         return this;
     }
 
-    public ServerConfiguration setPath(String path) {
+    public ServerConfiguration setPath(final String path) {
         this.path = path;
         return this;
     }
 
-    public ServerConfiguration setIsNullCryptoContext(boolean isNullCryptoContext) {
+    public ServerConfiguration setIsNullCryptoContext(final boolean isNullCryptoContext) {
         this.isNullCryptoContext = isNullCryptoContext;
         setParameter(NULL_CRYPTO_CONTEXT, String.valueOf(this.isNullCryptoContext));
         return this;
     }
 
-    public ServerConfiguration setInitialSequenceNumber(long initialSequenceNumber) {
+    public ServerConfiguration setInitialSequenceNumber(final long initialSequenceNumber) {
         this.initialSequenceNum = initialSequenceNumber;
         setParameter(INITIAL_SEQUENCE_NUM, String.valueOf(this.initialSequenceNum));
         return this;
     }
 
-    public ServerConfiguration setSetConsoleFilterStreamFactory(boolean setConsoleFilterStreamFactory) {
+    public ServerConfiguration setSetConsoleFilterStreamFactory(final boolean setConsoleFilterStreamFactory) {
         this.setConsoleFilterStreamFactory = setConsoleFilterStreamFactory;
         setParameter(CONSOLE_FILTER_STREAM_FACTORY, String.valueOf(this.setConsoleFilterStreamFactory));
         return this;
     }
 
-    public ServerConfiguration setUnsupportedEntityAuthenticationSchemes(List<EntityAuthenticationScheme> unSupportedEntityAuthFactories) {
+    public ServerConfiguration setUnsupportedEntityAuthenticationSchemes(final List<EntityAuthenticationScheme> unSupportedEntityAuthFactories) {
         this.unSupportedEntityAuthFactories = unSupportedEntityAuthFactories;
         clearParameter(UNSUPPORTED_ENTITY_SCHEMES);
         if(this.unSupportedEntityAuthFactories!=null) {
-            for(EntityAuthenticationScheme scheme : this.unSupportedEntityAuthFactories) {
+            for(final EntityAuthenticationScheme scheme : this.unSupportedEntityAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_ENTITY_SCHEMES, String.valueOf(scheme)));
             }
         }
         return this;
     }
 
-    public ServerConfiguration setUnsupportedUserAuthenticationSchemes(List<UserAuthenticationScheme> unSupportedUserAuthFactories) {
+    public ServerConfiguration setUnsupportedUserAuthenticationSchemes(final List<UserAuthenticationScheme> unSupportedUserAuthFactories) {
         this.unSupportedUserAuthFactories = unSupportedUserAuthFactories;
         clearParameter(UNSUPPORTED_USER_SCHEMES);
         if(this.unSupportedUserAuthFactories!=null) {
-            for(UserAuthenticationScheme scheme : this.unSupportedUserAuthFactories) {
+            for(final UserAuthenticationScheme scheme : this.unSupportedUserAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_USER_SCHEMES, String.valueOf(scheme)));
             }
         }
         return this;
     }
 
-    public ServerConfiguration setUnsupportedKeyExchangeSchemes(List<KeyExchangeScheme> unSupportedKeyxFactories) {
+    public ServerConfiguration setUnsupportedKeyExchangeSchemes(final List<KeyExchangeScheme> unSupportedKeyxFactories) {
         this.unSupportedKeyxFactories = unSupportedKeyxFactories;
         clearParameter(UNSUPPORTED_KEY_EXCHANGE_SCHEMES);
         if(this.unSupportedKeyxFactories != null) {
-            for(KeyExchangeScheme scheme : this.unSupportedKeyxFactories) {
+            for(final KeyExchangeScheme scheme : this.unSupportedKeyxFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_KEY_EXCHANGE_SCHEMES, String.valueOf(scheme)));
             }
         }
@@ -202,7 +202,7 @@ public class ServerConfiguration {
         return this;
     }
 
-    public ServerConfiguration clearParameter(String name) {
+    public ServerConfiguration clearParameter(final String name) {
         if (!nvps.isEmpty()) {
             for (final Iterator<NameValuePair> it = nvps.iterator(); it.hasNext(); ) {
                 final NameValuePair nvp = it.next();
@@ -215,19 +215,19 @@ public class ServerConfiguration {
         return this;
     }
 
-    public ServerConfiguration setParameter(String name, String value) {
+    public ServerConfiguration setParameter(final String name, final String value) {
         clearParameter(name);
         nvps.add(new NameValuePair(name, value));
         return this;
     }
 
     public void commitToServer() throws URISyntaxException, IOException {
-        StringBuilder urlBuilder = new StringBuilder(scheme + "://" + host + path + "?");
-        for (NameValuePair pair : nvps)
+        final StringBuilder urlBuilder = new StringBuilder(scheme + "://" + host + path + "?");
+        for (final NameValuePair pair : nvps)
             urlBuilder.append(pair.name + "=" + pair.value + "&");
-        URL url = new URL(urlBuilder.toString());
+        final URL url = new URL(urlBuilder.toString());
         
-        HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         conn.setRequestMethod("GET");
         conn.getResponseCode();
     }

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/EntityAuthTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/EntityAuthTests.java
@@ -41,10 +41,11 @@ import com.netflix.msl.userauth.UserAuthenticationScheme;
  * Date: 7/25/14
  */
 public class EntityAuthTests extends BaseTestClass {
-    private int numThreads = 0;
+    private final int numThreads = 0;
     private ServerConfiguration serverConfig = null;
     private static final int TIME_OUT = 60000; //60 seconds
     private static final String PATH = "/test";
+    private static final String USER_ID = "userId";
 
     @BeforeMethod
     public void setup() throws IOException, URISyntaxException {
@@ -79,6 +80,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -126,7 +128,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -156,6 +158,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.RSA)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -202,7 +205,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -235,11 +238,12 @@ public class EntityAuthTests extends BaseTestClass {
                 .setMaxEntityAuthRetryCount(2)
                 .resetCurrentEntityAuthRetryCount()
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenThe(message)
                 .shouldBe().validFirstEntityAuthRSAMsg()
@@ -268,6 +272,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.ECC)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -310,11 +315,12 @@ public class EntityAuthTests extends BaseTestClass {
                 .setMaxEntityAuthRetryCount(5)
                 .resetCurrentEntityAuthRetryCount()
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -344,6 +350,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.X509)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.DIFFIE_HELLMAN);
         clientConfig.commitConfiguration();
@@ -387,11 +394,12 @@ public class EntityAuthTests extends BaseTestClass {
                 .setMaxEntityAuthRetryCount(5)
                 .resetCurrentEntityAuthRetryCount()
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -422,6 +430,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -449,6 +458,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .clearKeyRequestData();
         clientConfig.commitConfiguration();
@@ -456,7 +466,7 @@ public class EntityAuthTests extends BaseTestClass {
         serverConfig.isMessageEncrypted(true)
                 .commitToServer();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/MasterTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/MasterTokenTests.java
@@ -55,6 +55,7 @@ public class MasterTokenTests extends BaseTestClass {
 
     private static final String PATH = "/test";
     private static final int TIME_OUT = 60000; // 60 Seconds
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
@@ -71,6 +72,7 @@ public class MasterTokenTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/SendTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/SendTests.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.client.tests;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.netflix.msl.MslConstants;
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.client.common.BaseTestClass;
+import com.netflix.msl.client.configuration.ClientConfiguration;
+import com.netflix.msl.client.configuration.ServerConfiguration;
+import com.netflix.msl.client.configuration.msg.ClientMessageContext;
+import com.netflix.msl.client.configuration.util.ClientMslContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
+import com.netflix.msl.io.Url;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageHeader;
+import com.netflix.msl.msg.MessageOutputStream;
+import com.netflix.msl.msg.MslControl;
+import com.netflix.msl.server.servlet.LogServlet;
+import com.netflix.msl.util.MslStore;
+
+/**
+ * <p>Tests of the {@link MslControl} send methods.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class SendTests extends BaseTestClass {
+    /** Local entity identity. */
+    private static final String ENTITY_IDENTITY = "send-test";
+    
+    /** Server path. */
+    private static final String PATH = "/log";
+    /** Network timeout in milliseconds. */
+    private static final int TIMEOUT = 60000;
+    
+    @BeforeClass
+    public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+        super.loadProperties();
+        serverConfig = new ServerConfiguration()
+            .resetDefaultConfig()
+            .setHost(getRemoteEntityUrl())
+            .setPath(PATH);
+        serverConfig.commitToServer();
+        
+        clientConfig = new ClientConfiguration()
+            .setScheme("http")
+            .setHost(getRemoteEntityUrl())
+            .setPath(PATH)
+            .setNumThreads(0)
+            .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE);
+        clientConfig.commitConfiguration();
+        
+        super.setServerMslCryptoContext();
+    }
+    
+    @AfterMethod
+    public void reset() {
+        final MslStore store = clientConfig.getMslContext().getMslStore();
+        store.clearCryptoContexts();
+        store.clearUserIdTokens();
+        store.clearServiceTokens();
+    }
+    
+    /**
+     * <p>Query the server for the reported string.</p>
+     * 
+     * @return the string returned by a report query.
+     * @throws IOException if there is an error making the query.
+     */
+    public String report() throws IOException {
+        // Prepare the request.
+        final String uri = "http://" + getRemoteEntityUrl() + PATH + "?" + LogServlet.REPORT;
+        final URL url = new URL(uri);
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        conn.setRequestMethod("GET");
+        
+        // Read the response.
+        final Reader in = new InputStreamReader(conn.getInputStream());
+        final StringBuffer content = new StringBuffer();
+        final char[] buffer = new char[16384];
+        while (true) {
+            final int count = in.read(buffer);
+            if (count == -1) break;
+            content.append(buffer, 0, count);
+        }
+        return content.toString();
+    }
+    
+    @Test
+    public void send() throws IOException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException {
+        // Prepare.
+        final String message = "fire-and-forget";
+        final MslControl ctrl = clientConfig.getMslControl();
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(false)
+            .setIsIntegrityProtected(false)
+            .clearKeyRequestData()
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Send message.
+        msgCtx.setBuffer(message.getBytes(MslConstants.DEFAULT_CHARSET));
+        final Future<MessageOutputStream> future = ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT);
+        MessageOutputStream mos = null;
+        try {
+            mos = future.get();
+            Assert.assertNotNull(mos);
+            final MessageHeader messageHeader = mos.getMessageHeader();
+            Assert.assertNotNull(messageHeader);
+            Assert.assertNull(messageHeader.getMasterToken());
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            e.printStackTrace(System.err);
+            return;
+        } finally {
+            if (mos != null)
+                try { mos.close(); } catch (final IOException e) {}
+        }
+        
+        // Query receipt.
+        final String report = report();
+        Assert.assertEquals(report, message);
+    }
+    
+    @Test
+    public void handshakeSend() throws IOException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException {
+        // Prepare.
+        final String message = "handshake";
+        final MslControl ctrl = clientConfig.getMslControl();
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(true)
+            .setIsIntegrityProtected(true)
+            .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED)
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Send message.
+        msgCtx.setBuffer(message.getBytes(MslConstants.DEFAULT_CHARSET));
+        final Future<MessageOutputStream> future = ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT);
+        MessageOutputStream mos = null;
+        try {
+            mos = future.get();
+            Assert.assertNotNull(mos);
+            final MessageHeader messageHeader = mos.getMessageHeader();
+            Assert.assertNotNull(messageHeader);
+            Assert.assertNotNull(messageHeader.getMasterToken());
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            e.printStackTrace(System.err);
+            return;
+        } finally {
+            if (mos != null)
+                try { mos.close(); } catch (final IOException e) {}
+        }
+        
+        // Query receipt.
+        final String report = report();
+        Assert.assertEquals(report, message);
+    }
+
+    /** Server configuration. */
+    private ServerConfiguration serverConfig;
+}

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
@@ -59,6 +59,7 @@ public class ServiceTokenTests extends BaseTestClass {
 
     private static final String PATH = "/test";
     private static final int TIME_OUT = 60000; // 60 Seconds
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
@@ -75,6 +76,7 @@ public class ServiceTokenTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/UserAuthTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/UserAuthTests.java
@@ -15,6 +15,15 @@
  */
 package com.netflix.msl.client.tests;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ExecutionException;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
@@ -27,14 +36,6 @@ import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * User: skommidi
@@ -42,9 +43,10 @@ import java.util.concurrent.ExecutionException;
  */
 public class UserAuthTests extends BaseTestClass {
     private static final int TIME_OUT = 60000; // 60 Seconds
-    private int numThreads = 0;
+    private final int numThreads = 0;
     private ServerConfiguration serverConfig;
     private static final String PATH = "/test";
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException {
@@ -64,11 +66,12 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.DIFFIE_HELLMAN);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenThe(message)
                 .shouldBe().validFirstEntityAuthNONEMsg()
@@ -84,6 +87,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.INVALID_EMAIL)
                 .setMaxUserAuthRetryCount(5)
@@ -91,7 +95,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -107,6 +111,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.INVALID_PASSWORD)
                 .setMaxUserAuthRetryCount(5)
@@ -114,7 +119,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -130,6 +135,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.EMPTY_EMAIL)
                 .setMaxUserAuthRetryCount(5)
@@ -137,7 +143,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -153,6 +159,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.EMPTY_PASSWORD)
                 .setMaxUserAuthRetryCount(5)
@@ -160,7 +167,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -176,6 +183,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.DIFFIE_HELLMAN)
                 .setNullUserAuthData();
@@ -202,6 +210,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.X509)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.INVALID_EMAIL)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED)
@@ -209,7 +218,7 @@ public class UserAuthTests extends BaseTestClass {
                 .resetCurrentUserAuthRetryCount();
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenThe(message)
                 .shouldBe().validFirstEntityAuthX509Msg()

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/UserIdTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/UserIdTokenTests.java
@@ -57,6 +57,7 @@ public class UserIdTokenTests extends BaseTestClass {
 
     private static final String PATH = "/test";
     private static final int TIME_OUT = 60000; // 60 Seconds
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
@@ -73,6 +74,7 @@ public class UserIdTokenTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();

--- a/integ-tests/src/test/javascript/SendTest.js
+++ b/integ-tests/src/test/javascript/SendTest.js
@@ -1,0 +1,344 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>Tests of the {@link MslControl} send methods.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+describe("SendTest", function() {
+    var MslConstants = require('msl-core/MslConstants.js');
+    var Url = require('msl-core/io/Url.js');
+    var Xhr = require('msl-core/io/Xhr.js');
+    var KeyExchangeScheme = require('msl-core/keyx/KeyExchangeScheme.js');
+    var MessageOutputStream = require('msl-core/msg/MessageOutputStream.js');
+    var MslControl = require('msl-core/msg/MslControl.js');
+    var UserAuthenticationScheme = require('msl-core/userauth/UserAuthenticationScheme.js');
+    var MslContext = require('msl-core/util/MslContext.js');
+    var MslStore = require('msl-core/util/MslStore.js');
+    var EntityAuthenticationScheme = require('msl-core/entityauth/EntityAuthenticationScheme.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var UnauthenticatedAuthenticationData = require('msl-core/entityauth/UnauthenticatedAuthenticationData.js');
+    
+    var textEncoding = require('msl-core/lib/textEncoding.js');
+    
+    var MockMslContext = require('msl-tests/util/MockMslContext.js');
+    var MslTestConstants = require('msl-tests/MslTestConstants.js');
+    var MockMessageContext = require('msl-tests/msg/MockMessageContext.js');
+    var NodeHttpLocation = require('msl-tests/io/NodeHttpLocation.js');
+    var MockRsaAuthenticationFactory = require('msl-tests/entityauth/MockRsaAuthenticationFactory.js');
+    
+    var http = require('http');
+    var url = require('url');
+    
+    /**
+     * A message context that will write data and require encryption and
+     * integrity protection.
+     */
+    var WriteMessageContext = MockMessageContext.extend({
+        /**
+         * Create a new write message context.
+         * 
+         * @param {MockMslContext} ctx MSL context.
+         * @param {?string} userId user ID. May be {@code null}.
+         * @param {?UserAuthenticationScheme} scheme user authentication scheme. May be {@code null}.
+         * @param {Uint8Array} data the data to write.
+         * @param {result: function(WriteMessageContext), error: function(Error)}
+         *        callback the callback that will receive the new message context
+         *        or any thrown exceptions.
+         * @throws NoSuchAlgorithmException if a key generation algorithm is not
+         *         found.
+         * @throws InvalidAlgorithmParameterException if key generation parameters
+         *         are invalid.
+         * @throws CryptoException if there is an error creating a key.
+         */
+        init: function init(ctx, userId, scheme, data, callback) {
+            var self = this;
+
+            init.base.call(this, ctx, userId, scheme, {
+                result: function(msgCtx) {
+                    AsyncExecutor(callback, function() {
+                        // The properties.
+                        var props = {
+                            _data: { value: data, writable: false, enumerable: false, configurable: false },
+                        };
+                        Object.defineProperties(this, props);
+                        return this;
+                    }, self);
+                },
+                error: callback.error
+            });
+        },
+        
+        /** @inheritDoc */
+        write: function write(output, timeout, callback) {
+            AsyncExecutor(callback, function() {
+                output.write(this._data, 0, this._data.length, timeout, callback);
+            }, this);
+        },
+    });
+    
+    /**
+     * Create a new write message context.
+     * 
+     * @param {MockMslContext} ctx MSL context.
+     * @param {string} userId user ID.
+     * @param {UserAuthenticationScheme} scheme user authentication scheme.
+     * @param {Uint8Array} data the data to write.
+     * @param {result: function(WriteMessageContext), error: function(Error)}
+     *        callback the callback that will receive the new message context
+     *        or any thrown exceptions.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws CryptoException if there is an error creating a key.
+     */
+    WriteMessageContext.create = function WriteMessageContext$create(ctx, userId, scheme, data, callback) {
+        new WriteMessageContext(ctx, userId, scheme, data, callback);
+    };
+    
+    /** Local entity identity. */
+    var ENTITY_IDENTITY = "send-test";
+
+    /** Server host. */
+    var HOST = "localhost:8080";
+    /** Server path. */
+    var PATH = "/msl-integ-tests/log";
+    /** Report query string. */
+    var REPORT = "report";
+    /** Network timeout in milliseconds. */
+    var TIMEOUT = 2000;
+
+    /** MSL control. */
+    var ctrl = new MslControl();
+    /** MSL context. */
+    var ctx;
+    
+    var initialized = false;
+    beforeEach(function() {
+        if (initialized) return;
+        
+        runs(function() {
+            MockMslContext.create(EntityAuthenticationScheme.NONE, false, {
+                result: function(x) { ctx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ctx; }, "ctx", MslTestConstants.TIMEOUT_CTX);
+        
+        runs(function() {
+            ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+            initialized = true;
+        });
+    });
+    
+    afterEach(function() {
+        var store = ctx.getMslStore();
+        store.clearCryptoContexts();
+        store.clearUserIdTokens();
+        store.clearServiceTokens();
+    });
+
+    /**
+     * <p>Query the server for the reported string.</p>
+     * 
+     * @param {{result: function(string), timeout: function(), error: function(Error)}}
+     *        callback the callback that will receive the response body, be
+     *        notified of timeout, or any thrown errors.
+     * @return the string returned by a report query.
+     */
+    function report(callback) {
+        // Prepare the request.
+        var options = url.parse("http://" + HOST + PATH + "?" + REPORT);
+        options.timeout = TIMEOUT;
+
+        // Buffer and then deliver the accumulated data. Only
+        // allow the callback to be triggered once, in case
+        // events keep arriving after the data has been
+        // delivered or after an error has occurred.
+        var buffer = "";
+        var delivered = false;
+        var request = http.get(options, function(message) {
+            message.on('data', function(chunk) {
+                try {
+                    if (typeof chunk === 'string')
+                        buffer += chunk;
+                    else
+                        buffer += chunk.toString();
+                } catch (e) {
+                    if (!delivered)
+                        callback.error(e);
+                    delivered = true;
+                }
+            });
+            message.on('end', function() {
+                if (!delivered)
+                    callback.result(buffer);
+                delivered = true;
+            });
+        });
+        request.on('timeout', function() {
+            if (!delivered)
+                callback.timeout();
+            delivered = true;
+        });
+        request.on('error', function(e) {
+            if (!delivered)
+                callback.error(e);
+            delivered = true;
+        });
+    }
+    
+    it("send", function() {
+        // Prepare.
+        var message = "handshake";
+        var messageBytes = textEncoding.getBytes(message);
+        var uri = "http://" + HOST + PATH;
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, messageBytes, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Do not require encryption or integrity protection.
+            msgCtx.setEncrypted(false);
+            msgCtx.setIntegrityProtected(false);
+
+            // Clear the key request data.
+            msgCtx.setKeyRequestData([]);
+            
+            ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Query receipt.
+        var result;
+        runs(function() {
+            report({
+                result: function(x) { result = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return result; }, "report", TIMEOUT);
+        
+        runs(function() {
+            expect(result).toEqual(message);
+        });
+    });
+    
+    it("send handshake", function() {
+        // Prepare.
+        var message = "handshake";
+        var messageBytes = textEncoding.getBytes(message);
+        var uri = "http://" + HOST + PATH;
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, messageBytes, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Require encryption and integrity protection.
+            msgCtx.setEncrypted(true);
+            msgCtx.setIntegrityProtected(true);
+            
+            // Set the key request data.
+            var publicKey = MockRsaAuthenticationFactory.RSA_PUBKEY;
+            var privateKey = MockRsaAuthenticationFactory.RSA_PRIVKEY;
+            var requestData = new AsymmetricWrappedExchange.RequestData("rsaKeypairId", AsymmetricWrappedExchange.Mechanism.JWE_RSA, publicKey, privateKey);
+            var keyxRequestData = [ requestData ];
+            msgCtx.setKeyRequestData(keyxRequestData);
+            
+            ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).not.toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Query receipt.
+        var result;
+        runs(function() {
+            report({
+                result: function(x) { result = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return result; }, "report", TIMEOUT);
+        
+        runs(function() {
+            expect(result).toEqual(message);
+        });
+    });
+});

--- a/integ-tests/src/test/javascript/package.json
+++ b/integ-tests/src/test/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msl-integ-tests-exec",
-  "version": "1.1218.0",
+  "version": "1.1219.0",
   "description": "Message Security Layer Integration Tests Execution",
   "keywords": [
     "msl",
@@ -21,8 +21,8 @@
     "lint": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs jshint --verbose"
   },
   "dependencies": {
-    "msl-core": "^1.1218.0",
-    "msl-tests": "^1.1218.0"
+    "msl-core": "^1.1219.0",
+    "msl-tests": "^1.1219.0"
   },
   "devDependencies": {
     "clarinet": "^0.11.0",

--- a/integ-tests/src/test/javascript/package.json
+++ b/integ-tests/src/test/javascript/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "msl-integ-tests-exec",
+  "version": "1.1218.0",
+  "description": "Message Security Layer Integration Tests Execution",
+  "keywords": [
+    "msl",
+    "message security layer",
+    "netflix"
+  ],
+  "homepage": "https://github.com/Netflix/msl",
+  "bugs": {
+    "url": "https://github.com/Netflix/msl/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com:Netflix/msl.git"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs -n1 jasmine-node --matchall --forceexit --captureExceptions ./node_modules/msl-tests/lib/jasmine/msl-helpers.js",
+    "lint": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs jshint --verbose"
+  },
+  "dependencies": {
+    "msl-core": "^1.1218.0",
+    "msl-tests": "^1.1218.0"
+  },
+  "devDependencies": {
+    "clarinet": "^0.11.0",
+    "ec-key": "0.0.2",
+    "elliptic": "^6.4.0",
+    "jshint": "^2.9.5",
+    "jsrsasign": "^7.2.2",
+    "ursa": "^0.9.4"
+  }
+}

--- a/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
+++ b/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
@@ -92,8 +92,8 @@ public class MockMessageContext implements MessageContext {
      * The message will not be encrypted or non-replayable.
      * 
      * @param ctx MSL context.
-     * @param userId user ID.
-     * @param scheme user authentication scheme.
+     * @param userId user ID. May be {@code null}.
+     * @param scheme user authentication scheme. May be {@code null}.
      * @throws NoSuchAlgorithmException if a key generation algorithm is not
      *         found.
      * @throws InvalidAlgorithmParameterException if key generation parameters
@@ -113,7 +113,7 @@ public class MockMessageContext implements MessageContext {
         
         if (UserAuthenticationScheme.EMAIL_PASSWORD.equals(scheme)) {
             userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL, MockEmailPasswordAuthenticationFactory.PASSWORD);
-        } else {
+        } else if (scheme != null) {
             throw new IllegalArgumentException("Unsupported authentication type: " + scheme.name());
         }
         

--- a/tests/src/main/javascript/io/NodeHttpLocation.js
+++ b/tests/src/main/javascript/io/NodeHttpLocation.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>An HTTP location that is implemented using Node HTTP.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netlix.com>
+ */
+(function(require, module) {
+    "use strict";
+    
+    var Url = require('msl-core/io/Url.js');
+    var MslIoException = require('msl-core/MslIoException.js');
+    var InterruptibleExecutor = require('msl-core/util/InterruptibleExecutor.js');
+    
+    var http = require('http');
+    var url = require('url');
+    
+    /**
+     * Interface for getting an HTTP response given a request.
+     */
+    var NodeHttpLocation = module.exports = Url.IHttpLocation.extend({
+        /**
+         * <p>Create a new Node HTTP location pointing at the specified
+         * endpoint.</p>
+         * 
+         * @param {string} endpoint the URL to send the request to.
+         */
+        init: function(endpoint) {
+            // Set properties.
+            var props = {
+                _endpoint: { value: endpoint, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+        
+        /**
+         * Given a request, gets the response.
+         *
+         * @param {{body: string}} request
+         * @param {number} timeout request response timeout in milliseconds or -1 for no timeout.
+         * @param {{result: function({=body: string, =content: Uint8Array}), timeout: function(), error: function(Error)}}
+         *        callback the callback that will receive the response data as
+         *        a string or bytes, be notified of timeout or any thrown
+         *        exceptions.
+         * @returns {{abort:Function})
+         */
+        /** @inheritDoc */
+        getResponse: function(request, timeout, callback) {
+            var self = this;
+            
+            // Declare the http.ClientRequest reference here to provide the
+            // abort function.
+            var req;
+        
+            InterruptibleExecutor(callback, function() {
+                // Convert the endpoint to HTTP request options.
+                var options = url.parse(this._endpoint);
+                options.method = 'POST';
+                options.timeout = timeout;
+                
+                // Issue the request asynchronously.
+                //
+                // Only allow the callback to be triggered once, in case events
+                // keep arriving after the data has been delivered or after an
+                // error has occurred.
+                var delivered = false;
+                req = http.request(options);
+                req.on('response', function(message) {
+                    InterruptibleExecutor(callback, function() {
+                        // Check for an error.
+                        if (message.statusCode < 200 || message.statusCode >= 300)
+                            throw new MslIoException("HTTP " + message.statusCode + ": " + message.statusMessage);
+                        
+                        // Buffer and then deliver the accumulated data. 
+                        var buffers = [];
+                        message.on('data', function(chunk) {
+                            try {
+                                if (typeof chunk === 'string') {
+                                    var buffer = Buffer.from(chunk);
+                                    buffers.push(buffer);
+                                } else {
+                                    buffers.push(chunk);
+                                }
+                            } catch (e) {
+                                if (!delivered)
+                                    callback.error(e);
+                                delivered = true;
+                            }
+                        });
+                        message.on('end', function() {
+                            try {
+                                if (!delivered) {
+                                    var data = Buffer.concat(buffers);
+                                    var content = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+                                    callback.result({ content: content });
+                                }
+                                delivered = true;
+                            } catch (e) {
+                                if (!delivered)
+                                    callback.error(e);
+                                delivered = true;
+                            }
+                        });
+                    }, self);
+                });
+                req.on('timeout', function() {
+                    if (!delivered)
+                        callback.timeout();
+                    delivered = true;
+                });
+                req.on('error', function(e) {
+                    if (!delivered)
+                        callback.error(e);
+                    delivered = true;
+                });
+                var postdata = Buffer.from(request.body.buffer);
+                req.end(postdata);
+            }, self);
+
+            // Return the abort function.
+            return { abort: function() { req.abort(); } };
+        },
+    });
+})(require, (typeof module !== 'undefined') ? module : mkmodule('NodeHttpLocation'));

--- a/tests/src/main/javascript/msg/MockMessageContext.js
+++ b/tests/src/main/javascript/msg/MockMessageContext.js
@@ -82,8 +82,8 @@
 	     * The message will not be encrypted or non-replayable.
 	     * 
 	     * @param {MockMslContext} ctx MSL context.
-	     * @param {string} userId user ID.
-	     * @param {UserAuthenticationScheme} scheme user authentication scheme.
+	     * @param {?string} userId user ID. May be {@code null}.
+	     * @param {?UserAuthenticationScheme} scheme user authentication scheme. May be {@code null}.
 	     * @param {result: function(MockMessageContext), error: function(Error)}
 	     *        callback the callback that will receive the new message context
 	     *        or any thrown exceptions.
@@ -121,10 +121,10 @@
 	        
 	        function createContext(tokenEncryptionKeyA, tokenHmacKeyA, tokenEncryptionKeyB, tokenHmacKeyB) {
 	            AsyncExecutor(callback, function() {
-	                var userAuthData;
+	                var userAuthData = null;
 	                if (UserAuthenticationScheme.EMAIL_PASSWORD == scheme) {
 	                    userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL, MockEmailPasswordAuthenticationFactory.PASSWORD);
-	                } else {
+	                } else if (scheme) {
 	                    throw new MslInternalException("Unsupported authentication type: " + scheme.name);
 	                }
 
@@ -332,7 +332,7 @@
      * The message will not be encrypted or non-replayable.
      * 
      * @param {MockMslContext} ctx MSL context.
-     * @param {string} userId user ID.
+     * @param {?string} userId user ID. May be {@code null}.
      * @param {UserAuthenticationScheme} scheme user authentication scheme.
      * @param {result: function(MockMessageContext), error: function(Error)}
      *        callback the callback that will receive the new message context


### PR DESCRIPTION
* Add `MslControl.send()` that can be used to fire-and-forget a MSL message to a remote entity. A handshake will be performed if necessary, but there is no confirmation of receipt or acceptance.
* Define Node.js IHttpLocation implementation.

Use of this method is not recommended as it does not confirm delivery or acceptance of the message. Establishing a MSL channel to send application data without requiring the remote entity to acknowledge receipt in the response application data is the recommended approach. Only use this method if guaranteed receipt is not required.