### PR TITLE
Only cache payloads in MessageInputStream if mark() is active.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -59,21 +59,21 @@ import com.netflix.msl.util.MslContext;
  * payload chunks carrying application data. Each payload chunk is individually
  * packaged but sequentially ordered. No payload chunks may be included in an
  * error message.</p>
- * 
+ *
  * <p>Data is read until an end-of-message payload chunk is encountered or an
  * error occurs. Closing a {@code MessageInputStream} does not close the source
  * input stream in case additional MSL messages will be read.</p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class MessageInputStream extends InputStream {
     /**
      * <p>Return the crypto context resulting from key response data contained
      * in the provided header.</p>
-     * 
+     *
      * <p>The {@link MslException}s thrown by this method will not have the
      * entity or user set.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param header header.
      * @param keyRequestData key request data for key exchange.
@@ -94,11 +94,11 @@ public class MessageInputStream extends InputStream {
         final MessageHeader messageHeader = header;
         final MasterToken masterToken = messageHeader.getMasterToken();
         final KeyResponseData keyResponse = messageHeader.getKeyResponseData();
-        
+
         // If there is no key response data then return null.
         if (keyResponse == null)
             return null;
-        
+
         // If the key response data master token is decrypted then use the
         // master token keys to create the crypto context.
         final MasterToken keyxMasterToken = keyResponse.getMasterToken();
@@ -158,20 +158,20 @@ public class MessageInputStream extends InputStream {
         // payloads will not decrypt properly. Throw an exception.
         throw new MslKeyExchangeException(MslError.KEYX_RESPONSE_REQUEST_MISMATCH, Arrays.toString(keyRequestData.toArray()));
     }
-    
+
     /**
      * <p>Construct a new message input stream. The header is parsed.</p>
-     * 
+     *
      * <p>If key request data is provided and a matching key response data is
      * found in the message header the key exchange will be performed to
      * process the message payloads.</p>
-     * 
+     *
      * <p>Service tokens will be decrypted and verified with the provided crypto
      * contexts identified by token name. A default crypto context may be
      * provided by using the empty string as the token name; if a token name is
      * not explcitly mapped onto a crypto context, the default crypto context
      * will be used.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param source MSL input stream.
      * @param keyRequestData key request data to use when processing key
@@ -218,7 +218,7 @@ public class MessageInputStream extends InputStream {
             throw new MslEncodingException(MslError.MSL_PARSE_ERROR, "header", e);
         }
         this.header = Header.parseHeader(ctx, mo, cryptoContexts);
-        
+
         try {
             // For error messages there are no key exchange or payload crypto
             // contexts.
@@ -227,7 +227,7 @@ public class MessageInputStream extends InputStream {
                 this.cryptoContext = null;
                 return;
             }
-            
+
             // Grab the key exchange crypto context, if any.
             final MessageHeader messageHeader = (MessageHeader)this.header;
             this.keyxCryptoContext = getKeyxCryptoContext(ctx, messageHeader, keyRequestData);
@@ -237,12 +237,12 @@ public class MessageInputStream extends InputStream {
             // context.
             if (ctx.isPeerToPeer() || this.keyxCryptoContext == null)
                 this.cryptoContext = messageHeader.getCryptoContext();
-                
+
             // Otherwise the payload crypto context equals the key exchange
             // crypto context.
             else
                 this.cryptoContext = this.keyxCryptoContext;
-            
+
             // If this is a handshake message but it is not renewable or does
             // not contain key request data then reject the message.
             if (messageHeader.isHandshake() &&
@@ -250,7 +250,7 @@ public class MessageInputStream extends InputStream {
             {
                 throw new MslMessageException(MslError.HANDSHAKE_DATA_MISSING, messageHeader.toString());
             }
-            
+
             // If I am in peer-to-peer mode or the master token is verified
             // (i.e. issued by the local entity which is therefore a trusted
             // network server) then perform the master token checks.
@@ -262,7 +262,7 @@ public class MessageInputStream extends InputStream {
                 final MslError revoked = factory.isMasterTokenRevoked(ctx, masterToken);
                 if (revoked != null)
                     throw new MslMasterTokenException(revoked, masterToken);
-                
+
                 // If the user ID token has been revoked then reject the
                 // message. We know the master token is not null and that it is
                 // verified so we assume the user ID token is as well.
@@ -272,14 +272,14 @@ public class MessageInputStream extends InputStream {
                     if (uitRevoked != null)
                         throw new MslUserIdTokenException(uitRevoked, userIdToken);
                 }
-                
+
                 // If the master token is expired...
                 if (masterToken.isExpired(null)) {
                     // If the message is not renewable or does not contain key
                     // request data then reject the message.
                     if (!messageHeader.isRenewable() || messageHeader.getKeyRequestData().isEmpty())
                         throw new MslMessageException(MslError.MESSAGE_EXPIRED, messageHeader.toString());
-                    
+
                     // If the master token will not be renewed by the token
                     // factory then reject the message.
                     //
@@ -290,7 +290,7 @@ public class MessageInputStream extends InputStream {
                         throw new MslMessageException(notRenewable, "Master token is expired and not renewable.");
                 }
             }
-            
+
             // If the message is non-replayable (it is not from a trusted
             // network server).
             final Long nonReplayableId = messageHeader.getNonReplayableId();
@@ -299,7 +299,7 @@ public class MessageInputStream extends InputStream {
                 // message.
                 if (masterToken == null)
                     throw new MslMessageException(MslError.INCOMPLETE_NONREPLAYABLE_MESSAGE, messageHeader.toString());
-                
+
                 // If the non-replayable ID is not accepted then notify the
                 // sender.
                 final TokenFactory factory = ctx.getTokenFactory();
@@ -323,7 +323,7 @@ public class MessageInputStream extends InputStream {
             throw e;
         }
     }
-    
+
     /* (non-Javadoc)
      * @see java.lang.Object#finalize()
      */
@@ -335,7 +335,7 @@ public class MessageInputStream extends InputStream {
 
     /**
      * Retrieve the next MSL object.
-     * 
+     *
      * @return the next MSL object or null if none remaining.
      * @throws MslEncodingException if there is a problem parsing the data.
      */
@@ -344,12 +344,12 @@ public class MessageInputStream extends InputStream {
         final MessageHeader messageHeader = getMessageHeader();
         if (messageHeader == null)
             throw new MslInternalException("Read attempted with error message.");
-        
+
         // If we previously reached the end of the message, don't try to read
         // more.
         if (eom)
             return null;
-        
+
         // Otherwise read the next MSL object.
         try {
             if (!tokenizer.more(-1)) {
@@ -364,7 +364,7 @@ public class MessageInputStream extends InputStream {
 
     /**
      * Retrieve the next payload chunk data.
-     * 
+     *
      * @return the next payload chunk data or null if none remaining.
      * @throws MslCryptoException if there is a problem decrypting or verifying
      *         the payload chunk.
@@ -379,16 +379,16 @@ public class MessageInputStream extends InputStream {
         final MessageHeader messageHeader = getMessageHeader();
         if (messageHeader == null)
             throw new MslInternalException("Read attempted with error message.");
-        
+
         // If reading buffered data return the next buffered payload data.
         if (payloadIterator != null && payloadIterator.hasNext())
             return payloadIterator.next();
-        
+
         // Otherwise read the next payload.
         final MslObject mo = nextMslObject();
         if (mo == null) return null;
         final PayloadChunk payload = new PayloadChunk(ctx, mo, cryptoContext);
-        
+
         // Make sure the payload belongs to this message and is the one we are
         // expecting.
         final MasterToken masterToken = messageHeader.getMasterToken();
@@ -410,7 +410,7 @@ public class MessageInputStream extends InputStream {
                 .setUserAuthenticationData(userAuthData);
         }
         ++payloadSequenceNumber;
-        
+
         // FIXME remove this logic once the old handshake inference logic
         // is no longer supported.
         // Check for a handshake if this is the first payload chunk.
@@ -418,27 +418,29 @@ public class MessageInputStream extends InputStream {
             handshake = (messageHeader.isRenewable() && !messageHeader.getKeyRequestData().isEmpty() &&
                 payload.isEndOfMessage() && payload.getData().length == 0);
         }
-        
+
         // Check for end of message.
         if (payload.isEndOfMessage())
             eom = true;
-        
-        // Save the payload in the buffer and return it. We have to unset the
-        // payload iterator since we're adding to the payloads list.
+
+        // If mark was called save the payload in the buffer. We have to unset
+        // the payload iterator since we're adding to the payloads list.
         final ByteArrayInputStream data = new ByteArrayInputStream(payload.getData());
-        payloads.add(data);
-        payloadIterator = null;
+        if (payloads != null) {
+            payloads.add(data);
+            payloadIterator = null;
+        }
         return data;
     }
-    
+
     /**
      * Returns true if the message is a handshake message.
-     * 
+     *
      * FIXME
      * This method should be removed by a direct query of the message header
      * once the old behavior of inferred handshake messages based on a single
      * empty payload chunk is no longer supported.
-     * 
+     *
      * @return true if the message is a handshake message.
      * @throws MslCryptoException if there is a problem decrypting or verifying
      *         the payload chunk.
@@ -450,13 +452,13 @@ public class MessageInputStream extends InputStream {
      */
     public boolean isHandshake() throws MslCryptoException, MslEncodingException, MslMessageException, MslInternalException, MslException {
         final MessageHeader messageHeader = getMessageHeader();
-        
+
         // Error messages are not handshake messages.
         if (messageHeader == null) return false;
-        
+
         // If the message header has its handshake flag set return true.
         if (messageHeader.isHandshake()) return true;
-        
+
         // If we haven't read a payload we don't know if this is a handshake
         // message or not. This also implies the current payload is null.
         if (handshake == null) {
@@ -476,7 +478,7 @@ public class MessageInputStream extends InputStream {
         // Return the current handshake status.
         return handshake.booleanValue();
     }
-    
+
     /**
      * @return the message header. Will be null for error messages.
      */
@@ -485,7 +487,7 @@ public class MessageInputStream extends InputStream {
             return (MessageHeader)header;
         return null;
     }
-    
+
     /**
      * @return the error header. Will be null except for error messages.
      */
@@ -494,12 +496,12 @@ public class MessageInputStream extends InputStream {
             return (ErrorHeader)header;
         return null;
     }
-    
+
     /**
      * Returns the sender's entity identity. The identity will be unknown if
      * the local entity is a trusted network client and the message was sent by
      * a trusted network server using the local entity's master token.
-     * 
+     *
      * @return the sender's entity identity or null if unknown.
      * @throws MslCryptoException if there is a crypto error accessing the
      *         entity identity;
@@ -515,12 +517,12 @@ public class MessageInputStream extends InputStream {
         final ErrorHeader errorHeader = getErrorHeader();
         return errorHeader.getEntityAuthenticationData().getIdentity();
     }
-    
+
     /**
      * Returns the user associated with the message. The user will be unknown
      * if the local entity is a trusted network client and the message was sent
      * by a trusted network server.
-     * 
+     *
      * @return the user associated with the message or null if unknown.
      */
     public MslUser getUser() {
@@ -529,14 +531,14 @@ public class MessageInputStream extends InputStream {
             return null;
         return messageHeader.getUser();
     }
-    
+
     /**
      * @return the payload crypto context. Will be null for error messages.
      */
     public ICryptoContext getPayloadCryptoContext() {
         return cryptoContext;
     }
-    
+
     /**
      * @return the key exchange crypto context. Will be null if no key response
      *         data was returned in this message and for error messages.
@@ -544,7 +546,7 @@ public class MessageInputStream extends InputStream {
     public ICryptoContext getKeyExchangeCryptoContext() {
         return keyxCryptoContext;
     }
-    
+
     /* (non-Javadoc)
      * @see java.io.InputStream#available()
      */
@@ -553,27 +555,29 @@ public class MessageInputStream extends InputStream {
         // Start with the amount available in the current payload.
         if (currentPayload == null) return 0;
         int available = currentPayload.available();
-        
+
         // If there is buffered data, iterate over all subsequent buffered
         // payloads.
-        final int startIndex = payloads.indexOf(currentPayload);
-        if (startIndex != -1 && startIndex < payloads.size() - 1) {
-            final Iterator<ByteArrayInputStream> nextPayloads = payloads.listIterator(startIndex + 1);
-            while (nextPayloads.hasNext()) {
-                final ByteArrayInputStream payload = nextPayloads.next();
-                available += payload.available();
+        if (payloads != null) {
+            final int startIndex = payloads.indexOf(currentPayload);
+            if (startIndex != -1 && startIndex < payloads.size() - 1) {
+                final Iterator<ByteArrayInputStream> nextPayloads = payloads.listIterator(startIndex + 1);
+                while (nextPayloads.hasNext()) {
+                    final ByteArrayInputStream payload = nextPayloads.next();
+                    available += payload.available();
+                }
             }
         }
-        
+
         // Return available bytes.
         return available;
     }
-    
+
     /**
      * By default the source input stream is not closed when this message input
      * stream is closed. If it should be closed then this method can be used to
      * dictate the desired behavior.
-     * 
+     *
      * @param close true if the source input stream should be closed, false if
      *        it should not.
      */
@@ -590,7 +594,7 @@ public class MessageInputStream extends InputStream {
         // to reuse the connection.
         if (closeSource)
             source.close();
-        
+
         // Otherwise if this is not a handshake message or error message then
         // consume all payloads that may still be on the source input stream.
         else {
@@ -603,7 +607,7 @@ public class MessageInputStream extends InputStream {
                 }
             } catch (final MslException e) {
                 // Ignore exceptions.
-            } 
+            }
         }
     }
 
@@ -612,23 +616,34 @@ public class MessageInputStream extends InputStream {
      */
     @Override
     public void mark(final int readlimit) {
+        // Remember the read limit, reset the read count.
+        this.readlimit = readlimit;
+        this.readcount = 0;
+
+        // Initialize the payload buffer if we were not already buffering data.
+        if (payloads == null)
+            payloads = new LinkedList<ByteArrayInputStream>();
+
         // If there is a current payload...
         if (currentPayload != null) {
             // Remove all buffered data earlier than the current payload.
-            payloadIterator = null;
             while (payloads.size() > 0 && !payloads.get(0).equals(currentPayload))
                 payloads.remove(0);
-            
+
+            // Add the current payload if it was not already buffered.
+            if (payloads.size() == 0)
+                payloads.add(currentPayload);
+
             // Reset the iterator to continue reading buffered data from the
             // current payload.
             payloadIterator = payloads.listIterator();
             currentPayload = payloadIterator.next();
-            
+
             // Set the new mark point on the current payload.
             currentPayload.mark(readlimit);
             return;
         }
-        
+
         // Otherwise we've either read to the end or haven't read anything at
         // all yet. Discard all buffered data.
         payloadIterator = null;
@@ -664,7 +679,7 @@ public class MessageInputStream extends InputStream {
             readException = null;
             throw e;
         }
-        
+
         // Return end of stream immediately for handshake messages.
         try {
             if (this.isHandshake())
@@ -677,18 +692,18 @@ public class MessageInputStream extends InputStream {
             readException = null;
             throw new IOException("Error reading the payload chunk.", e);
         }
-        
+
         // Read from payloads until we are done or cannot read anymore.
         int bytesRead = 0;
         while (bytesRead < len) {
             final int read = (currentPayload != null) ? currentPayload.read(cbuf, off + bytesRead, len - bytesRead) : -1;
-            
+
             // If we read some data continue.
             if (read != -1) {
                 bytesRead += read;
                 continue;
             }
-            
+
             // Otherwise grab the next payload data.
             try {
                 currentPayload = nextData();
@@ -702,16 +717,31 @@ public class MessageInputStream extends InputStream {
                     readException = ioe;
                     return bytesRead;
                 }
-                
+
                 // Otherwise throw the exception now.
                 throw ioe;
             }
         }
-        
+
         // If nothing was read (but something was requested) return end of
         // stream.
         if (bytesRead == 0 && len > 0)
             return -1;
+
+        // If buffering data increment the read count.
+        if (payloads != null) {
+            readcount += bytesRead;
+
+            // If the read count exceeds the read limit stop buffering payloads
+            // and reset the read count and limit, but retain the payload
+            // iterator as we need to continue reading from any buffered data.
+            if (readcount > readlimit) {
+                payloads = null;
+                readcount = readlimit = 0;
+            }
+        }
+
+        // Return the number of bytes read.
         return bytesRead;
     }
 
@@ -728,6 +758,10 @@ public class MessageInputStream extends InputStream {
      */
     @Override
     public void reset() throws IOException {
+        // Do nothing if we are not buffering.
+        if (payloads == null)
+            return;
+
         // Reset all payloads and initialize the payload iterator.
         //
         // We need to reset the payloads since we are going to re-read them and
@@ -740,6 +774,9 @@ public class MessageInputStream extends InputStream {
         } else {
             currentPayload = null;
         }
+
+        // Reset the read count.
+        readcount = 0;
     }
 
     /* (non-Javadoc)
@@ -751,13 +788,13 @@ public class MessageInputStream extends InputStream {
         int bytesSkipped = 0;
         while (bytesSkipped < n) {
             final long skipped = (currentPayload != null) ? currentPayload.skip(n - bytesSkipped) : 0;
-            
+
             // If we skipped some data continue.
             if (skipped != 0) {
                 bytesSkipped += skipped;
                 continue;
             }
-            
+
             // Otherwise grab the next payload data.
             try {
                 currentPayload = nextData();
@@ -771,43 +808,47 @@ public class MessageInputStream extends InputStream {
         }
         return bytesSkipped;
     }
-    
+
     /** MSL context. */
     private final MslContext ctx;
     /** MSL input stream. */
     private final InputStream source;
     /** MSL tokenizer. */
     private final MslTokenizer tokenizer;
-    
+
     /** Header. */
     private final Header header;
     /** Payload crypto context. */
     private final ICryptoContext cryptoContext;
     /** Key exchange crypto context. */
     private final ICryptoContext keyxCryptoContext;
-    
+
     /** Current payload sequence number. */
     private long payloadSequenceNumber = 1;
     /** End of message reached. */
     private boolean eom = false;
     /** Handshake message. */
     private Boolean handshake = null;
-    
+
     /** True if the source input stream should be closed. */
     private boolean closeSource = false;
-    
+
     /**
-     * Buffered payload data.
-     * 
-     * This list contains all payload data that has been read since the last
-     * call to {@link #mark(int)}.
+     * Buffered payload data. Not null if buffering data.
+     *
+     * This list contains all payload data that has been referenced since the
+     * last call to {@link #mark(int)}.
      */
-    private final List<ByteArrayInputStream> payloads = new LinkedList<ByteArrayInputStream>();
+    private List<ByteArrayInputStream> payloads = null;
     /** Buffered payload data iterator. Not null if reading buffered data. */
     private ListIterator<ByteArrayInputStream> payloadIterator = null;
+    /** Mark read limit. */
+    private int readlimit = 0;
+    /** Mark read count. */
+    private int readcount = 0;
     /** Current payload chunk data. */
     private ByteArrayInputStream currentPayload = null;
-    
+
     /** Cached read exception. */
     private IOException readException = null;
 }

--- a/core/src/main/javascript/io/InputStream.js
+++ b/core/src/main/javascript/io/InputStream.js
@@ -50,10 +50,24 @@
 	     * Marks the current position in this input stream. A subsequent call to
 	     * the reset method repositions this stream at the last marked position so
 	     * that subsequent reads re-read the same bytes.
+         *
+         * <p> The <code>readlimit</code> arguments tells this input stream to
+         * allow that many bytes to be read before the mark position gets
+         * invalidated.
+         *
+         * <p> The general contract of <code>mark</code> is that, if the method
+         * <code>markSupported</code> returns <code>true</code>, the stream somehow
+         * remembers all the bytes read after the call to <code>mark</code> and
+         * stands ready to supply those same bytes again if and whenever the method
+         * <code>reset</code> is called.  However, the stream is not required to
+         * remember any data at all if more than <code>readlimit</code> bytes are
+         * read from the stream before <code>reset</code> is called.
 	     *
+	     * @param {number=} readlimit optional maximum limit of bytes that can
+	     *                  be read before the mark position becomes invalid.
 	     * @see #reset()
 	     */
-	    mark: function() {},
+	    mark: function(readlimit) {},
 	
 	    /**
 	     * Repositions this stream to the position at the time the mark method was

--- a/core/src/main/javascript/io/MslEncoderFactory.js
+++ b/core/src/main/javascript/io/MslEncoderFactory.js
@@ -123,7 +123,7 @@
                 
                 // Read the byte stream identifier.
                 var bufferedSource = source.markSupported() ? source : new BufferedInputStream(source);
-                bufferedSource.mark();
+                bufferedSource.mark(1);
                 bufferedSource.read(1, timeout, {
                     result: function(bytes) {
                         AsyncExecutor(callback, function() {

--- a/core/src/main/javascript/io/Url.js
+++ b/core/src/main/javascript/io/Url.js
@@ -240,9 +240,9 @@
         },
 
         /** @inheritDoc */
-        mark: function mark() {
+        mark: function mark(readlimit) {
             if (this._buffer)
-                this._buffer.mark();
+                this._buffer.mark(readlimit);
             // If the buffer doesn't exist yet, it is implicitly marked as that
             // is the behavior of ByteArrayInputStream.
         },

--- a/core/src/main/javascript/msg/ConsoleFilterStreamFactory.js
+++ b/core/src/main/javascript/msg/ConsoleFilterStreamFactory.js
@@ -52,8 +52,8 @@
         },
         
         /** @inheritDoc */
-        mark: function mark() {
-        	this._input.mark();
+        mark: function mark(readlimit) {
+            this._input.mark(readlimit);
         },
         
         /** @inheritDoc */

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -224,11 +224,33 @@
                         _eom: { value: false, writable: true, enumerable: false, configurable: false },
                         _handshake: { value: null, writable: true, enumerable: false, configurable: false },
                         _closeSource: { value: false, writable: true, enumerable: false, configurable: false },
-                        /** @type {Array.<Uint8Array>} */
+                        /**
+                         * Buffered payload data.
+                         * 
+                         * @type {Array.<Uint8Array>}
+                         */
                         _payloads: { value: [], writable: true, enumerable: false, configurable: false },
                         _payloadIndex: { value: -1, writable: true, enumerable: false, configurable: false },
                         _payloadOffset: { value: 0, writable: true, enuemrable: false, configurable: false },
-                        _markOffset: { value: 0, writable: true, enumerable: false, configurable: false },
+                        /**
+                         * First payload byte offset when {@link #mark(int)}
+                         * was called. Will be -1 if not buffering data.
+                         * 
+                         * @type {number}
+                         */
+                        _markOffset: { value: -1, writable: true, enumerable: false, configurable: false },
+                        /**
+                         * Mark read limit. -1 for no limit.
+                         * 
+                         * @type {number}
+                         */
+                        _readlimit: { value: 0, writable: true, enumerable: false, configurable: false },
+                        /**
+                         * Mark read count.
+                         * 
+                         * @type {number}
+                         */
+                        _readcount: { value: 0, writable: true, enumerable: false, configurable: false },
                         _currentPayload: { value: null, writable: true, enumerable: false, configurable: false },
                         _readException: { value: null, writable: true, enumerable: false, configurable: false },
                         // Set true once the header has been read and payloads may
@@ -755,12 +777,13 @@
                                         if (payload.isEndOfMessage())
                                             this._eom = true;
 
-                                        // Save the payload in the buffer and return it. We have to
-                                        // unset the payload iterator since we're adding to the
-                                        // payloads list.
+                                        // If mark was called save the payload in the buffer. We have to unset
+                                        // the payload iterator since we're adding to the payloads list.
                                         var data = payload.data;
-                                        this._payloads.push(data);
-                                        this._payloadIndex = -1;
+                                        if (this._markOffset != -1) {
+                                            this._payloads.push(data);
+                                            this._payloadIndex = -1;
+                                        }
                                         return data;
                                     }, self);
                                 },
@@ -1030,12 +1053,23 @@
         },
 
         /** @inheritDoc */
-        mark: function mark() {
+        mark: function mark(readlimit) {
+            // Remember the read limit, reset the read count.
+            this._readlimit = (readlimit) ? readlimit : -1;
+            this._readcount = 0;
+
+            // Start buffering.
+            this._markOffset = 0;
+            
             // If there is a current payload...
             if (this._currentPayload) {
                 // Remove all buffered data earlier than the current payload.
                 while (this._payloads.length > 0 && this._payloads[0] !== this._currentPayload)
                     this._payloads.shift();
+                
+                // Add the current payload if it was not already buffered.
+                if (this._payloads.length == 0)
+                    this._payloads.push(this._currentPayload);
 
                 // Reset the iterator to continue reading buffered data from the
                 // current payload.
@@ -1190,6 +1224,19 @@
                                     read = count;
                                     dataOffset += count;
                                     this._payloadOffset += count;
+
+                                    // If buffering data increment the read count.
+                                    if (this._markOffset != -1) {
+                                        this._readcount += count;
+                                        
+                                        // If the read count exceeds the read limit stop buffering payloads
+                                        // and reset the read count and limit, but retain the payload
+                                        // iterator as we need to continue reading from any buffered data.
+                                        if (this._readlimit != -1 && this._readcount > this._readlimit) {
+                                            this._markOffset = -1;
+                                            this._readcount = this._readlimit = 0;
+                                        }
+                                    }
                                 }
                             }
 
@@ -1259,6 +1306,10 @@
 
         /** @inheritDoc */
         reset: function reset() {
+            // Do nothing if we are not buffering.
+            if (this._markOffset == -1)
+                return;
+            
             // Reset all payloads and initialize the payload iterator.
             //
             // We need to reset the payloads since we are going to re-read them and
@@ -1270,6 +1321,9 @@
             } else {
                 this._currentPayload = null;
             }
+            
+            // Reset the read count.
+            this._readcount = 0;
         },
     });
 

--- a/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
@@ -46,8 +46,8 @@ var SimpleFilterStreamFactory;
         },
         
         /** @inheritDoc */
-        mark: function mark() {
-            this._input.mark();
+        mark: function mark(readlimit) {
+            this._input.mark(readlimit);
         },
         
         /** @inheritDoc */

--- a/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -44,7 +44,6 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -94,7 +93,7 @@ import com.netflix.msl.util.MslTestUtils;
 
 /**
  * Message input stream unit tests.
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class MessageInputStreamTest {
@@ -107,7 +106,7 @@ public class MessageInputStreamTest {
     private static final int MAX_DATA_SIZE = 100 * 1024;
     /** Non-replayable ID acceptance window. */
     private static final long NON_REPLAYABLE_ID_WINDOW = 65536;
-    
+
     /** Random. */
     private static Random random = new Random();
     /** Trusted network MSL context. */
@@ -122,18 +121,18 @@ public class MessageInputStreamTest {
     private static final List<PayloadChunk> payloads = new ArrayList<PayloadChunk>();
     /** Data read buffer. */
     private static byte[] buffer;
-    
+
     private static MessageHeader MESSAGE_HEADER;
     private static ErrorHeader ERROR_HEADER;
     private static final Set<KeyRequestData> KEY_REQUEST_DATA = new HashSet<KeyRequestData>();
     private static KeyResponseData KEY_RESPONSE_DATA;
     private static ICryptoContext KEYX_CRYPTO_CONTEXT, ALT_MSL_CRYPTO_CONTEXT;
-    
+
     private static final long SEQ_NO = 1;
     private static final long MSG_ID = 42;
     private static final boolean END_OF_MSG = true;
     private static final byte[] DATA = new byte[32];
-    
+
     /**
      * A crypto context that always returns false for verify. The other crypto
      * operations are no-ops.
@@ -147,11 +146,11 @@ public class MessageInputStreamTest {
             return false;
         }
     }
-    
+
     /**
      * Increments the provided non-replayable ID by 1, wrapping around to zero
      * if the provided value is equal to {@link MslConstants#MAX_LONG_VALUE}.
-     * 
+     *
      * @param id the non-replayable ID to increment.
      * @return the non-replayable ID + 1.
      * @throws MslInternalException if the provided non-replayable ID is out of
@@ -162,11 +161,11 @@ public class MessageInputStreamTest {
             throw new MslInternalException("Non-replayable ID " + id + " is outside the valid range.");
         return (id == MslConstants.MAX_LONG_VALUE) ? 0 : id + 1;
     }
-    
+
     /**
      * Create a new input stream containing a MSL message constructed from the
      * provided header and payloads.
-     * 
+     *
      * @param header message or error header.
      * @param payloads zero or more payload chunks.
      * @return an input stream containing the MSL message.
@@ -180,10 +179,10 @@ public class MessageInputStreamTest {
             baos.write(payload.toMslEncoding(encoder, ENCODER_FORMAT));
         return new ByteArrayInputStream(baos.toByteArray());
     }
-    
+
     @Rule
     public ExpectedMslException thrown = ExpectedMslException.none();
-    
+
     @BeforeClass
     public static void setup() throws MslMasterTokenException, MslEntityAuthException, MslException {
         trustedNetCtx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
@@ -191,21 +190,21 @@ public class MessageInputStreamTest {
         encoder = trustedNetCtx.getMslEncoderFactory();
         random.nextBytes(DATA);
         buffer = new byte[MAX_PAYLOAD_CHUNKS * MAX_DATA_SIZE];
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         MESSAGE_HEADER = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         ERROR_HEADER =  new ErrorHeader(trustedNetCtx, entityAuthData, null, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
-        
+
         final KeyRequestData keyRequest = new SymmetricWrappedExchange.RequestData(KeyId.PSK);
         KEY_REQUEST_DATA.add(keyRequest);
         final KeyExchangeFactory factory = trustedNetCtx.getKeyExchangeFactory(keyRequest.getKeyExchangeScheme());
         final KeyExchangeData keyxData = factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequest, entityAuthData);
         KEY_RESPONSE_DATA = keyxData.keyResponseData;
         KEYX_CRYPTO_CONTEXT = keyxData.cryptoContext;
-        
+
         final byte[] mke = new byte[16];
         final byte[] mkh = new byte[32];
         final byte[] mkw = new byte[16];
@@ -215,9 +214,9 @@ public class MessageInputStreamTest {
         final SecretKey encryptionKey = new SecretKeySpec(mke, JcaAlgorithm.AES);
         final SecretKey hmacKey = new SecretKeySpec(mkh, JcaAlgorithm.HMAC_SHA256);
         final SecretKey wrappingKey = new SecretKeySpec(mkw, JcaAlgorithm.AESKW);
-        ALT_MSL_CRYPTO_CONTEXT = new SymmetricCryptoContext(trustedNetCtx, "clientMslCryptoContext", encryptionKey, hmacKey, wrappingKey); 
+        ALT_MSL_CRYPTO_CONTEXT = new SymmetricCryptoContext(trustedNetCtx, "clientMslCryptoContext", encryptionKey, hmacKey, wrappingKey);
     }
-    
+
     @AfterClass
     public static void teardown() {
         ALT_MSL_CRYPTO_CONTEXT = null;
@@ -231,12 +230,12 @@ public class MessageInputStreamTest {
         p2pCtx = null;
         trustedNetCtx = null;
     }
-    
+
     @Before
     public void reset() {
         payloads.clear();
     }
-    
+
     @Test
     public void messageHeaderEmpty() throws MslEncodingException, MslException, IOException, MslEncoderException {
         // An end-of-message payload is expected.
@@ -244,7 +243,7 @@ public class MessageInputStreamTest {
         payloads.add(new PayloadChunk(trustedNetCtx, SEQ_NO, MSG_ID, END_OF_MSG, null, new byte[0], cryptoContext));
         final InputStream is = generateInputStream(MESSAGE_HEADER, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertEquals(0, mis.available());
         assertNull(mis.getErrorHeader());
         assertEquals(MESSAGE_HEADER, mis.getMessageHeader());
@@ -253,12 +252,12 @@ public class MessageInputStreamTest {
         assertEquals(-1, mis.read(buffer));
         assertEquals(-1, mis.read(buffer, 0, 1));
         assertEquals(0, mis.skip(1));
-        
+
         mis.mark(0);
         mis.reset();
         mis.close();
     }
-    
+
     @Test
     public void messageHeaderData() throws MslEncodingException, MslException, IOException, MslEncoderException {
         // An end-of-message payload is expected.
@@ -269,53 +268,53 @@ public class MessageInputStreamTest {
 
         assertEquals(DATA.length, mis.read(buffer));
         assertArrayEquals(DATA, Arrays.copyOf(buffer, DATA.length));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void entityAuthDataIdentity() throws MslException, IOException, MslEncoderException {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-     
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
 
         assertEquals(entityAuthData.getIdentity(), mis.getIdentity());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void masterTokenIdentity() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final MasterToken masterToken = MslTestUtils.getMasterToken(trustedNetCtx, 1, 1);
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
-     
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
 
         assertEquals(masterToken.getIdentity(), mis.getIdentity());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void errorHeaderIdentity() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, IOException, MslException, MslEncoderException {
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final ErrorHeader errorHeader = new ErrorHeader(trustedNetCtx, entityAuthData, null, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
-        
+
         final InputStream is = generateInputStream(errorHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertEquals(entityAuthData.getIdentity(), mis.getIdentity());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void revokedEntity() throws IOException, MslUserAuthException, MslKeyExchangeException, MslException, MslEncoderException {
         thrown.expect(MslEntityAuthException.class);
@@ -325,18 +324,18 @@ public class MessageInputStreamTest {
         final MockAuthenticationUtils authutils = new MockAuthenticationUtils();
         final UnauthenticatedAuthenticationFactory factory = new UnauthenticatedAuthenticationFactory(authutils);
         ctx.addEntityAuthenticationFactory(factory);
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
-     
+
         authutils.revokeEntity(entityAuthData.getIdentity());
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void revokedMasterToken() throws IOException, MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslException, MslEncoderException {
         thrown.expect(MslMasterTokenException.class);
@@ -345,7 +344,7 @@ public class MessageInputStreamTest {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
         final MockTokenFactory factory = new MockTokenFactory();
         ctx.setTokenFactory(factory);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
@@ -356,17 +355,17 @@ public class MessageInputStreamTest {
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void nullUser() throws MslEncodingException, MslEntityAuthException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, MslException, IOException, MslEncoderException {
         final InputStream is = generateInputStream(MESSAGE_HEADER, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertNull(mis.getUser());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void userIdTokenUser() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final MasterToken masterToken = MslTestUtils.getMasterToken(trustedNetCtx, 1, 1);
@@ -374,15 +373,15 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
-     
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
 
         assertEquals(userIdToken.getUser(), mis.getUser());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void revokedUserIdToken() throws IOException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, MslException, MslEncoderException {
         thrown.expect(MslUserIdTokenException.class);
@@ -391,19 +390,19 @@ public class MessageInputStreamTest {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
         final MockTokenFactory factory = new MockTokenFactory();
         ctx.setTokenFactory(factory);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(ctx, masterToken, 1, MockEmailPasswordAuthenticationFactory.USER);
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
-        
+
         factory.setRevokedUserIdToken(userIdToken);
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void untrustedUserIdToken() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, MslEncoderException, MslException, IOException {
         thrown.expect(MslUserIdTokenException.class);
@@ -412,19 +411,19 @@ public class MessageInputStreamTest {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
         final MockTokenFactory factory = new MockTokenFactory();
         ctx.setTokenFactory(factory);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
         final UserIdToken userIdToken = MslTestUtils.getUntrustedUserIdToken(ctx, masterToken, 1, MockEmailPasswordAuthenticationFactory.USER);
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
-        
+
         factory.setRevokedUserIdToken(userIdToken);
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     // FIXME This can be removed once the old handshake logic is removed.
     @Test
     public void explicitHandshake() throws IOException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, MslException, MslEncoderException {
@@ -432,15 +431,15 @@ public class MessageInputStreamTest {
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertTrue(mis.isHandshake());
-        
+
         mis.close();
     }
-    
+
     // FIXME This can be removed once the old handshake logic is removed.
     @Test
     public void inferredHandshake() throws MslException, IOException, MslEncoderException {
@@ -448,16 +447,16 @@ public class MessageInputStreamTest {
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         payloads.add(new PayloadChunk(trustedNetCtx, SEQ_NO, MSG_ID, END_OF_MSG, null, new byte[0], messageHeader.getCryptoContext()));
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertTrue(mis.isHandshake());
-        
+
         mis.close();
     }
-    
+
     // FIXME This can be removed once the old handshake logic is removed.
     @Test
     public void notHandshake() throws IOException, MslException, MslEncoderException {
@@ -465,55 +464,55 @@ public class MessageInputStreamTest {
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         payloads.add(new PayloadChunk(trustedNetCtx, SEQ_NO, MSG_ID, END_OF_MSG, null, DATA, messageHeader.getCryptoContext()));
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertFalse(mis.isHandshake());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void keyExchange() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         // Encrypt the payload with the key exchange crypto context.
         payloads.add(new PayloadChunk(trustedNetCtx, SEQ_NO, MSG_ID, END_OF_MSG, null, DATA, KEYX_CRYPTO_CONTEXT));
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertEquals(DATA.length, mis.read(buffer));
         assertArrayEquals(DATA, Arrays.copyOf(buffer, DATA.length));
         assertEquals(mis.getPayloadCryptoContext(), mis.getKeyExchangeCryptoContext());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void peerKeyExchange() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = p2pCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, entityAuthData, null, headerData, peerData);
-        
+
         // Encrypt the payload with the key exchange crypto context.
         final ICryptoContext cryptoContext = messageHeader.getCryptoContext();
         payloads.add(new PayloadChunk(p2pCtx, SEQ_NO, MSG_ID, END_OF_MSG, null, DATA, cryptoContext));
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(p2pCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertEquals(DATA.length, mis.read(buffer));
         assertArrayEquals(DATA, Arrays.copyOf(buffer, DATA.length));
         assertTrue(mis.getPayloadCryptoContext() != mis.getKeyExchangeCryptoContext());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void unsupportedKeyExchangeScheme() throws IOException, MslUserAuthException, MslException, MslEncoderException {
         thrown.expect(MslKeyExchangeException.class);
@@ -522,23 +521,23 @@ public class MessageInputStreamTest {
 
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
         ctx.removeKeyExchangeFactories(KeyExchangeScheme.SYMMETRIC_WRAPPED);
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void missingKeyRequestData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         // We need to replace the MSL crypto context before parsing the message
         // so create a local MSL context.
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, true);
-        
+
         thrown.expect(MslKeyExchangeException.class);
         thrown.expectMslError(MslError.KEYX_RESPONSE_REQUEST_MISMATCH);
         thrown.expectMessageId(MSG_ID);
@@ -547,20 +546,20 @@ public class MessageInputStreamTest {
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
-        
+
         ctx.setMslCryptoContext(new RejectingCryptoContext());
         final InputStream is = generateInputStream(messageHeader, payloads);
         final Set<KeyRequestData> keyRequestData = Collections.emptySet();
         final MessageInputStream mis = new MessageInputStream(ctx, is, keyRequestData, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void incompatibleKeyRequestData() throws MslKeyExchangeException, MslCryptoException, MslEncodingException, MslEntityAuthException, MslMasterTokenException, MslMessageException, MslUserAuthException, IOException, MslException, MslEncoderException {
         // We need to replace the MSL crypto context before parsing the message
         // so create a local MSL context.
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, true);
-        
+
         thrown.expect(MslKeyExchangeException.class);
         thrown.expectMslError(MslError.KEYX_RESPONSE_REQUEST_MISMATCH);
         thrown.expectMessageId(MSG_ID);
@@ -573,7 +572,7 @@ public class MessageInputStreamTest {
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final KeyExchangeData keyExchangeData = factory.generateResponse(ctx, ENCODER_FORMAT, keyRequest, entityAuthData);
         final KeyResponseData keyResponseData = keyExchangeData.keyResponseData;
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
@@ -583,7 +582,7 @@ public class MessageInputStreamTest {
         final MessageInputStream mis = new MessageInputStream(ctx, is, keyRequestData, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void oneCompatibleKeyRequestData() throws IOException, MslUserAuthException, MslException, MslEncoderException {
         // Populate the key request data such that the compatible data requires
@@ -593,21 +592,21 @@ public class MessageInputStreamTest {
         keyRequestData.add(new SymmetricWrappedExchange.RequestData(KeyId.SESSION));
         keyRequestData.add(keyRequest);
         keyRequestData.add(new SymmetricWrappedExchange.RequestData(KeyId.SESSION));
-        
+
         final KeyExchangeFactory factory = trustedNetCtx.getKeyExchangeFactory(keyRequest.getKeyExchangeScheme());
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final KeyExchangeData keyExchangeData = factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequest, entityAuthData);
         final KeyResponseData keyResponseData = keyExchangeData.keyResponseData;
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, keyRequestData, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredRenewableClientMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
@@ -616,12 +615,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredRenewablePeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
@@ -630,12 +629,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(p2pCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredNotRenewableClientMessage() throws IOException, MslUserAuthException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -650,12 +649,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredNoKeyRequestDataClientMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -670,16 +669,16 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredNotRenewableServerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslEncoderException, MslException, IOException {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
-        
+
         // Expired messages received by a trusted network client should not be
         // rejected.
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
@@ -693,10 +692,10 @@ public class MessageInputStreamTest {
         // constructed it after a previous message exchange.
         final ICryptoContext cryptoContext = new SessionCryptoContext(ctx, masterToken);
         ctx.getMslStore().setCryptoContext(masterToken, cryptoContext);
-        
+
         // Generate the input stream. This will encode the message.
         final InputStream is = generateInputStream(messageHeader, payloads);
-        
+
         // Change the MSL crypto context so the master token can no longer be
         // verified or decrypted.
         ctx.setMslCryptoContext(ALT_MSL_CRYPTO_CONTEXT);
@@ -706,7 +705,7 @@ public class MessageInputStreamTest {
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredNoKeyRequestDataPeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -719,12 +718,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(p2pCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void expiredNotRenewablePeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -737,12 +736,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(p2pCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void handshakeNotRenewable() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -753,12 +752,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, false, true, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void handshakeMissingKeyRequestData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -769,12 +768,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, true, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void nonReplayableNoMasterTokenClientMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -785,12 +784,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void nonReplayableNoMasterTokenPeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -801,12 +800,12 @@ public class MessageInputStreamTest {
         final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(p2pCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void nonReplayableIdEqual() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -815,12 +814,12 @@ public class MessageInputStreamTest {
 
         final long nonReplayableId = 1L;
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1L, 1L);
         final MockTokenFactory factory = new MockTokenFactory();
         factory.setLargestNonReplayableId(nonReplayableId);
         ctx.setTokenFactory(factory);
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
@@ -829,7 +828,7 @@ public class MessageInputStreamTest {
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void nonReplayableIdSmaller() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -838,12 +837,12 @@ public class MessageInputStreamTest {
 
         final long nonReplayableId = 2L;
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1L, 1L);
         final MockTokenFactory factory = new MockTokenFactory();
         factory.setLargestNonReplayableId(nonReplayableId);
         ctx.setTokenFactory(factory);
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, nonReplayableId - 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
@@ -852,15 +851,15 @@ public class MessageInputStreamTest {
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void nonReplayableIdOutsideWindow() throws IOException, MslUserAuthException, MslKeyExchangeException, MslException, MslEncoderException {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1L, 1L);
         final MockTokenFactory factory = new MockTokenFactory();
         ctx.setTokenFactory(factory);
-        
+
         long largestNonReplayableId = MslConstants.MAX_LONG_VALUE - NON_REPLAYABLE_ID_WINDOW - 1;
         long nonReplayableId = MslConstants.MAX_LONG_VALUE;
         for (int i = 0; i < 2; ++i) {
@@ -881,20 +880,20 @@ public class MessageInputStreamTest {
             } finally {
                 if (mis != null) mis.close();
             }
-            
+
             largestNonReplayableId = incrementNonReplayableId(largestNonReplayableId);
             nonReplayableId = incrementNonReplayableId(nonReplayableId);
         }
     }
-    
+
     @Test
     public void nonReplayableIdInsideWindow() throws MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1L, 1L);
         final MockTokenFactory factory = new MockTokenFactory();
         ctx.setTokenFactory(factory);
-        
+
         long largestNonReplayableId = MslConstants.MAX_LONG_VALUE - NON_REPLAYABLE_ID_WINDOW;
         long nonReplayableId = MslConstants.MAX_LONG_VALUE;
         for (int i = 0; i < NON_REPLAYABLE_ID_WINDOW + 1; ++i) {
@@ -913,12 +912,12 @@ public class MessageInputStreamTest {
             } finally {
                 if (mis != null) mis.close();
             }
-            
+
             largestNonReplayableId = incrementNonReplayableId(largestNonReplayableId);
             nonReplayableId = incrementNonReplayableId(nonReplayableId);
         }
     }
-    
+
     @Test
     public void replayedClientMessage() throws MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -926,21 +925,21 @@ public class MessageInputStreamTest {
         thrown.expectMessageId(MSG_ID);
 
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1L, 1L);
         final MockTokenFactory factory = new MockTokenFactory();
         factory.setLargestNonReplayableId(1L);
         ctx.setTokenFactory(factory);
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void replayedPeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
@@ -948,36 +947,36 @@ public class MessageInputStreamTest {
         thrown.expectMessageId(MSG_ID);
 
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, true);
-        
+
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1L, 1L);
         final MockTokenFactory factory = new MockTokenFactory();
         factory.setLargestNonReplayableId(1L);
         ctx.setTokenFactory(factory);
-        
+
         final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(ctx, is, KEY_REQUEST_DATA, cryptoContexts);
         mis.close();
     }
-    
+
     @Test
     public void errorHeader() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslException, IOException, MslEncoderException {
         final InputStream is = generateInputStream(ERROR_HEADER, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
-        
+
         assertEquals(0, mis.available());
         assertEquals(ERROR_HEADER, mis.getErrorHeader());
         assertNull(mis.getMessageHeader());
         assertTrue(mis.markSupported());
-        
+
         mis.mark(0);
         mis.reset();
         mis.close();
     }
-    
+
     @Test(expected = MslInternalException.class)
     public void readFromError() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslException, IOException, MslEncoderException {
         final InputStream is = generateInputStream(ERROR_HEADER, payloads);
@@ -988,21 +987,21 @@ public class MessageInputStreamTest {
             mis.close();
         }
     }
-    
+
     @Test
     public void readFromHandshakeMessage() throws IOException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, MslException, MslEncoderException {
         final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
-        
+
         final InputStream is = generateInputStream(messageHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
         final int read = mis.read();
         assertEquals(-1, read);
         mis.close();
     }
-    
+
     @Test
     public void missingEndOfMessage() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslException, IOException, MslEncoderException {
         final InputStream is = generateInputStream(MESSAGE_HEADER, payloads);
@@ -1010,10 +1009,10 @@ public class MessageInputStreamTest {
 
         // If there's nothing left we'll receive end of message anyway.
         assertEquals(-1, mis.read(buffer));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void prematureEndOfMessage() throws MslCryptoException, MslEncodingException, MslException, IOException, MslEncoderException {
         // Payloads after an end of message are ignored.
@@ -1037,10 +1036,10 @@ public class MessageInputStreamTest {
         // Read everything. We shouldn't get any of the extra payloads.
         assertEquals(appdata.length, mis.read(buffer));
         assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void mismatchedMessageId() throws MslCryptoException, MslEncodingException, MslException, IOException, MslEncoderException {
         // Payloads with an incorrect message ID should be skipped.
@@ -1077,10 +1076,10 @@ public class MessageInputStreamTest {
         }
         assertEquals(badPayloads, caughtExceptions);
         assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void incorrectSequenceNumber() throws MslCryptoException, MslEncodingException, MslException, IOException, MslEncoderException {
         // Payloads with an incorrect sequence number should be skipped.
@@ -1117,10 +1116,10 @@ public class MessageInputStreamTest {
         }
         assertEquals(badPayloads, caughtExceptions);
         assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void markReset() throws MslEncodingException, MslCryptoException, MslException, IOException, MslEncoderException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -1146,7 +1145,7 @@ public class MessageInputStreamTest {
         mis.reset();
         assertEquals(expectedBeginning.length, mis.read(buffer, beginningOffset, beginningLength));
         assertArrayEquals(expectedBeginning, Arrays.copyOfRange(buffer, beginningOffset, beginningTo));
-        
+
         // Mark and reset from where we are.
         final int middleOffset = beginningTo;
         final int middleLength = appdata.length / 4;
@@ -1158,7 +1157,7 @@ public class MessageInputStreamTest {
         mis.reset();
         assertEquals(expectedMiddle.length, mis.read(buffer, middleOffset, middleLength));
         assertArrayEquals(expectedMiddle, Arrays.copyOfRange(buffer, middleOffset, middleTo));
-        
+
         // Mark and reset the remainder.
         final int endingOffset = middleTo;
         final int endingLength = appdata.length - middleLength - beginningLength;
@@ -1170,13 +1169,13 @@ public class MessageInputStreamTest {
         mis.reset();
         assertEquals(expectedEnding.length, mis.read(buffer, endingOffset, endingLength));
         assertArrayEquals(expectedEnding, Arrays.copyOfRange(buffer, endingOffset, endingTo));
-        
+
         // Confirm equality.
         assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void markResetShortMark() throws IOException, MslEncodingException, MslEntityAuthException, MslUserAuthException, MslException, MslEncoderException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -1195,18 +1194,18 @@ public class MessageInputStreamTest {
         final int beginningOffset = 0;
         final int beginningLength = appdata.length / 2;
         final int beginningTo = beginningOffset + beginningLength;
-        final byte[] expectedBeginning = Arrays.copyOfRange(appdata, beginningOffset, beginningLength);
+        final byte[] expectedBeginning = Arrays.copyOfRange(appdata, beginningOffset, beginningTo);
         mis.mark(appdata.length);
         assertEquals(expectedBeginning.length, mis.read(buffer, beginningOffset, beginningLength));
         assertArrayEquals(expectedBeginning, Arrays.copyOfRange(buffer, beginningOffset, beginningTo));
         mis.reset();
-        
+
         // Read a little bit, and mark again so we drop one or more payloads
         // but are likely to have more than one payload remaining.
         final byte[] reread = new byte[appdata.length / 4];
         assertEquals(reread.length, mis.read(reread));
         mis.mark(appdata.length);
-        
+
         // Read the remainder, reset, and re-read to confirm.
         final int endingOffset = reread.length;
         final int endingLength = appdata.length - endingOffset;
@@ -1217,20 +1216,128 @@ public class MessageInputStreamTest {
         mis.reset();
         assertEquals(expectedEnding.length, mis.read(buffer, endingOffset, endingLength));
         assertArrayEquals(expectedEnding, Arrays.copyOfRange(buffer, endingOffset, endingTo));
-        
+
         // Confirm equality.
         assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
-        
+
         mis.close();
     }
-    
-    @Ignore
+
     @Test
-    public void markReadlimit() {
-        // This isn't a legitimate test as the behavior when exceeding the
-        // readlimit is nondeterministic.
+    public void markOneReadlimit() throws IOException, MslEncodingException, MslEntityAuthException, MslUserAuthException, MslException, MslEncoderException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ICryptoContext cryptoContext = MESSAGE_HEADER.getCryptoContext();
+        for (int i = 0; i < MAX_PAYLOAD_CHUNKS; ++i) {
+            final byte[] data = new byte[random.nextInt(MAX_DATA_SIZE) + 1];
+            random.nextBytes(data);
+            payloads.add(new PayloadChunk(trustedNetCtx, SEQ_NO + i, MSG_ID, (i == MAX_PAYLOAD_CHUNKS - 1), null, data, cryptoContext));
+            baos.write(data);
+        }
+        final byte[] appdata = baos.toByteArray();
+        final InputStream is = generateInputStream(MESSAGE_HEADER, payloads);
+        final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
+
+        // Mark one byte and reset to the beginning.
+        final byte expectedOne = appdata[0];
+        mis.mark(1);
+        assertEquals(expectedOne, mis.read());
+        mis.reset();
+
+        // Read a little bit and reset (which should not work).
+        final int beginningOffset = 0;
+        final int beginningLength = appdata.length / 2;
+        final int beginningTo = beginningOffset + beginningLength;
+        final byte[] expectedBeginning = Arrays.copyOfRange(appdata, beginningOffset, beginningTo);
+        assertEquals(expectedBeginning.length, mis.read(buffer, beginningOffset, beginningLength));
+        assertArrayEquals(expectedBeginning, Arrays.copyOfRange(buffer, beginningOffset, beginningTo));
+        mis.reset();
+
+        // Read the remainder.
+        final int endingOffset = beginningLength;
+        final int endingLength = appdata.length - endingOffset;
+        final int endingTo = endingOffset + endingLength;
+        final byte[] expectedEnding = Arrays.copyOfRange(appdata, endingOffset, endingTo);
+        assertEquals(expectedEnding.length, mis.read(buffer, endingOffset, endingLength));
+        assertArrayEquals(expectedEnding, Arrays.copyOfRange(buffer, endingOffset, endingTo));
+
+        // Confirm equality.
+        assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
+
+        // Confirm end-of-stream.
+        assertEquals(-1, mis.read());
+
+        mis.close();
     }
-    
+
+    @Test
+    public void markReadLimit() throws IOException, MslEncodingException, MslEntityAuthException, MslUserAuthException, MslException, MslEncoderException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ICryptoContext cryptoContext = MESSAGE_HEADER.getCryptoContext();
+        for (int i = 0; i < MAX_PAYLOAD_CHUNKS; ++i) {
+            final byte[] data = new byte[random.nextInt(MAX_DATA_SIZE) + 1];
+            random.nextBytes(data);
+            payloads.add(new PayloadChunk(trustedNetCtx, SEQ_NO + i, MSG_ID, (i == MAX_PAYLOAD_CHUNKS - 1), null, data, cryptoContext));
+            baos.write(data);
+        }
+        final byte[] appdata = baos.toByteArray();
+        final InputStream is = generateInputStream(MESSAGE_HEADER, payloads);
+        final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
+
+        // Read a little bit and mark with a short read limit.
+        final int beginningOffset = 0;
+        final int beginningLength = appdata.length / 4;
+        final int beginningTo = beginningOffset + beginningLength;
+        final byte[] expectedBeginning = Arrays.copyOfRange(appdata, beginningOffset, beginningTo);
+        assertEquals(expectedBeginning.length, mis.read(buffer, beginningOffset, beginningLength));
+        assertArrayEquals(expectedBeginning, Arrays.copyOfRange(buffer, beginningOffset, beginningTo));
+        final int readlimit = appdata.length / 8;
+        mis.mark(readlimit);
+
+        // Read up to the read limit.
+        final int readOffset = beginningLength;
+        final int readLength = readlimit;
+        final int readTo = readOffset + readLength;
+        final byte[] expectedRead = Arrays.copyOfRange(appdata, readOffset, readTo);
+        assertEquals(expectedRead.length, mis.read(buffer, readOffset, readLength));
+        assertArrayEquals(expectedRead, Arrays.copyOfRange(buffer, readOffset, readTo));
+
+        // Reset and re-read.
+        mis.reset();
+        assertEquals(expectedRead.length, mis.read(buffer, readOffset, readLength));
+        assertArrayEquals(expectedRead, Arrays.copyOfRange(buffer, readOffset, readTo));
+
+        // Reset and re-read.
+        mis.reset();
+        assertEquals(expectedRead.length, mis.read(buffer, readOffset, readLength));
+        assertArrayEquals(expectedRead, Arrays.copyOfRange(buffer, readOffset, readTo));
+
+        // Reset and read past the read limit.
+        mis.reset();
+        final int readPastOffset = beginningLength;
+        final int readPastLength = readlimit + 1;
+        final int readPastTo = readPastOffset + readPastLength;
+        final byte[] expectedReadPast = Arrays.copyOfRange(appdata, readPastOffset, readPastTo);
+        assertEquals(expectedReadPast.length, mis.read(buffer, readPastOffset, readPastLength));
+        assertArrayEquals(expectedReadPast, Arrays.copyOfRange(buffer, readPastOffset, readPastTo));
+
+        // Reset and confirm it did not work.
+        mis.reset();
+        final int endingOffset = readPastTo;
+        final int endingLength = appdata.length - endingOffset;
+        final int endingTo = appdata.length;
+        final byte[] expectedEnding = Arrays.copyOfRange(appdata, endingOffset, endingTo);
+        assertEquals(expectedEnding.length, mis.read(buffer, endingOffset, endingLength));
+        assertArrayEquals(expectedEnding, Arrays.copyOfRange(buffer, endingOffset, endingTo));
+
+        // Confirm equality.
+        assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
+
+        // Confirm end-of-stream.
+        assertEquals(-1, mis.read());
+
+        mis.close();
+    }
+
     @Test
     public void available() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslException, IOException, MslEncoderException {
         final ICryptoContext cryptoContext = MESSAGE_HEADER.getCryptoContext();
@@ -1247,24 +1354,24 @@ public class MessageInputStreamTest {
         final int firstLength = payloads.get(0).getData().length;
         mis.read();
         assertEquals(firstLength - 1, mis.available());
-        
+
         // Mark and read the remainder. Nothing should be available.
         mis.mark(buffer.length);
         final int bytesRead = mis.read(buffer);
         assertEquals(0, mis.available());
-        
+
         // Reset. Everything except for the original one byte should be
         // available.
         mis.reset();
         assertEquals(bytesRead, mis.available());
-        
+
         // Read a little bit. Reset. Confirm the amount available.
         final int shortRead = mis.read(buffer, 0, bytesRead / 10);
         assertEquals(bytesRead - shortRead, mis.available());
-        
+
         mis.close();
     }
-    
+
     @Test
     public void skipAvailable() throws MslCryptoException, MslEncodingException, MslException, IOException, MslEncoderException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -1283,7 +1390,7 @@ public class MessageInputStreamTest {
         mis.mark(appdata.length);
         final int skipLength = appdata.length / 6;
         assertEquals(skipLength, mis.skip(skipLength));
-        
+
         // Confirm availability equal to the current payload's remaining data.
         int consumedBytes = 0;
         final ListIterator<PayloadChunk> chunks = payloads.listIterator();
@@ -1292,7 +1399,7 @@ public class MessageInputStreamTest {
             consumedBytes += payload.getData().length;
         }
         assertEquals(consumedBytes - skipLength, mis.available());
-        
+
         // Read and skip for a while.
         int skipped = skipLength;
         while (skipped < appdata.length) {
@@ -1302,7 +1409,7 @@ public class MessageInputStreamTest {
             assertEquals(expected.length, mis.read(buffer, skipped, readLength));
             assertArrayEquals(expected, Arrays.copyOfRange(buffer, skipped, readTo));
             skipped += expected.length;
-            
+
             // Confirm availability equal to the current payload's remaining
             // data.
             while (consumedBytes < skipped && chunks.hasNext()) {
@@ -1311,7 +1418,7 @@ public class MessageInputStreamTest {
             }
             assertEquals(consumedBytes - skipped, mis.available());
         }
-        
+
         // Reset and redo the read and skips now that the data is buffered.
         mis.reset();
         skipped = 0;
@@ -1322,17 +1429,17 @@ public class MessageInputStreamTest {
             assertEquals(expected.length, mis.read(buffer, skipped, readLength));
             assertArrayEquals(expected, Arrays.copyOfRange(buffer, skipped, readTo));
             skipped += expected.length;
-            
+
             // Confirm availability equal to the remaining data.
             assertEquals(appdata.length - skipped, mis.available());
         }
-        
+
         // Confirm equality.
         assertArrayEquals(appdata, Arrays.copyOfRange(buffer, 0, appdata.length));
-        
+
         mis.close();
     }
-    
+
     @Test
     public void largePayload() throws MslEncodingException, MslException, IOException, MslEncoderException {
         final ICryptoContext cryptoContext = MESSAGE_HEADER.getCryptoContext();
@@ -1346,7 +1453,7 @@ public class MessageInputStreamTest {
         assertEquals(copy.length, mis.read(copy));
         assertEquals(-1, mis.read());
         assertArrayEquals(data, copy);
-        
+
         mis.close();
     }
 }

--- a/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
@@ -1224,7 +1224,7 @@ public class MessageInputStreamTest {
     }
 
     @Test
-    public void markOneReadlimit() throws IOException, MslEncodingException, MslEntityAuthException, MslUserAuthException, MslException, MslEncoderException {
+    public void markOneReadLimit() throws IOException, MslEncodingException, MslEntityAuthException, MslUserAuthException, MslException, MslEncoderException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ICryptoContext cryptoContext = MESSAGE_HEADER.getCryptoContext();
         for (int i = 0; i < MAX_PAYLOAD_CHUNKS; ++i) {

--- a/tests/src/test/javascript/msg/MessageInputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageInputStreamTest.js
@@ -3594,6 +3594,365 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return closed; }, "closed", MslTestConstants.TIMEOUT);
     });
+    
+    it("mark/reset with read limit of 1", function() {
+        var baos;
+        var i = 0;
+        runs(function() {
+            baos = new ByteArrayOutputStream();
+            var cryptoContext = MESSAGE_HEADER.cryptoContext;
+            function writePayload() {
+                if (i == MAX_PAYLOAD_CHUNKS)
+                    return;
+
+                var data = new Uint8Array(random.nextInt(MAX_DATA_SIZE) + 1);
+                random.nextBytes(data);
+                PayloadChunk.create(trustedNetCtx, SEQ_NO + i, MSG_ID, (i == MAX_PAYLOAD_CHUNKS - 1), null, data, cryptoContext, {
+                    result: function(chunk) {
+                        payloads.push(chunk);
+                        baos.write(data, 0, data.length, TIMEOUT, {
+                            result: function(success) {
+                                ++i;
+                                writePayload();
+                            },
+                            timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                        });
+                    },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            }
+            writePayload();
+        });
+        waitsFor(function() { return i == MAX_PAYLOAD_CHUNKS; }, "payloads to be written", TIMEOUT);
+
+        var is;
+        runs(function() {
+            generateInputStream(MESSAGE_HEADER, payloads, {
+                result: function(x) { is = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return is; }, "is", MslTestConstants.TIMEOUT);
+
+        var mis;
+        runs(function() {
+            MessageInputStream.create(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts, TIMEOUT, {
+                result: function(x) { mis = x; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var appdata, buffer;
+        var oneRead = 0;
+        runs(function() {
+            buffer = new Uint8Array(MAX_READ_LEN);
+            appdata = baos.toByteArray();
+            
+            // Mark one byte and reset to the beginning.
+            mis.mark(1);
+            mis.read(1, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, 0);
+                    oneRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return oneRead > 0; }, "one read", TIMEOUT);
+        
+        var beginningRead = 0;
+        var beginningOffset, beginningLength;
+        runs(function() {
+            var expectedOne = appdata[0];
+            expect(buffer[0]).toEqual(expectedOne);
+            mis.reset();
+            
+            // Read a little bit and reset (which should not work).
+            beginningOffset = 0;
+            beginningLength = Math.floor(appdata.length / 2);
+            mis.read(beginningLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, beginningOffset);
+                    beginningRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return beginningRead > 0; }, "beginning read", TIMEOUT);
+        
+        var endingRead = 0;
+        var endingOffset, endingLength;
+        runs(function() {
+            var expectedBeginning = Arrays.copyOf(appdata, beginningOffset, beginningLength);
+            expect(beginningRead).toEqual(expectedBeginning.length);
+            var actualBeginning = Arrays.copyOf(buffer, beginningOffset, beginningLength);
+            expect(actualBeginning).toEqual(expectedBeginning);
+            mis.reset();
+            
+            // Read the remainder.
+            endingOffset = beginningLength;
+            endingLength = appdata.length - endingOffset;
+            mis.read(endingLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, endingOffset);
+                    endingRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return endingRead > 0; }, "ending read", TIMEOUT);
+
+        var eos;
+        runs(function() {
+            var expectedEnding = Arrays.copyOf(appdata, endingOffset, endingLength);
+            expect(endingRead).toEqual(expectedEnding.length);
+            var actualEnding = Arrays.copyOf(buffer, endingOffset, endingLength);
+            expect(actualEnding).toEqual(expectedEnding);
+            
+            // Confirm equality.
+            var actualdata = Arrays.copyOf(buffer, 0, appdata.length);
+            expect(actualdata).toEqual(appdata);
+            
+            // Confirm end-of-stream.
+            mis.read(-1, TIMEOUT, {
+                result: function(x) {
+                    eos = x;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return eos == null; }, "end-of-stream", TIMEOUT);
+        
+        var closed;
+        runs(function() {
+            mis.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", MslTestConstants.TIMEOUT);
+    });
+    
+    it("mark/reset with read limit", function() {
+        var baos;
+        var i = 0;
+        runs(function() {
+            baos = new ByteArrayOutputStream();
+            var cryptoContext = MESSAGE_HEADER.cryptoContext;
+            function writePayload() {
+                if (i == MAX_PAYLOAD_CHUNKS)
+                    return;
+
+                var data = new Uint8Array(random.nextInt(MAX_DATA_SIZE) + 1);
+                random.nextBytes(data);
+                PayloadChunk.create(trustedNetCtx, SEQ_NO + i, MSG_ID, (i == MAX_PAYLOAD_CHUNKS - 1), null, data, cryptoContext, {
+                    result: function(chunk) {
+                        payloads.push(chunk);
+                        baos.write(data, 0, data.length, TIMEOUT, {
+                            result: function(success) {
+                                ++i;
+                                writePayload();
+                            },
+                            timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                        });
+                    },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+                });
+            }
+            writePayload();
+        });
+        waitsFor(function() { return i == MAX_PAYLOAD_CHUNKS; }, "payloads to be written", TIMEOUT);
+
+        var is;
+        runs(function() {
+            generateInputStream(MESSAGE_HEADER, payloads, {
+                result: function(x) { is = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return is; }, "is", MslTestConstants.TIMEOUT);
+
+        var mis;
+        runs(function() {
+            MessageInputStream.create(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts, TIMEOUT, {
+                result: function(x) { mis = x; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var appdata, buffer;
+        var beginningRead = 0;
+        var beginningOffset, beginningLength;
+        runs(function() {
+            buffer = new Uint8Array(MAX_READ_LEN);
+            appdata = baos.toByteArray();
+            
+            // Read a little bit and mark with a short read limit.
+            beginningOffset = 0;
+            beginningLength = Math.floor(appdata.length / 4);
+            mis.read(beginningLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, beginningOffset);
+                    beginningRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return beginningRead > 0; }, "beginning read", TIMEOUT);
+        
+        var readlimit;
+        var readRead = 0;
+        var readOffset, readLength;
+        runs(function() {
+            var expectedBeginning = Arrays.copyOf(appdata, beginningOffset, beginningLength);
+            expect(beginningRead).toEqual(expectedBeginning.length);
+            var actualBeginning = Arrays.copyOf(buffer, beginningOffset, beginningLength);
+            expect(actualBeginning).toEqual(expectedBeginning);
+            readlimit = Math.floor(appdata.length / 8);
+            mis.mark(readlimit);
+            
+            // Read up to the read limit.
+            readOffset = beginningLength;
+            readLength = readlimit;
+            mis.read(readLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, readOffset);
+                    readRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return readRead > 0; }, "read read", TIMEOUT);
+        
+        var expectedRead;
+        runs(function() {
+            expectedRead = Arrays.copyOf(appdata, readOffset, readLength);
+            expect(readRead).toEqual(expectedRead.length);
+            var actualRead = Arrays.copyOf(buffer, readOffset, readLength);
+            expect(actualRead).toEqual(expectedRead);
+            
+            // Reset and re-read.
+            readRead = 0;
+            mis.reset();
+            mis.read(readLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, readOffset);
+                    readRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return readRead > 0; }, "re-read read", TIMEOUT);
+        
+        runs(function() {
+            expect(readRead).toEqual(expectedRead.length);
+            var actualRead = Arrays.copyOf(buffer, readOffset, readLength);
+            expect(actualRead).toEqual(expectedRead);
+            
+            // Reset and re-read.
+            readRead = 0;
+            mis.reset();
+            mis.read(readLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, readOffset);
+                    readRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return readRead > 0; }, "re-re-read read", TIMEOUT);
+        
+        var readPastRead = 0;
+        var readPastOffset, readPastLength;
+        runs(function() {
+            expect(readRead).toEqual(expectedRead.length);
+            var actualRead = Arrays.copyOf(buffer, readOffset, readLength);
+            expect(actualRead).toEqual(expectedRead);
+
+            // Reset and read past the read limit.
+            mis.reset();
+            readPastOffset = beginningLength;
+            readPastLength = readlimit + 1;
+            mis.read(readPastLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, readPastOffset);
+                    readPastRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return readPastRead > 0; }, "read past read", TIMEOUT);
+        
+        var endingRead;
+        var endingOffset, endingLength;
+        runs(function() {
+            var expectedReadPast = Arrays.copyOf(appdata, readPastOffset, readPastLength);
+            expect(readPastRead).toEqual(expectedReadPast.length);
+            var actualReadPast = Arrays.copyOf(buffer, readPastOffset, readPastLength);
+            expect(actualReadPast).toEqual(expectedReadPast);
+
+            // Reset and confirm it did not work.
+            mis.reset();
+            endingOffset = readPastOffset + readPastLength;
+            endingLength = appdata.length - endingOffset;
+            mis.read(endingLength, TIMEOUT, {
+                result: function(x) {
+                    buffer.set(x, endingOffset);
+                    endingRead = x.length;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return endingRead > 0; }, "ending read", TIMEOUT);
+        
+        runs(function() {
+            var expectedEnding = Arrays.copyOf(appdata, endingOffset, endingLength);
+            expect(endingRead).toEqual(expectedEnding.length);
+            var actualEnding = Arrays.copyOf(buffer, endingOffset, endingLength);
+            expect(actualEnding).toEqual(expectedEnding);
+
+            // Confirm equality.
+            var actualdata = Arrays.copyOf(buffer, 0, appdata.length);
+            expect(actualdata).toEqual(appdata);
+            
+            // Confirm end-of-stream.
+            mis.read(-1, TIMEOUT, {
+                result: function(x) {
+                    eos = x;
+                },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return eos == null; }, "end-of-stream", TIMEOUT);
+        
+        var closed;
+        runs(function() {
+            mis.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new Error('timedout'); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", MslTestConstants.TIMEOUT);
+    });
 
     it("large payload", function() {
         var data = new Uint8Array(250 * 1024);


### PR DESCRIPTION
Fixes #227. Caching will stop after the read limit (optional in JavaScript) is hit.