### PR TITLE
Add module support to SimpleClient

### DIFF
--- a/examples/simple/src/main/javascript/client/App.js
+++ b/examples/simple/src/main/javascript/client/App.js
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-// msl requires
-var KeyFormat = require('../../../../../../core/src/main/javascript/crypto/KeyFormat.js');
-var MslConstants = require('../../../../../../core/src/main/javascript/MslConstants.js');
-var PublicKey = require('../../../../../../core/src/main/javascript/crypto/PublicKey.js');
-var TextEncoding = require('../../../../../../core/src/main/javascript/util/TextEncoding.js');
-var WebCryptoAlgorithm = require('../../../../../../core/src/main/javascript/crypto/WebCryptoAlgorithm.js');
-var WebCryptoUsage = require('../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js');
+var KeyFormat = require('msl-core/crypto/KeyFormat.js');
+var MslConstants = require('msl-core/MslConstants.js');
+var PublicKey = require('msl-core/crypto/PublicKey.js');
+var TextEncoding = require('msl-core/util/TextEncoding.js');
+var WebCryptoAlgorithm = require('msl-core/crypto/WebCryptoAlgorithm.js');
+var WebCryptoUsage = require('msl-core/crypto/WebCryptoUsage.js');
 
-// simple client requires
 var AdvancedRequest = require('./msg/AdvancedRequest.js');
 var SimpleClient$create = require('./SimpleClient.js').create;
 var SimpleConstants = require('./SimpleConstants.js');
 var SimpleEchoRequest = require('./msg/SimpleEchoRequest.js');
 var SimpleFilterStreamFactory = require('./msg/SimpleFilterStreamFactory.js');
-var SimpleLogRequest = require('./msg/SimpleLogRequest.js').SimpleLogRequest;
+var SimpleLogRequest = require('./msg/SimpleLogRequest.js');
 var SimpleMessageDebugContext = require('./msg/SimpleMessageDebugContext.js');
 var SimpleProfileRequest = require('./msg/SimpleProfileRequest.js');
 var SimpleQueryRequest = require('./msg/SimpleQueryRequest.js');

