### PR TITLE
fix requires to work with both Module.js and Browserify

### DIFF
--- a/core/src/main/javascript/crypto/X509.js
+++ b/core/src/main/javascript/crypto/X509.js
@@ -22,5 +22,5 @@
 (function(require, module) {
     "use strict";
     
-    var X509 = module.exports = require('jsrsasign').X509;
+    var X509 = module.exports = require('../lib/jsrsasign.js').X509;
 })(require, (typeof module !== 'undefined') ? module : mkmodule('X509'));

--- a/core/src/main/javascript/entityauth/X509AuthenticationData.js
+++ b/core/src/main/javascript/entityauth/X509AuthenticationData.js
@@ -45,7 +45,7 @@
     var MslError = require('../MslError.js');
     var X509 = require('../crypto/X509.js');
     
-    var hex2b64 = require('jsrsasign').hex2b64;
+    var hex2b64 = require('../lib/jsrsasign.js').hex2b64;
     
     /**
      * Key entity X.509 certificate.

--- a/core/src/main/javascript/io/ClarinetParser.js
+++ b/core/src/main/javascript/io/ClarinetParser.js
@@ -24,7 +24,7 @@
 	"use strict";
 	
 	var Class = require('../util/Class.js');
-	var clarinet = require('clarinet');
+	var clarinet = require('../lib/clarinet.js');
 		
 	var ClarinetParser = module.exports = Class.create({
 	    /**


### PR DESCRIPTION
This fix (pointing requires to a fully qualified path) allows the modules to be picked up by either Module.js or Browserify.

Also, my editor apparently refuses to save a file without the last line ending in a newline.