### PR TITLE
Add sign() overload to ICryptoContext that accepts ErrorHeader

### DIFF
--- a/core/src/main/java/com/netflix/msl/crypto/AsymmetricCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/AsymmetricCryptoContext.java
@@ -44,7 +44,7 @@ import com.netflix.msl.io.MslObject;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public abstract class AsymmetricCryptoContext implements ICryptoContext {
+public abstract class AsymmetricCryptoContext extends ICryptoContext {
     /** Null transform or algorithm. */
     protected static final String NULL_OP = "nullOp";
     

--- a/core/src/main/java/com/netflix/msl/crypto/AsymmetricCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/AsymmetricCryptoContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/crypto/ClientMslCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/ClientMslCryptoContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/crypto/ClientMslCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/ClientMslCryptoContext.java
@@ -28,7 +28,7 @@ import com.netflix.msl.io.MslEncoderFormat;
  * @author Wesley Miaw <wmiaw@netflix.com>
  * @see com.netflix.msl.util.MslContext#getMslCryptoContext()
  */
-public class ClientMslCryptoContext implements ICryptoContext {
+public class ClientMslCryptoContext extends ICryptoContext {
     /* (non-Javadoc)
      * @see com.netflix.msl.crypto.ICryptoContext#encrypt(byte[], com.netflix.msl.io.MslEncoderFactory, com.netflix.msl.io.MslEncoderFormat)
      */

--- a/core/src/main/java/com/netflix/msl/crypto/ICryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/ICryptoContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/crypto/ICryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/ICryptoContext.java
@@ -18,6 +18,7 @@ package com.netflix.msl.crypto;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.io.MslEncoderFactory;
 import com.netflix.msl.io.MslEncoderFormat;
+import com.netflix.msl.msg.ErrorHeader;
 
 /**
  * A generic cryptographic context suitable for encryption/decryption,
@@ -25,7 +26,7 @@ import com.netflix.msl.io.MslEncoderFormat;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public interface ICryptoContext {
+public abstract class ICryptoContext {
     /**
      * Encrypts some data.
      * 
@@ -35,7 +36,7 @@ public interface ICryptoContext {
      * @return the ciphertext.
      * @throws MslCryptoException if there is an error encrypting the data.
      */
-    public byte[] encrypt(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format) throws MslCryptoException;
+    public abstract byte[] encrypt(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format) throws MslCryptoException;
     
     /**
      * Decrypts some data.
@@ -45,7 +46,7 @@ public interface ICryptoContext {
      * @return the plaintext.
      * @throws MslCryptoException if there is an error decrypting the data.
      */
-    public byte[] decrypt(final byte[] data, final MslEncoderFactory encoder) throws MslCryptoException;
+    public abstract byte[] decrypt(final byte[] data, final MslEncoderFactory encoder) throws MslCryptoException;
     
     /**
      * Wraps some data.
@@ -56,7 +57,7 @@ public interface ICryptoContext {
      * @return the wrapped data.
      * @throws MslCryptoException if there is an error wrapping the data.
      */
-    public byte[] wrap(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format) throws MslCryptoException;
+    public abstract byte[] wrap(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format) throws MslCryptoException;
     
     /**
      * Unwraps some data.
@@ -66,7 +67,7 @@ public interface ICryptoContext {
      * @return the plaintext.
      * @throws MslCryptoException if there is an error unwrapping the data.
      */
-    public byte[] unwrap(final byte[] data, final MslEncoderFactory encoder) throws MslCryptoException;
+    public abstract byte[] unwrap(final byte[] data, final MslEncoderFactory encoder) throws MslCryptoException;
     
     /**
      * Computes the signature for some data. The signature may not be a
@@ -78,8 +79,25 @@ public interface ICryptoContext {
      * @return the signature.
      * @throws MslCryptoException if there is an error computing the signature.
      */
-    public byte[] sign(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format) throws MslCryptoException;
-    
+    public abstract byte[] sign(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format) throws MslCryptoException;
+
+    /**
+     * Computes the signature for some data. This form of the sign method
+     * accepts an additional MSL ErrorHeader object that can be used as
+     * operational context when signing errors. The default implementation
+     * below ignores that parameter, but subclasses can provide an override.
+     *
+     * @param data the data.
+     * @param encoder MSL encoder factory.
+     * @param format MSL encoder format.
+     * @param errorHeader MSL ErrorHeader instance
+     * @return the signature.
+     * @throws MslCryptoException if there is an error computing the signature.
+     */
+    public byte[] sign(final byte[] data, final MslEncoderFactory encoder, final MslEncoderFormat format, ErrorHeader errorHeader) throws MslCryptoException {
+        return sign(data, encoder, format);
+    }
+
     /**
      * Verifies the signature for some data. The signature may not be a
      * signature proper, but the name suits the concept.
@@ -90,5 +108,5 @@ public interface ICryptoContext {
      * @return true if the data is verified, false if validation fails.
      * @throws MslCryptoException if there is an error verifying the signature.
      */
-    public boolean verify(final byte[] data, final byte[] signature, final MslEncoderFactory encoder) throws MslCryptoException;
+    public abstract boolean verify(final byte[] data, final byte[] signature, final MslEncoderFactory encoder) throws MslCryptoException;
 }

--- a/core/src/main/java/com/netflix/msl/crypto/JsonWebEncryptionCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/JsonWebEncryptionCryptoContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/crypto/JsonWebEncryptionCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/JsonWebEncryptionCryptoContext.java
@@ -58,7 +58,7 @@ import com.netflix.msl.util.MslContext;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public class JsonWebEncryptionCryptoContext implements ICryptoContext {
+public class JsonWebEncryptionCryptoContext extends ICryptoContext {
     /** Encoding charset. */
     private static final Charset UTF_8 = Charset.forName("UTF-8");
     
@@ -137,7 +137,7 @@ public class JsonWebEncryptionCryptoContext implements ICryptoContext {
      * The Content Encryption Key crypto context is used to encrypt/decrypt the
      * randomly generated content encryption key.
      */
-    public static abstract class CekCryptoContext implements ICryptoContext {
+    public static abstract class CekCryptoContext extends ICryptoContext {
         /**
          * Create a new content encryption key crypto context with the
          * specified content encryption key encryption algorithm.

--- a/core/src/main/java/com/netflix/msl/crypto/NullCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/NullCryptoContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/crypto/NullCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/NullCryptoContext.java
@@ -25,7 +25,7 @@ import com.netflix.msl.io.MslEncoderFormat;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public class NullCryptoContext implements ICryptoContext {
+public class NullCryptoContext extends ICryptoContext {
     /* (non-Javadoc)
      * @see com.netflix.msl.crypto.ICryptoContext#encrypt(byte[], com.netflix.msl.io.MslEncoderFactory, com.netflix.msl.io.MslEncoderFormat)
      */

--- a/core/src/main/java/com/netflix/msl/crypto/SymmetricCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/SymmetricCryptoContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/crypto/SymmetricCryptoContext.java
+++ b/core/src/main/java/com/netflix/msl/crypto/SymmetricCryptoContext.java
@@ -53,7 +53,7 @@ import com.netflix.msl.util.MslUtils;
  * 
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
-public class SymmetricCryptoContext implements ICryptoContext {
+public class SymmetricCryptoContext extends ICryptoContext {
     /** AES encryption cipher algorithm. */
     private static final String AES_ALGO = "AES";
     /** AES encryption cipher algorithm. */

--- a/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
+++ b/core/src/main/java/com/netflix/msl/keyx/JsonWebKeyLadderExchange.java
@@ -402,7 +402,7 @@ public class JsonWebKeyLadderExchange extends KeyExchangeFactory {
      * web key string representation's binary encoding for compatibility with
      * the wrapping algorithm used.</p> 
      */
-    public static abstract class JwkCryptoContext implements ICryptoContext {
+    public static abstract class JwkCryptoContext extends ICryptoContext {
         /* (non-Javadoc)
          * @see com.netflix.msl.crypto.ICryptoContext#encrypt(byte[], com.netflix.msl.io.MslEncoderFactory, com.netflix.msl.io.MslEncoderFormat)
          */

--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -309,7 +309,7 @@ public class ErrorHeader extends Header {
         }
         final byte[] signature;
         try {
-            signature = cryptoContext.sign(ciphertext, encoder, format);
+            signature = cryptoContext.sign(ciphertext, encoder, format, this);
         } catch (final MslCryptoException e) {
             throw new MslEncoderException("Error signing the error data.", e);
         }

--- a/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/ErrorHeader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
ErrorHeader.toMslEncoding() invokes this new method and passes in an ErrorHeader. The default implementation is to just call the existing abstract sign() method and ignore the new parameter. However, ICryptoContext subclasses may overload this new method to use the ErrorHeader parameter as an operational context to influence error signing behavior.