--- a/examples/simple/src/main/javascript/client/App.js
+++ b/examples/simple/src/main/javascript/client/App.js
@@ -192,9 +192,11 @@ function logoutUser() {
 }
 
 function setRequestType(type) {
+    var i;
+    
     // Unselect the request tabs.
     var tabs = document.getElementsByClassName('tab');
-    for (var i = 0; i < tabs.length; ++i)
+    for (i = 0; i < tabs.length; ++i)
         tabs[i].className = "";
 
     // Select the request tab.
@@ -203,19 +205,19 @@ function setRequestType(type) {
 
     // Disable all fields.
     var fieldElements = document.getElementsByClassName('field');
-    for (var i = 0; i < fieldElements.length; ++i) {
+    for (i = 0; i < fieldElements.length; ++i) {
         var field = fieldElements[i];
         field.style.visibility = 'hidden';
         field.style.position = 'absolute';
-    };
+    }
 
     // Enable the selected field.
     var enabledElements = document.getElementsByClassName(type);
-    for (var i = 0; i < enabledElements.length; ++i) {
-        var field = enabledElements[i];
-        field.style.position = 'relative';
-        field.style.visibility = 'visible';
-    };
+    for (i = 0; i < enabledElements.length; ++i) {
+        var enabled = enabledElements[i];
+        enabled.style.position = 'relative';
+        enabled.style.visibility = 'visible';
+    }
 
     // Set the request type.
     var typeField = document.getElementById('type');

--- a/examples/simple/src/main/javascript/client/App.js
+++ b/examples/simple/src/main/javascript/client/App.js
@@ -14,6 +14,26 @@
  * limitations under the License.
  */
 
+// msl requires
+var KeyFormat = require('../../../../../../core/src/main/javascript/crypto/KeyFormat.js');
+var MslConstants = require('../../../../../../core/src/main/javascript/MslConstants.js');
+var PublicKey = require('../../../../../../core/src/main/javascript/crypto/PublicKey.js');
+var TextEncoding = require('../../../../../../core/src/main/javascript/util/TextEncoding.js');
+var WebCryptoAlgorithm = require('../../../../../../core/src/main/javascript/crypto/WebCryptoAlgorithm.js');
+var WebCryptoUsage = require('../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js');
+
+// simple client requires
+var AdvancedRequest = require('./msg/AdvancedRequest.js');
+var SimpleClient$create = require('./SimpleClient.js').create;
+var SimpleConstants = require('./SimpleConstants.js');
+var SimpleEchoRequest = require('./msg/SimpleEchoRequest.js');
+var SimpleFilterStreamFactory = require('./msg/SimpleFilterStreamFactory.js');
+var SimpleLogRequest = require('./msg/SimpleLogRequest.js').SimpleLogRequest;
+var SimpleMessageDebugContext = require('./msg/SimpleMessageDebugContext.js');
+var SimpleProfileRequest = require('./msg/SimpleProfileRequest.js');
+var SimpleQueryRequest = require('./msg/SimpleQueryRequest.js');
+var SimpleQuitRequest = require('./msg/SimpleQuitRequest.js');
+
 function getQueryParam(key, defaultValue) {
     var queryString = window.location.search;
     var regex = new RegExp(key + '=([^&?]*)');

--- a/examples/simple/src/main/javascript/client/SimpleClient.js
+++ b/examples/simple/src/main/javascript/client/SimpleClient.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,27 +17,25 @@
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var Class = require('../../../../../../core/src/main/javascript/util/Class.js');
-    var AsyncExecutor = require('../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
-    var EmailPasswordAuthenticationData = require('../../../../../../core/src/main/javascript/userauth/EmailPasswordAuthenticationData.js');
-    var KeyFormat = require('../../../../../../core/src/main/javascript/crypto/KeyFormat.js');
-    var MslCrypto = require('../../../../../../core/src/main/javascript/crypto/MslCrypto.js');
-    var MslIoException = require('../../../../../../core/src/main/javascript/MslIoException.js');
-    var Url = require('../../../../../../core/src/main/javascript/io/Url.js');
-    var WebCryptoAlgorithm = require('../../../../../../core/src/main/javascript/crypto/WebCryptoAlgorithm.js');
-    var WebCryptoUsage = require('../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js');
-    var Xhr = require('../../../../../../core/src/main/javascript/io/Xhr.js');
-    var AsymmetricWrappedExchange = require('../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
-    var MslControl = require('../../../../../../core/src/main/javascript/msg/MslControl.js');
-    var PublicKey = require('../../../../../../core/src/main/javascript/crypto/PublicKey.js');
-    var RsaStore = require('../../../../../../core/src/main/javascript/entityauth/RsaStore.js');
+    var Class = require('msl-core/util/Class.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var EmailPasswordAuthenticationData = require('msl-core/userauth/EmailPasswordAuthenticationData.js');
+    var KeyFormat = require('msl-core/crypto/KeyFormat.js');
+    var MslCrypto = require('msl-core/crypto/MslCrypto.js');
+    var MslIoException = require('msl-core/MslIoException.js');
+    var Url = require('msl-core/io/Url.js');
+    var WebCryptoAlgorithm = require('msl-core/crypto/WebCryptoAlgorithm.js');
+    var WebCryptoUsage = require('msl-core/crypto/WebCryptoUsage.js');
+    var Xhr = require('msl-core/io/Xhr.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var MslControl = require('msl-core/msg/MslControl.js');
+    var PublicKey = require('msl-core/crypto/PublicKey.js');
+    var RsaStore = require('msl-core/entityauth/RsaStore.js');
 
-    // simpleclient requires
-    var SimpleKeyxManager$create = require('./keyx/SimpleKeyxManager.js').create;
+    var SimpleKeyxManager = require('./keyx/SimpleKeyxManager.js');
     var AdvancedRequestMessageContext = require('./msg/AdvancedRequestMessageContext.js');
     var SimpleRequestMessageContext = require('./msg/SimpleRequestMessageContext.js');
-    var SimpleRequest = require('./msg/SimpleRequest.js').SimpleRequest;
+    var SimpleRequest = require('./msg/SimpleRequest.js');
     var SimpleMslContext = require('./util/SimpleMslContext.js')
     var SimpleConstants = require('./SimpleConstants.js');
 
@@ -47,7 +45,7 @@
      *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    var SimpleClient = module.exports.SimpleClient = Class.create({
+    var SimpleClient = module.exports = Class.create({
         /**
          * <p>Create a new client.</p>
          *
@@ -69,7 +67,7 @@
 	                	var mechanism = (MslCrypto.getWebCryptoVersion() == MslCrypto.WebCryptoVersion.LEGACY)
 	                		? AsymmetricWrappedExchange.Mechanism.JWE_RSA
 	                		: AsymmetricWrappedExchange.Mechanism.JWK_RSA;
-	                    SimpleKeyxManager$create(mechanism, {
+	                    SimpleKeyxManager.create(mechanism, {
 	                        result: function(keyxMgr) {
 	                            AsyncExecutor(callback, function() {
 	                                // Create the RSA key store.
@@ -247,7 +245,10 @@
      *        callback the callback that will receive the created client or
      *        any thrown exceptions.
      */
-    var SimpleClient$create = module.exports.create = function SimpleClient$create(identity, factory, callback) {
+    var SimpleClient$create = function SimpleClient$create(identity, factory, callback) {
         new SimpleClient(identity, factory, callback);
     };
+    
+    // Exports.
+    module.exports.create = SimpleClient$create;
 })(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleClient'));

--- a/examples/simple/src/main/javascript/client/SimpleClient.js
+++ b/examples/simple/src/main/javascript/client/SimpleClient.js
@@ -36,7 +36,7 @@
     var AdvancedRequestMessageContext = require('./msg/AdvancedRequestMessageContext.js');
     var SimpleRequestMessageContext = require('./msg/SimpleRequestMessageContext.js');
     var SimpleRequest = require('./msg/SimpleRequest.js');
-    var SimpleMslContext = require('./util/SimpleMslContext.js')
+    var SimpleMslContext = require('./util/SimpleMslContext.js');
     var SimpleConstants = require('./SimpleConstants.js');
 
     /**

--- a/examples/simple/src/main/javascript/client/SimpleConstants.js
+++ b/examples/simple/src/main/javascript/client/SimpleConstants.js
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleConstants = {
-    /** Default server port. */
-    SERVER_PORT: 8080,
-    /** MSL control timeout in milliseconds. */
-    TIMEOUT_MS: 120 * 1000,
-    
-    /** Server entity ID. */
-    SERVER_ID: "SimpleMslServer",
-    /** Server 2048-bit RSA public key. */
-    RSA_PUBKEY_B64:
+
+(function(require, module) {
+    var SimpleConstants = module.exports = {
+        /** Default server port. */
+        SERVER_PORT: 8080,
+        /** MSL control timeout in milliseconds. */
+        TIMEOUT_MS: 120 * 1000,
+
+        /** Server entity ID. */
+        SERVER_ID: "SimpleMslServer",
+        /** Server 2048-bit RSA public key. */
+        RSA_PUBKEY_B64:
         "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4feorj/FWQi8AhbvjK3G" +
         "L31ct6N+Ad/3FwqNsa4vAsfPmilLRx0DWhkxRycetmQEAa+1THyNCzobIduQE3UY" +
         "8NtdOiy1S3BtHDoiSNEITFPAs0l2OAZ2ZUv0KIr9sLWAznlXMclLOBXtLOQMCs2e" +
@@ -30,35 +32,36 @@ var SimpleConstants = {
         "4tuu0ENsO/ebgMx2ltZ4b9dkzA65DM6XxEC60jK1AW+/wvFb4+iPQqrA7mdiZWsp" +
         "zqMRTaAUDHKJo2LFBc6N0/wuTsXczHx6TYz5b2hrI6N+O7EEuxirAaU+xU7XEqv2" +
         "dQIDAQAB",
-        
-    
-    /** Client entity ID. */
-    CLIENT_ID: "SimpleMslClient",
-    
-    /** Email/Password set. */
-    EMAIL_PASSWORDS: [
-        [ "kirito", "asuna" ],
-        [ "chie", "shuhei" ],
-        [ "hideki", "chi" ]
-    ],
-    /** Server administrator. */
-    ADMIN_USERNAME: "kirito",
-    
-    /**
-     * Query data: user, key.
-     *
-     * If the first value is not null, only the listed user has permission to
-     * access the data value.
-     */
-    QUERY_DATA: [
-        [ null, "cat" ],
-        [ "chie", "alien" ],
-        [ "kirito", "sword" ],
-        [ null, "dog" ],
-        [ null, "bird" ],
-        [ null, "turtle" ],
-        [ null, "fish" ],
-        [ "chie", "bathhouse" ],
-        [ "hideki", "computer" ],
-    ],
-};
+
+
+        /** Client entity ID. */
+        CLIENT_ID: "SimpleMslClient",
+
+        /** Email/Password set. */
+        EMAIL_PASSWORDS: [
+            [ "kirito", "asuna" ],
+            [ "chie", "shuhei" ],
+            [ "hideki", "chi" ]
+        ],
+        /** Server administrator. */
+        ADMIN_USERNAME: "kirito",
+
+        /**
+         * Query data: user, key.
+         *
+         * If the first value is not null, only the listed user has permission to
+         * access the data value.
+         */
+        QUERY_DATA: [
+            [ null, "cat" ],
+            [ "chie", "alien" ],
+            [ "kirito", "sword" ],
+            [ null, "dog" ],
+            [ null, "bird" ],
+            [ null, "turtle" ],
+            [ null, "fish" ],
+            [ "chie", "bathhouse" ],
+            [ "hideki", "computer" ],
+        ],
+    };
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleConstants'));

--- a/examples/simple/src/main/javascript/client/SimpleConstants.js
+++ b/examples/simple/src/main/javascript/client/SimpleConstants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 (function(require, module) {
     var SimpleConstants = module.exports = {
         /** Default server port. */

--- a/examples/simple/src/main/javascript/client/keyx/SimpleKeyxManager.js
+++ b/examples/simple/src/main/javascript/client/keyx/SimpleKeyxManager.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,22 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleKeyxManager;
-var SimpleKeyxManager$create;
-var SimpleKeyxManager$KeyPair;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // msl requires
+    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
+    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
+    var Class = require('../../../../../../../core/src/main/javascript/util/Class.js');
+    var MslCrypto = require('../../../../../../../core/src/main/javascript/crypto/MslCrypto.js');
+    var PrivateKey = require('../../../../../../../core/src/main/javascript/crypto/PrivateKey.js');
+    var PublicKey = require('../../../../../../../core/src/main/javascript/crypto/PublicKey.js');
+    var WebCryptoAlgorithm = require('../../../../../../../core/src/main/javascript/crypto/WebCryptoAlgorithm.js');
+    var WebCryptoUsage = require('../../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js');
+
     /**
      * <p>A key pair holds a public and private key pair.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    var KeyPair = SimpleKeyxManager$KeyPair = Class.create({
+    var KeyPair = module.exports.SimpleKeyxManager$KeyPair = Class.create({
         /**
          * <p>Create a new key pair.</p>
-         * 
+         *
          * @param {PublicKey} publicKey the public key.
          * @param {PrivateKey} privateKey the private key.
          */
@@ -41,20 +48,20 @@ var SimpleKeyxManager$KeyPair;
             Object.defineProperties(this, props);
         }
     });
-    
+
     /**
      * <p>This class manages the lifetime of generated asymmetric keys used for
      * asymmetric wrapped key exchange. It is more efficient to generate a key
      * pair and use it multiple times until a key exchange occurs at which
      * point new keys should be generated and used.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleKeyxManager = Class.create({
+    var SimpleKeyxManager = module.exports.SimpleKeyxManager = Class.create({
         /**
          * <p>Create a new asymmetric wrapped key exchange manager. A pair of
          * initial keys will be generated.</p>
-         * 
+         *
          * @param {AsymmetricWrappedExchange.Mechanism} mechanism the key
          *        mechanism to use.
          * @param {{result: function(SimpleKeyxManager), error: function(Error)}}
@@ -63,7 +70,7 @@ var SimpleKeyxManager$KeyPair;
          */
         init: function init(mechanism, callback) {
             var self = this;
-            
+
             AsyncExecutor(callback, function() {
                 // Set properties.
                 var props = {
@@ -72,7 +79,7 @@ var SimpleKeyxManager$KeyPair;
                     _privkey: { value: null, writable: true, enumerable: false, configurable: false },
                 };
                 Object.defineProperties(this, props);
-                
+
                 // Generate the initial keys.
                 this.regenerate({
                     result: function(success) {
@@ -83,36 +90,36 @@ var SimpleKeyxManager$KeyPair;
                 });
             }, self);
         },
-        
+
         /**
          * <p>Return the key exchange mechanism.</p>
-         * 
+         *
          * @return {AsymmetricWrappedExchange.Mechanism} the key exchange
          *         mechanism.
          */
         getMechanism: function getMechanism() {
         	return this._mechanism;
         },
-        
+
         /**
          * <p>Return the current key pair.</p>
-         * 
+         *
          * @return {KeyPair} the current key pair.
          */
         getKeyPair: function getKeyPair() {
             return new KeyPair(this._pubkey, this._privkey);
         },
-        
+
         /**
          * <p>Regenerate the current key pair.</p>
-         * 
+         *
          * @param {{result: function(boolean), error: function(Error)}}
          *        callback the callback that will receive true on success or
          *        any thrown exceptions.
          */
         regenerate: function regenerate(callback) {
             var self = this;
-            
+
             AsyncExecutor(callback, function() {
                 var oncomplete = function(result) {
                     PrivateKey.create(result.privateKey, {
@@ -150,14 +157,14 @@ var SimpleKeyxManager$KeyPair;
     /**
      * <p>Create a new asymmetric wrapped key exchange manager. A pair of
      * initial keys will be generated.</p>
-     * 
+     *
      * @param {AsymmetricWrappedExchange.Mechanism} mechanism the key
      *        mechanism to use.
      * @param {{result: function(SimpleKeyxManager), error: function(Error)}}
      *        callback the callback that will receive the key manager or
      *        any thrown exceptions.
      */
-    SimpleKeyxManager$create = function SimpleKeyxManager$create(mechanism, callback) {
+    var SimpleKeyxManager$create = module.exports.create = function SimpleKeyxManager$create(mechanism, callback) {
         new SimpleKeyxManager(mechanism, callback);
     };
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleKeyxManager'));

--- a/examples/simple/src/main/javascript/client/keyx/SimpleKeyxManager.js
+++ b/examples/simple/src/main/javascript/client/keyx/SimpleKeyxManager.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,21 @@
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
-    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
-    var Class = require('../../../../../../../core/src/main/javascript/util/Class.js');
-    var MslCrypto = require('../../../../../../../core/src/main/javascript/crypto/MslCrypto.js');
-    var PrivateKey = require('../../../../../../../core/src/main/javascript/crypto/PrivateKey.js');
-    var PublicKey = require('../../../../../../../core/src/main/javascript/crypto/PublicKey.js');
-    var WebCryptoAlgorithm = require('../../../../../../../core/src/main/javascript/crypto/WebCryptoAlgorithm.js');
-    var WebCryptoUsage = require('../../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var Class = require('msl-core/util/Class.js');
+    var MslCrypto = require('msl-core/crypto/MslCrypto.js');
+    var PrivateKey = require('msl-core/crypto/PrivateKey.js');
+    var PublicKey = require('msl-core/crypto/PublicKey.js');
+    var WebCryptoAlgorithm = require('msl-core/crypto/WebCryptoAlgorithm.js');
+    var WebCryptoUsage = require('msl-core/crypto/WebCryptoUsage.js');
 
     /**
      * <p>A key pair holds a public and private key pair.</p>
      *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    var KeyPair = module.exports.SimpleKeyxManager$KeyPair = Class.create({
+    var KeyPair = Class.create({
         /**
          * <p>Create a new key pair.</p>
          *
@@ -57,7 +56,7 @@
      *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    var SimpleKeyxManager = module.exports.SimpleKeyxManager = Class.create({
+    var SimpleKeyxManager = module.exports = Class.create({
         /**
          * <p>Create a new asymmetric wrapped key exchange manager. A pair of
          * initial keys will be generated.</p>
@@ -164,7 +163,11 @@
      *        callback the callback that will receive the key manager or
      *        any thrown exceptions.
      */
-    var SimpleKeyxManager$create = module.exports.create = function SimpleKeyxManager$create(mechanism, callback) {
+    var SimpleKeyxManager$create = function SimpleKeyxManager$create(mechanism, callback) {
         new SimpleKeyxManager(mechanism, callback);
     };
+    
+    // Exports.
+    module.exports.KeyPair = KeyPair;
+    module.exports.create = SimpleKeyxManager$create;
 })(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleKeyxManager'));

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,22 +16,24 @@
 
 /**
  * <p>Advanced request type.</p>
- * 
+ *
  * <p>Advanced requests have no defined message structure and instead contain
  * exactly the application data provided.</p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-var AdvancedRequest;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
-    AdvancedRequest = Class.create({
+
+    // msl requires
+    var Class = require('../../../../../../../core/src/main/javascript/util/Class.js');
+
+    var AdvancedRequest = module.exports = Class.create({
         /**
          * <p>Create an advanced request with the specified message properties
          * and application data.</p>
-         * 
+         *
          * @param {string} recipient the intended recipient's entity identity.
          * @param {boolean} isEncrypted true if encryption is required.
          * @param {boolean} isIntegrityProtected true if integrity protection
@@ -56,4 +58,4 @@ var AdvancedRequest;
             Object.defineProperties(this, props);
         },
     })
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('AdvancedRequest'));

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
@@ -56,5 +56,5 @@
             };
             Object.defineProperties(this, props);
         },
-    })
+    });
 })(require, (typeof module !== 'undefined') ? module : mkmodule('AdvancedRequest'));

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var Class = require('../../../../../../../core/src/main/javascript/util/Class.js');
+    var Class = require('msl-core/util/Class.js');
 
     var AdvancedRequest = module.exports = Class.create({
         /**

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequestMessageContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
     "use strict";
 
     // msl requires
-    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
-    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
-    var MessageContext = require('../../../../../../../core/src/main/javascript/msg/MessageContext.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var MessageContext = require('msl-core/msg/MessageContext.js');
 
     // Shortcuts.
     var Mechanism = AsymmetricWrappedExchange.Mechanism;

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequestMessageContext.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,24 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var AdvancedRequestMessageContext;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // msl requires
+    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
+    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
+    var MessageContext = require('../../../../../../../core/src/main/javascript/msg/MessageContext.js');
+
     // Shortcuts.
     var Mechanism = AsymmetricWrappedExchange.Mechanism;
     var RequestData = AsymmetricWrappedExchange.RequestData;
 
     /**
      * <p>Example client message context for sending advanced requests.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    AdvancedRequestMessageContext = MessageContext.extend({
+    var AdvancedRequestMessageContext = module.exports = MessageContext.extend({
         /**
          * <p>Create a new simple request message context.</p>
-         * 
+         *
          * @param {?string} requesting user ID. May be {@code null}.
          * @param {?UserAuthenticationData} requesting user authentication data.
          *        May be {@code null}.
@@ -52,55 +56,55 @@ var AdvancedRequestMessageContext;
             };
             Object.defineProperties(this, props);
         },
-        
+
         /** @inheritDoc */
         getCryptoContexts: function getCryptoContexts() {
             return {};
         },
-        
+
         /** @inheritDoc */
         getRecipient: function() {
             return this._request.recipient;
         },
-    
+
         /** @inheritDoc */
         isEncrypted: function() {
             return this._request.isEncrypted;
         },
-        
+
         /** @inheritDoc */
         isIntegrityProtected: function isIntegrityProtected() {
             return this._request.isIntegrityProtected;
         },
-    
+
         /** @inheritDoc */
         isNonReplayable: function isNonReplayable() {
             return this._request.isNonReplayable;
         },
-        
+
         /** @inheritDoc */
         isRequestingTokens: function() {
             return this._request.isRequestingTokens;
         },
-    
+
         /** @inheritDoc */
         getUserId: function() {
             return this._userId;
         },
-    
+
         /** @inheritDoc */
         getUserAuthData: function(reauthCode, renewable, required, callback) {
             AsyncExecutor(callback, function() {
                 if (!this._userId)
                     return null;
-                
+
                 // If new user authentication data is required then fail and
                 // return null. Notify the application.
                 if (reauthCode) {
                     this._errorCallback("New user authentication data is required: " + reauthCode + ".");
                     return null;
                 }
-                
+
                 // Ignore the renewable flag. We never perform user
                 // verification.
                 //
@@ -108,12 +112,12 @@ var AdvancedRequestMessageContext;
                 return this._userAuthData;
             }, this);
         },
-    
+
         /** @inheritDoc */
         getUser: function getUser() {
             return null;
         },
-    
+
         /** @inheritDoc */
         getKeyRequestData: function(callback) {
             AsyncExecutor(callback, function() {
@@ -123,12 +127,12 @@ var AdvancedRequestMessageContext;
                 return [ request ];
             }, this);
         },
-    
+
         /** @inheritDoc */
         updateServiceTokens: function updateServiceTokens(builder, handshake, callback) {
             callback.result(true);
         },
-    
+
         /** @inheritDoc */
         write: function(output, timeout, callback) {
             AsyncExecutor(callback, function() {
@@ -146,10 +150,10 @@ var AdvancedRequestMessageContext;
                 });
             }, this);
         },
-        
+
         /** @inheritDoc */
         getDebugContext: function getDebugContext() {
             return this._dbgCtx;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('AdvancedRequestMessageContext'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleEchoRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleEchoRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleEchoRequest;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // simpleclient requires
+    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
+    var Type = require('./SimpleRequest.js').Type;
+
     /** JSON key message. */
     var KEY_MESSAGE = "message";
-    
-    // Shortcuts.
-    var Type = SimpleRequest$Type;
 
     /**
      * <p>Request to echo the request message. The requesting entity identity and
      * user (if any) is also echoed.</p>
-     * 
+     *
      * <p>The request data object is defined as:
      * {@code
      * data = {
@@ -37,25 +37,25 @@ var SimpleEchoRequest;
      * <ul>
      * <li>{@code message} is the message to echo.</li>
      * </ul></p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleEchoRequest = SimpleRequest.extend({
+    var SimpleEchoRequest = module.exports = SimpleRequest.extend({
         /**
          * <p>Create a new echo request.</p>
-         * 
+         *
          * @param {string} message the message to echo.
          */
         init: function init(message) {
             init.base.call(this, Type.ECHO);
-            
+
             // Properties.
             var props = {
                 message: { value: message, writable: false, enumerable: true, configurable: false },
             };
             Object.defineProperties(this, props);
         },
-        
+
         /** @inheritDoc */
         getData: function getData() {
             var jo = {};
@@ -63,4 +63,4 @@ var SimpleEchoRequest;
             return jo;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleEchoRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleEchoRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleEchoRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 (function(require, module) {
     "use strict";
 
-    // simpleclient requires
-    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
-    var Type = require('./SimpleRequest.js').Type;
+    var SimpleRequest = require('../msg/SimpleRequest.js');
 
     /** JSON key message. */
     var KEY_MESSAGE = "message";
@@ -47,7 +45,7 @@
          * @param {string} message the message to echo.
          */
         init: function init(message) {
-            init.base.call(this, Type.ECHO);
+            init.base.call(this, SimpleRequest.Type.ECHO);
 
             // Properties.
             var props = {

--- a/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleFilterStreamFactory;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // msl requires
+    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
+    var FilterStreamFactory = require('../../../../../../../core/src/main/javascript/msg/FilterStreamFactory.js');
+    var InputStream = require('../../../../../../../core/src/main/javascript/io/InputStream.js');
+    var MslConstants = require('../../../../../../../core/src/main/javascript/MslConstants.js');
+    var MslIoException = require('../../../../../../../core/src/main/javascript/MslIoException.js');
+    var OutputStream = require('../../../../../../../core/src/main/javascript/io/OutputStream.js');
+    var TextEncoding = require('../../../../../../../core/src/main/javascript/util/TextEncoding.js');
+
     /**
      * <p>A filter input stream that appends read data to a text HTML DOM
      * element.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
     var TextInputStream = InputStream.extend({
         /**
          * Create a new text input stream backed by the provided input stream.
-         * 
+         *
          * @param {Element} target target text HTML DOM element.
          * @param {InputStream} in the backing input stream.
          */
@@ -39,22 +47,22 @@ var SimpleFilterStreamFactory;
             };
             Object.defineProperties(this, props);
         },
-    
+
         /** @inheritDoc */
         close: function close(timeout, callback) {
             this._input.close(timeout, callback);
         },
-        
+
         /** @inheritDoc */
         mark: function mark(readlimit) {
             this._input.mark(readlimit);
         },
-        
+
         /** @inheritDoc */
         reset: function reset() {
             this._input.reset();
         },
-        
+
         /** @inheritDoc */
         markSupported: function markSupported() {
             return this._input.markSupported();
@@ -63,7 +71,7 @@ var SimpleFilterStreamFactory;
         /** @inheritDoc */
         read: function read(len, timeout, callback) {
             var self = this;
-            
+
             this._input.read(len, timeout, {
                 result: function(data) {
                 	AsyncExecutor(callback, function() {
@@ -91,17 +99,17 @@ var SimpleFilterStreamFactory;
             });
         },
     });
-    
+
     /**
      * <p>A filter output stream that appends written data to a text HTML DOM
      * element.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
     var TextOutputStream = OutputStream.extend({
         /**
          * Create a new text output stream backed by the provided output stream.
-         * 
+         *
          * @param {Element} target target text HTML DOM element.
          * @param {OutputStream} output the backing output stream.
          */
@@ -137,18 +145,18 @@ var SimpleFilterStreamFactory;
             this._output.flush(timeout, callback);
         },
     });
-    
+
     /**
      * <p>This filter stream factory will append stream data to provided text
      * HTML DOM elements.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleFilterStreamFactory = FilterStreamFactory.extend({
+    var SimpleFilterStreamFactory = module.exports = FilterStreamFactory.extend({
         /**
          * <p>Create a new filter stream factory that is tied to the provided
          * HTML text elements.</p>
-         * 
+         *
          * @param {Element} sentText sent text HTML DOM element.
          * @param {Element} receivedText received text HTML DOM element.
          */
@@ -160,15 +168,15 @@ var SimpleFilterStreamFactory;
             };
             Object.defineProperties(this, props);
         },
-        
+
         /** @inheritDoc */
         getInputStream: function getInputStream(input) {
             return new TextInputStream(this._received, input);
         },
-        
+
         /** @inheritDoc */
         getOutputStream: function getOutputStream(output) {
             return new TextOutputStream(this._sent, output);
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleFilterStreamFactory'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
@@ -17,14 +17,13 @@
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
-    var FilterStreamFactory = require('../../../../../../../core/src/main/javascript/msg/FilterStreamFactory.js');
-    var InputStream = require('../../../../../../../core/src/main/javascript/io/InputStream.js');
-    var MslConstants = require('../../../../../../../core/src/main/javascript/MslConstants.js');
-    var MslIoException = require('../../../../../../../core/src/main/javascript/MslIoException.js');
-    var OutputStream = require('../../../../../../../core/src/main/javascript/io/OutputStream.js');
-    var TextEncoding = require('../../../../../../../core/src/main/javascript/util/TextEncoding.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var FilterStreamFactory = require('msl-core/msg/FilterStreamFactory.js');
+    var InputStream = require('msl-core/io/InputStream.js');
+    var MslConstants = require('msl-core/MslConstants.js');
+    var MslIoException = require('msl-core/MslIoException.js');
+    var OutputStream = require('msl-core/io/OutputStream.js');
+    var TextEncoding = require('msl-core/util/TextEncoding.js');
 
     /**
      * <p>A filter input stream that appends read data to a text HTML DOM

--- a/examples/simple/src/main/javascript/client/msg/SimpleLogRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleLogRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,32 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleLogRequest;
-var SimpleLogRequest$Severity;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // simpleclient requires
+    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
+    var Type = require('./SimpleRequest.js').Type;
+
     /** JSON key timestamp. */
     var KEY_TIMESTAMP = "timestamp";
     /** JSON key severity. */
     var KEY_SEVERITY = "severity";
     /** JSON key message. */
     var KEY_MESSAGE = "message";
-    
+
     /** Log message severity. */
-    var Severity = SimpleLogRequest$Severity = {
+    var Severity = module.exports.Severity = {
         ERROR: "ERROR",
         WARN: "WARN",
         INFO: "INFO"
     };
-    
-    // Shortcuts.
-    var Type = SimpleRequest$Type;
-    
+
     /**
      * <p>Request to log a message.</p>
-     * 
+     *
      * <p>The request data object is defined as:
      * {@code
      * data = {
@@ -52,13 +51,13 @@ var SimpleLogRequest$Severity;
      * <li>{@code severity} is the log message severity.</li>
      * <li>{@code message} is the log message text.</li>
      * </ul></p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleLogRequest = SimpleRequest.extend({
+    var SimpleLogRequest = module.exports.SimpleLogRequest = SimpleRequest.extend({
         /**
          * <p>Create a new log request.</p>
-         * 
+         *
          * @param {number} timestamp the log message time in seconds since the UNIX
          *                 epoch.
          * @param {Severity} severity the log message severity.
@@ -66,7 +65,7 @@ var SimpleLogRequest$Severity;
          */
         init: function init(timestamp, severity, message) {
             init.base.call(this, Type.LOG);
-            
+
             // Set properties.
             var props = {
                 timestamp: { value: timestamp, writable: false, enumerable: true, configurable: false },
@@ -75,7 +74,7 @@ var SimpleLogRequest$Severity;
             };
             Object.defineProperties(this, props);
         },
-        
+
         /** @inheritDoc */
         getData: function getData() {
             var jo = {};
@@ -85,4 +84,4 @@ var SimpleLogRequest$Severity;
             return jo;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleLogRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleLogRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleLogRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 (function(require, module) {
     "use strict";
 
-    // simpleclient requires
-    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
-    var Type = require('./SimpleRequest.js').Type;
+    var SimpleRequest = require('../msg/SimpleRequest.js');
 
     /** JSON key timestamp. */
     var KEY_TIMESTAMP = "timestamp";
@@ -54,7 +51,7 @@
      *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    var SimpleLogRequest = module.exports.SimpleLogRequest = SimpleRequest.extend({
+    var SimpleLogRequest = module.exports = SimpleRequest.extend({
         /**
          * <p>Create a new log request.</p>
          *
@@ -64,7 +61,7 @@
          * @param {string} message the log message text.
          */
         init: function init(timestamp, severity, message) {
-            init.base.call(this, Type.LOG);
+            init.base.call(this, SimpleRequest.Type.LOG);
 
             // Set properties.
             var props = {

--- a/examples/simple/src/main/javascript/client/msg/SimpleMessageDebugContext.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleMessageDebugContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,7 @@
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var MessageDebugContext = require('../../../../../../../core/src/main/javascript/msg/MessageDebugContext.js');
+    var MessageDebugContext = require('msl-core/msg/MessageDebugContext.js');
 
     var SimpleMessageDebugContext = module.exports = MessageDebugContext.extend({
         /**

--- a/examples/simple/src/main/javascript/client/msg/SimpleMessageDebugContext.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleMessageDebugContext.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleMessageDebugContext;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
-    SimpleMessageDebugContext = MessageDebugContext.extend({
+
+    // msl requires
+    var MessageDebugContext = require('../../../../../../../core/src/main/javascript/msg/MessageDebugContext.js');
+
+    var SimpleMessageDebugContext = module.exports = MessageDebugContext.extend({
         /**
          * <p>Create a new message debug context that is tied to the provided
          * HTML text elements.</p>
-         * 
+         *
          * @param {Element} sentText sent text HTML DOM element.
          * @param {Element} receivedText received text HTML DOM element.
          */
@@ -34,7 +36,7 @@ var SimpleMessageDebugContext;
             };
             Object.defineProperties(this, props);
         },
-        
+
         /** @inheritDoc */
         sentHeader: function sentHeader(header) {
             // Append a pair of newlines. This should terminate the message
@@ -49,4 +51,4 @@ var SimpleMessageDebugContext;
             this._received.innerHTML += "\n\n";
         }
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleMessageDebugContext'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleProfileRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleProfileRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,32 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleProfileRequest;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
-    // Shortcuts.
-    var Type = SimpleRequest$Type;
-    
+
+    // simpleclient requires
+    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
+    var Type = require('./SimpleRequest.js').Type;
+
     /**
      * <p>Request to return a user profile.</p>
-     * 
+     *
      * <p>The request data object is defined as an empty JSON object.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleProfileRequest = SimpleRequest.extend({
+    var SimpleProfileRequest = module.exports = SimpleRequest.extend({
         /**
          * <p>Create a new user profile request.</p>
          */
         init: function init() {
             init.base.call(this, Type.USER_PROFILE);
         },
-    
+
         /** @inheritDoc */
         getData: function getData() {
             return {};
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleProfileRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleProfileRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleProfileRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 (function(require, module) {
     "use strict";
 
-    // simpleclient requires
-    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
-    var Type = require('./SimpleRequest.js').Type;
+    var SimpleRequest = require('../msg/SimpleRequest.js');
 
     /**
      * <p>Request to return a user profile.</p>
@@ -33,7 +31,7 @@
          * <p>Create a new user profile request.</p>
          */
         init: function init() {
-            init.base.call(this, Type.USER_PROFILE);
+            init.base.call(this, SimpleRequest.Type.USER_PROFILE);
         },
 
         /** @inheritDoc */

--- a/examples/simple/src/main/javascript/client/msg/SimpleQueryRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleQueryRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleQueryRequest;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // simpleclient requires
+    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
+    var Type = require('./SimpleRequest.js').Type;
+
     /** JSON key key. */
     var KEY_KEY = "key";
-    
-    // Shortcuts.
-    var Type = SimpleRequest$Type;
 
     /**
      * <p>Query for a data value. Some data values require a user identity for
      * access.</p>
-     * 
+     *
      * <p>The request data object is defined as:
      * {@code
      * data = {
@@ -37,26 +37,26 @@ var SimpleQueryRequest;
      * <ul>
      * <li>{@code key} is the data key identifying the value.</li>
      * </ul></p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleQueryRequest = SimpleRequest.extend({
-        
+    var SimpleQueryRequest = module.exports = SimpleRequest.extend({
+
         /**
          * <p>Create a new query request.</p>
-         * 
+         *
          * @param {string} key the data key.
          */
         init: function init(key) {
             init.base.call(this, Type.QUERY);
-            
+
             // Set properties.
             var props = {
                 key: { value: key, writable: false, enumerable: false, configurable: false }
             };
             Object.defineProperties(this, props);
         },
-    
+
         /** @inheritDoc */
         getData: function getData() {
             var jo = {};
@@ -64,4 +64,4 @@ var SimpleQueryRequest;
             return jo;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleQueryRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleQueryRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleQueryRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 (function(require, module) {
     "use strict";
 
-    // simpleclient requires
-    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
-    var Type = require('./SimpleRequest.js').Type;
+    var SimpleRequest = require('../msg/SimpleRequest.js');
 
     /** JSON key key. */
     var KEY_KEY = "key";
@@ -48,7 +46,7 @@
          * @param {string} key the data key.
          */
         init: function init(key) {
-            init.base.call(this, Type.QUERY);
+            init.base.call(this, SimpleRequest.Type.QUERY);
 
             // Set properties.
             var props = {

--- a/examples/simple/src/main/javascript/client/msg/SimpleQuitRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleQuitRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,33 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleQuitRequest;
 
-(function() {
+(function(require, module) {
     "use strict";
 
-    // Shortcuts.
-    var Type = SimpleRequest$Type;
-    
+    // simpleclient requires
+    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
+    var Type = require('./SimpleRequest.js').Type;
+
     /**
      * <p>Request to terminate the server. Only the server administrator is
      * permitted to execute this request.</p>
-     * 
+     *
      * <p>The request data object is defined as an empty JSON object.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleQuitRequest = SimpleRequest.extend({
+    var SimpleQuitRequest = module.exports = SimpleRequest.extend({
         /**
          * <p>Create a new quit request.</p>
          */
         init: function init() {
             init.base.call(this, Type.QUIT);
         },
-    
+
         /** @inheritDoc */
         getData: function getData() {
             return {};
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleQuitRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleQuitRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleQuitRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 (function(require, module) {
     "use strict";
 
-    // simpleclient requires
-    var SimpleRequest = require('./SimpleRequest.js').SimpleRequest;
-    var Type = require('./SimpleRequest.js').Type;
+    var SimpleRequest = require('../msg/SimpleRequest.js');
 
     /**
      * <p>Request to terminate the server. Only the server administrator is
@@ -34,7 +32,7 @@
          * <p>Create a new quit request.</p>
          */
         init: function init() {
-            init.base.call(this, Type.QUIT);
+            init.base.call(this, SimpleRequest.Type.QUIT);
         },
 
         /** @inheritDoc */

--- a/examples/simple/src/main/javascript/client/msg/SimpleRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,10 @@
  *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var Class = require('../../../../../../../core/src/main/javascript/util/Class.js');
+    var Class = require('msl-core/util/Class.js');
 
     /** JSON key type. */
     var KEY_TYPE = "type";
@@ -45,7 +43,7 @@
     var KEY_DATA = "data";
 
     /** Request type. */
-    var Type = module.exports.Type = {
+    var Type = {
         /** Echo request data. */
         ECHO: "ECHO",
         /** Query for data. */
@@ -58,7 +56,7 @@
         QUIT: "QUIT",
     };
 
-    var SimpleRequest = module.exports.SimpleRequest = Class.create({
+    var SimpleRequest = module.exports = Class.create({
         /**
          * <p>Create a simple request.</p>
          *
@@ -85,4 +83,7 @@
             return jo;
         },
     });
+    
+    // Exports.
+    module.exports.Type = Type;
 })(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleRequest.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 
 /**
  * <p>Example request type and parser.</p>
- * 
+ *
  * <p>Requests are represented as JSON as follows:
  * {@code {
  * request = {
@@ -29,14 +29,15 @@
  * <li>{@code type} is the request type.</li>
  * <li>{@code data} is the request data.</li>
  * </ul></p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-var SimpleRequest;
-var SimpleRequest$Type;
 
-(function() {
+(function(require, module) {
     "use strict";
+
+    // msl requires
+    var Class = require('../../../../../../../core/src/main/javascript/util/Class.js');
 
     /** JSON key type. */
     var KEY_TYPE = "type";
@@ -44,7 +45,7 @@ var SimpleRequest$Type;
     var KEY_DATA = "data";
 
     /** Request type. */
-    var Type = SimpleRequest$Type = {
+    var Type = module.exports.Type = {
         /** Echo request data. */
         ECHO: "ECHO",
         /** Query for data. */
@@ -56,11 +57,11 @@ var SimpleRequest$Type;
         /** Terminate server execution. */
         QUIT: "QUIT",
     };
-    
-    SimpleRequest = Class.create({
+
+    var SimpleRequest = module.exports.SimpleRequest = Class.create({
         /**
          * <p>Create a simple request.</p>
-         * 
+         *
          * @param {Type} type request type.
          */
         init: function init(type) {
@@ -70,12 +71,12 @@ var SimpleRequest$Type;
             };
             Object.defineProperties(this, props);
         },
-    
+
         /**
          * @return {object} the request data object.
          */
         getData: function() {},
-    
+
         /** @inheritDoc */
         toJSON: function toJSON() {
             var jo = {};
@@ -84,4 +85,4 @@ var SimpleRequest$Type;
             return jo;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleRequest'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,25 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleRequestMessageContext;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    // msl requires
+    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
+    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
+    var MessageContext = require('../../../../../../../core/src/main/javascript/msg/MessageContext.js');
+    var MslConstants = require('../../../../../../../core/src/main/javascript/MslConstants.js');
+    var TextEncoding = require('../../../../../../../core/src/main/javascript/util/TextEncoding.js');
+
+    // simpleclient requires
+    var Type = require('./SimpleRequest.js').Type;
+    var SimpleConstants = require('../SimpleConstants.js');
+
     // Shortcuts.
-    var Type = SimpleRequest$Type;
     var Mechanism = AsymmetricWrappedExchange.Mechanism;
     var RequestData = AsymmetricWrappedExchange.RequestData;
 
     /**
      * <p>Example client message context for sending request messages.</p>
-     * 
+     *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleRequestMessageContext = MessageContext.extend({
+    var SimpleRequestMessageContext = module.exports = MessageContext.extend({
         /**
          * <p>Create a new simple request message context.</p>
-         * 
+         *
          * @param {?string} requesting user ID. May be {@code null}.
          * @param {?UserAuthenticationData} requesting user authentication data.
          *        May be {@code null}.
@@ -53,17 +62,17 @@ var SimpleRequestMessageContext;
             };
             Object.defineProperties(this, props);
         },
-        
+
         /** @inheritDoc */
         getCryptoContexts: function getCryptoContexts() {
             return {};
         },
-        
+
         /** @inheritDoc */
         getRecipient: function() {
             return SimpleConstants.SERVER_ID;
         },
-    
+
         /** @inheritDoc */
         isEncrypted: function() {
             switch (this._request.type) {
@@ -77,42 +86,42 @@ var SimpleRequestMessageContext;
                     return true;
             }
         },
-        
+
         /** @inheritDoc */
         isIntegrityProtected: function isIntegrityProtected() {
             return true;
         },
-    
+
         /** @inheritDoc */
         isNonReplayable: function isNonReplayable() {
             return false;
         },
-        
+
         /** @inheritDoc */
         isRequestingTokens: function() {
             if (this._request.type == Type.LOG)
                 return true;
             return false;
         },
-    
+
         /** @inheritDoc */
         getUserId: function() {
             return this._userId;
         },
-    
+
         /** @inheritDoc */
         getUserAuthData: function(reauthCode, renewable, required, callback) {
             AsyncExecutor(callback, function() {
                 if (!this._userId)
                     return null;
-                
+
                 // If new user authentication data is required then fail and
                 // return null. Notify the application.
                 if (reauthCode) {
                     this._errorCallback("New user authentication data is required: " + reauthCode + ".");
                     return null;
                 }
-                
+
                 // Ignore the renewable flag. We never perform user
                 // verification.
                 //
@@ -120,12 +129,12 @@ var SimpleRequestMessageContext;
                 return this._userAuthData;
             }, this);
         },
-    
+
         /** @inheritDoc */
         getUser: function getUser() {
             return null;
         },
-    
+
         /** @inheritDoc */
         getKeyRequestData: function(callback) {
             AsyncExecutor(callback, function() {
@@ -135,12 +144,12 @@ var SimpleRequestMessageContext;
                 return [ request ];
             }, this);
         },
-    
+
         /** @inheritDoc */
         updateServiceTokens: function updateServiceTokens(builder, handshake, callback) {
             callback.result(true);
         },
-    
+
         /** @inheritDoc */
         write: function(output, timeout, callback) {
             AsyncExecutor(callback, function() {
@@ -159,10 +168,10 @@ var SimpleRequestMessageContext;
                 });
             }, this);
         },
-        
+
         /** @inheritDoc */
         getDebugContext: function getDebugContext() {
             return this._dbgCtx;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleRequestMessageContext'));

--- a/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,19 @@
 (function(require, module) {
     "use strict";
 
-    // msl requires
-    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
-    var AsyncExecutor = require('../../../../../../../core/src/main/javascript/util/AsyncExecutor.js');
-    var MessageContext = require('../../../../../../../core/src/main/javascript/msg/MessageContext.js');
-    var MslConstants = require('../../../../../../../core/src/main/javascript/MslConstants.js');
-    var TextEncoding = require('../../../../../../../core/src/main/javascript/util/TextEncoding.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var MessageContext = require('msl-core/msg/MessageContext.js');
+    var MslConstants = require('msl-core/MslConstants.js');
+    var TextEncoding = require('msl-core/util/TextEncoding.js');
 
-    // simpleclient requires
-    var Type = require('./SimpleRequest.js').Type;
+    var SimpleRequest = require('../msg/SimpleRequest.js');
     var SimpleConstants = require('../SimpleConstants.js');
 
     // Shortcuts.
     var Mechanism = AsymmetricWrappedExchange.Mechanism;
     var RequestData = AsymmetricWrappedExchange.RequestData;
+    var Type = SimpleRequest.Type;
 
     /**
      * <p>Example client message context for sending request messages.</p>

--- a/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
@@ -81,6 +81,7 @@
                 case Type.ECHO:
                 case Type.LOG:
                 case Type.USER_PROFILE:
+                    /* falls through */
                 default:
                     return true;
             }

--- a/examples/simple/src/main/javascript/client/package.json
+++ b/examples/simple/src/main/javascript/client/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "msl-example-client",
+  "version": "1.1220.0",
+  "description": "Message Security Layer Simple Example Client",
+  "keywords": [
+    "msl",
+    "message security layer",
+    "netflix"
+  ],
+  "homepage": "https://github.com/Netflix/msl",
+  "bugs": {
+    "url": "https://github.com/Netflix/msl/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com:Netflix/msl.git"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "lint": "find -E ../.. -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs jshint --verbose",
+    "version": "echo `git describe --dirty`"
+  },
+  "dependencies": {
+    "msl-core": "^1.1220.0"
+  }
+}

--- a/examples/simple/src/main/javascript/client/package.json
+++ b/examples/simple/src/main/javascript/client/package.json
@@ -22,5 +22,10 @@
   },
   "dependencies": {
     "msl-core": "^1.1220.0"
+  },
+  "devDependencies": {
+    "clarinet": "^0.11.0",
+    "jsrsasign": "^7.2.2",
+    "jshint": "^2.9.5"
   }
 }

--- a/examples/simple/src/main/javascript/client/util/SimpleKeyxMslStore.js
+++ b/examples/simple/src/main/javascript/client/util/SimpleKeyxMslStore.js
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleKeyxMslStore;
 
-(function() {
+(function(require, module) {
     "use strict";
+
+    var SimpleMslStore = require('../../../../../../../core/src/main/javascript/util/SimpleMslStore.js');
 
     /**
      * <p>An in-memory MSL store that manages state and is integrated with the
@@ -25,7 +26,7 @@ var SimpleKeyxMslStore;
      *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleKeyxMslStore = SimpleMslStore.extend({
+    var SimpleKeyxMslStore = module.exports = SimpleMslStore.extend({
         /**
          * <p>Create a new key exchange-aware MSL store.</p>
          *
@@ -59,4 +60,4 @@ var SimpleKeyxMslStore;
             });
         }
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleKeyxMslStore'));

--- a/examples/simple/src/main/javascript/client/util/SimpleKeyxMslStore.js
+++ b/examples/simple/src/main/javascript/client/util/SimpleKeyxMslStore.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 (function(require, module) {
     "use strict";
 
-    var SimpleMslStore = require('../../../../../../../core/src/main/javascript/util/SimpleMslStore.js');
+    var SimpleMslStore = require('msl-core/util/SimpleMslStore.js');
 
     /**
      * <p>An in-memory MSL store that manages state and is integrated with the

--- a/examples/simple/src/main/javascript/client/util/SimpleMslContext.js
+++ b/examples/simple/src/main/javascript/client/util/SimpleMslContext.js
@@ -13,11 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var SimpleMslContext;
 
-(function() {
+(function(require, module) {
     "use strict";
-    
+
+    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
+    var AuthenticationUtils = require('../../../../../../../core/src/main/javascript/util/AuthenticationUtils.js');
+    var ClientMslCryptoContext = require('../../../../../../../core/src/main/javascript/crypto/ClientMslCryptoContext.js');
+    var ClientTokenFactory = require('../../../../../../../core/src/main/javascript/tokens/ClientTokenFactory.js');
+    var DefaultMslEncoderFactory = require('../../../../../../../core/src/main/javascript/io/DefaultMslEncoderFactory.js');
+    var EntityAuthenticationScheme = require('../../../../../../../core/src/main/javascript/entityauth/EntityAuthenticationScheme.js');
+    var KeyExchangeScheme = require('../../../../../../../core/src/main/javascript/keyx/KeyExchangeScheme.js');
+    var MessageCapabilities = require('../../../../../../../core/src/main/javascript/msg/MessageCapabilities.js');
+    var MslConstants = require('../../../../../../../core/src/main/javascript/MslConstants.js');
+    var MslContext = require('../../../../../../../core/src/main/javascript/util/MslContext.js');
+    var MslEncoderFormat = require('../../../../../../../core/src/main/javascript/io/MslEncoderFormat.js');
+    var MslUser = require('../../../../../../../core/src/main/javascript/tokens/MslUser.js');
+    var Random = require('../../../../../../../core/src/main/javascript/util/Random.js');
+    var RsaAuthenticationFactory = require('../../../../../../../core/src/main/javascript/entityauth/RsaAuthenticationFactory.js');
+    var UnauthenticatedAuthenticationData = require('../../../../../../../core/src/main/javascript/entityauth/UnauthenticatedAuthenticationData.js');
+    var UnauthenticatedAuthenticationFactory = require('../../../../../../../core/src/main/javascript/entityauth/UnauthenticatedAuthenticationFactory.js');
+    var UserAuthenticationScheme = require('../../../../../../../core/src/main/javascript/userauth/UserAuthenticationScheme.js');
+
+    var SimpleKeyxMslStore = require('./SimpleKeyxMslStore.js');
+
     /**
      * Local authentication utils that only permits the unauthenticated entity
      * authentication scheme to be used by the local entity identity.
@@ -84,7 +103,7 @@ var SimpleMslContext;
      *
      * @author Wesley Miaw <wmiaw@netflix.com>
      */
-    SimpleMslContext = MslContext.extend({
+    var SimpleMslContext = module.exports =  MslContext.extend({
         /**
          * <p>Create a new client MSL context.</p>
          *
@@ -222,4 +241,4 @@ var SimpleMslContext;
             return this._encoder;
         },
     });
-})();
+})(require, (typeof module !== 'undefined') ? module : mkmodule('SimpleMslContext'));

--- a/examples/simple/src/main/javascript/client/util/SimpleMslContext.js
+++ b/examples/simple/src/main/javascript/client/util/SimpleMslContext.js
@@ -17,25 +17,25 @@
 (function(require, module) {
     "use strict";
 
-    var AsymmetricWrappedExchange = require('../../../../../../../core/src/main/javascript/keyx/AsymmetricWrappedExchange.js');
-    var AuthenticationUtils = require('../../../../../../../core/src/main/javascript/util/AuthenticationUtils.js');
-    var ClientMslCryptoContext = require('../../../../../../../core/src/main/javascript/crypto/ClientMslCryptoContext.js');
-    var ClientTokenFactory = require('../../../../../../../core/src/main/javascript/tokens/ClientTokenFactory.js');
-    var DefaultMslEncoderFactory = require('../../../../../../../core/src/main/javascript/io/DefaultMslEncoderFactory.js');
-    var EntityAuthenticationScheme = require('../../../../../../../core/src/main/javascript/entityauth/EntityAuthenticationScheme.js');
-    var KeyExchangeScheme = require('../../../../../../../core/src/main/javascript/keyx/KeyExchangeScheme.js');
-    var MessageCapabilities = require('../../../../../../../core/src/main/javascript/msg/MessageCapabilities.js');
-    var MslConstants = require('../../../../../../../core/src/main/javascript/MslConstants.js');
-    var MslContext = require('../../../../../../../core/src/main/javascript/util/MslContext.js');
-    var MslEncoderFormat = require('../../../../../../../core/src/main/javascript/io/MslEncoderFormat.js');
-    var MslUser = require('../../../../../../../core/src/main/javascript/tokens/MslUser.js');
-    var Random = require('../../../../../../../core/src/main/javascript/util/Random.js');
-    var RsaAuthenticationFactory = require('../../../../../../../core/src/main/javascript/entityauth/RsaAuthenticationFactory.js');
-    var UnauthenticatedAuthenticationData = require('../../../../../../../core/src/main/javascript/entityauth/UnauthenticatedAuthenticationData.js');
-    var UnauthenticatedAuthenticationFactory = require('../../../../../../../core/src/main/javascript/entityauth/UnauthenticatedAuthenticationFactory.js');
-    var UserAuthenticationScheme = require('../../../../../../../core/src/main/javascript/userauth/UserAuthenticationScheme.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var AuthenticationUtils = require('msl-core/util/AuthenticationUtils.js');
+    var ClientMslCryptoContext = require('msl-core/crypto/ClientMslCryptoContext.js');
+    var ClientTokenFactory = require('msl-core/tokens/ClientTokenFactory.js');
+    var DefaultMslEncoderFactory = require('msl-core/io/DefaultMslEncoderFactory.js');
+    var EntityAuthenticationScheme = require('msl-core/entityauth/EntityAuthenticationScheme.js');
+    var KeyExchangeScheme = require('msl-core/keyx/KeyExchangeScheme.js');
+    var MessageCapabilities = require('msl-core/msg/MessageCapabilities.js');
+    var MslConstants = require('msl-core/MslConstants.js');
+    var MslContext = require('msl-core/util/MslContext.js');
+    var MslEncoderFormat = require('msl-core/io/MslEncoderFormat.js');
+    var MslUser = require('msl-core/tokens/MslUser.js');
+    var Random = require('msl-core/util/Random.js');
+    var RsaAuthenticationFactory = require('msl-core/entityauth/RsaAuthenticationFactory.js');
+    var UnauthenticatedAuthenticationData = require('msl-core/entityauth/UnauthenticatedAuthenticationData.js');
+    var UnauthenticatedAuthenticationFactory = require('msl-core/entityauth/UnauthenticatedAuthenticationFactory.js');
+    var UserAuthenticationScheme = require('msl-core/userauth/UserAuthenticationScheme.js');
 
-    var SimpleKeyxMslStore = require('./SimpleKeyxMslStore.js');
+    var SimpleKeyxMslStore = require('../util/SimpleKeyxMslStore.js');
 
     /**
      * Local authentication utils that only permits the unauthenticated entity


### PR DESCRIPTION
This commit introduces the module pattern used in msl core to the simple client.  SimpleClient.html is untouched.

Sadly, my editor removed trailing whitespace from lines.  I apologize for the extra noise.