### PR TITLE
Create MslControl.send() and .push() functions.

### DIFF
--- a/core/.cproject
+++ b/core/.cproject
@@ -34,7 +34,7 @@
 								<option id="gnu.cpp.compiler.option.include.paths.2016204762" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1122826244" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -43,16 +43,16 @@
 								</option>
 								<option id="gnu.cpp.compiler.option.optimization.level.1875088536" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.89084273" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.1076832623" superClass="gnu.cpp.compiler.option.dialect.std" value="gnu.cpp.compiler.dialect.default" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.1076832623" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.default" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.511782228" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.145763403" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
 								<option id="gnu.c.compiler.option.include.paths.1305836267" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.349824378" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.debugging.level.1041658437" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.38550529" superClass="gnu.c.compiler.option.dialect.std" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.38550529" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1347910571" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>
@@ -97,7 +97,7 @@
 								<option id="gnu.cpp.compiler.option.include.paths.1221189470" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1724244947" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -121,7 +121,7 @@
 								<option id="gnu.c.compiler.option.debugging.level.1590413777" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.dialect.std.1707864846" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.include.paths.1644780074" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1011007670" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>

--- a/core/src/main/cpp/io/BufferedInputStream.cpp
+++ b/core/src/main/cpp/io/BufferedInputStream.cpp
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <io/BufferedInputStream.h>
+#include <io/ByteArrayOutputStream.h>
+#include <IOException.h>
+
+#include <algorithm>
+
+using namespace std;
+
+namespace netflix {
+namespace msl {
+namespace io {
+
+void BufferedInputStream::mark(size_t readlimit)
+{
+    // If there is no current mark, then start buffering.
+    if (!buffer_) {
+        buffer_ = make_shared<ByteArrayOutputStream>();
+        bufpos_ = 0;
+        readlimit_ = readlimit;
+        return;
+    }
+
+    // If there is data buffered and the current mark position is not
+    // zero (at the beginning) then truncate the buffer.
+    if (bufpos_ > 0) {
+        shared_ptr<ByteArray> data = buffer_->toByteArray();
+        buffer_->reset();
+        buffer_->write(*data, bufpos_, data->size() - bufpos_);
+        bufpos_ = 0;
+    }
+
+    // Otherwise the existing buffer contains the correct data.
+    //
+    // Set the new read limit.
+    readlimit_ = readlimit;
+}
+
+void BufferedInputStream::reset()
+{
+    if (!buffer_)
+        throw IOException("Cannot reset before input stream has been marked or if mark has been invalidated.");
+
+    // Start reading from the beginning of the buffer.
+    bufpos_ = 0;
+}
+
+int BufferedInputStream::read(ByteArray& out, size_t offset, size_t len, int timeout)
+{
+    if (closed_)
+        throw IOException("Stream is already closed.");
+
+    // If we have any data in the buffer, read it first.
+    ByteArray bufferedData;
+    if (buffer_ && buffer_->size() > bufpos_) {
+        // Otherwise read the amount requested but no more than
+        // what remains in the buffer.
+        size_t endpos = min(buffer_->size(), bufpos_ + len);
+
+        // Extract the buffered data.
+        shared_ptr<ByteArray> buffer = buffer_->toByteArray();
+        bufferedData.assign(buffer->begin() + bufpos_, buffer->begin() + endpos);
+        bufpos_ += bufferedData.size();
+
+        // If the data is of sufficient size, return it.
+        if (bufferedData.size() >= len) {
+            copy(bufferedData.begin(), bufferedData.end(), out.begin() + offset);
+            return bufferedData.size();
+        }
+    }
+
+    // We were not able to read enough off the buffer.
+    //
+    // Read any remaining data off the backing source.
+    const size_t remainingLength = len - bufferedData.size();
+    ByteArray sourceData(remainingLength);
+    int count = source_->read(sourceData, timeout);
+
+    // On end of stream, return the buffered data.
+    if (count == -1) {
+        copy(bufferedData.begin(), bufferedData.end(), out.begin() + offset);
+        return bufferedData.size();
+    }
+
+    // Append to the buffer if we are buffering.
+    if (buffer_) {
+        // Stop buffering if the additional data would exceed the read limit.
+        if (buffer_->size() + count > readlimit_) {
+            buffer_.reset();
+            bufpos_ = 0;
+            readlimit_ = 0;
+        }
+
+        // Otherwise append.
+        else {
+            buffer_->write(sourceData, 0, count);
+            bufpos_ += count;
+            // The mark position should now be equal to the buffer length.
+        }
+    }
+
+    // Return the buffered data and the read data.
+    copy(bufferedData.begin(), bufferedData.end(), out.begin() + offset);
+    copy(sourceData.begin(), sourceData.begin() + count, out.begin() + offset);
+    return bufferedData.size() + count;
+}
+
+int BufferedInputStream::skip(size_t n, int timeout)
+{
+    if (closed_)
+        throw IOException("Stream is already closed.");
+
+    // If we have any data in the buffer, skip it first.
+    size_t skipcount = 0;
+    if (buffer_ && buffer_->size() > bufpos_) {
+        skipcount = min(n, buffer_->size() - bufpos_);
+        bufpos_ += skipcount;
+
+        // If we skipped as much as requested return immediately.
+        if (skipcount == n)
+            return skipcount;
+    }
+
+    // We were not able to skip enough using just buffered data.
+    ByteArray data(n - skipcount);
+    int readcount = read(data, timeout);
+    if (readcount == -1) return skipcount;
+    return readcount + skipcount;
+}
+
+}}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/BufferedInputStream.h
+++ b/core/src/main/cpp/io/BufferedInputStream.h
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SRC_IO_BUFFEREDINPUTSTREAM_H_
+#define SRC_IO_BUFFEREDINPUTSTREAM_H_
+
+#include <io/InputStream.h>
+
+#include <memory>
+#include <vector>
+
+namespace netflix {
+namespace msl {
+typedef std::vector<uint8_t> ByteArray;
+namespace io {
+class ByteArrayOutputStream;
+
+/**
+ * <p>A {@code BufferedInputStream} adds support for the {@code mark()} and
+ * {@code reset()} functions.</p>
+ *
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+class BufferedInputStream : public InputStream
+{
+public:
+    virtual ~BufferedInputStream() {}
+
+    BufferedInputStream(std::shared_ptr<InputStream> source)
+        : source_(source)
+    {}
+
+    /** @inheritDoc */
+    virtual void abort() {
+        source_->abort();
+    }
+
+    /** @inheritDoc */
+    virtual bool close(int timeout = -1)
+    {
+        closed_ = true;
+        return source_->close(timeout);
+    }
+
+    /** @inheritDoc */
+    virtual void mark(size_t readlimit);
+
+    /** @inheritDoc */
+    virtual void reset();
+
+    /** @inheritDoc */
+    virtual bool markSupported() { return true; }
+
+    /** @inheritDoc */
+    virtual int read(ByteArray& out, int timeout = -1)
+    {
+        return read(out, 0, out.size(), timeout);
+    }
+
+    /** @inheritDoc */
+    virtual int read(ByteArray& out, size_t offset, size_t len, int timeout = -1);
+
+    /** @inheritDoc */
+    virtual int skip(size_t n, int timeout = -1);
+
+private:
+    /** The backing input stream. */
+    std::shared_ptr<InputStream> source_;
+    /**
+     * Buffer of data read since the last call to mark(). Not set if
+     * mark() has not been called or if the read limit has been
+     * exceeded.
+     */
+    std::shared_ptr<ByteArrayOutputStream> buffer_;
+    /** Current buffer read position. */
+    size_t bufpos_ = 0;
+    /** Requested maximum number of bytes to buffer. */
+    size_t readlimit_ = 0;
+    /** True if stream is closed. */
+    bool closed_ = false;
+};
+
+}}} // namespace netflix::msl::io
+#endif /* SRC_IO_BUFFEREDINPUTSTREAM_H_ */

--- a/core/src/main/cpp/io/BufferedInputStream.h
+++ b/core/src/main/cpp/io/BufferedInputStream.h
@@ -36,14 +36,23 @@ class ByteArrayOutputStream;
 class BufferedInputStream : public InputStream
 {
 public:
+    /** Default read size: 8192 bytes. */
+    static const size_t DEFAULT_READ_SIZE;
+
     virtual ~BufferedInputStream() {}
 
-    BufferedInputStream(std::shared_ptr<InputStream> source)
-        : source_(source)
-    {}
+    /**
+     * Create a new buffered input stream that will read from the provided
+     * source input stream in byte chunks of the specified size.
+     *
+     * @param source the source input stream.
+     * @param size read size.
+     */
+    BufferedInputStream(std::shared_ptr<InputStream> source, size_t size = DEFAULT_READ_SIZE);
 
     /** @inheritDoc */
-    virtual void abort() {
+    virtual void abort()
+    {
         source_->abort();
     }
 
@@ -78,6 +87,8 @@ public:
 private:
     /** The backing input stream. */
     std::shared_ptr<InputStream> source_;
+    /** Read size in bytes. */
+    size_t readsize_;
     /**
      * Buffer of data read since the last call to mark(). Not set if
      * mark() has not been called or if the read limit has been
@@ -86,8 +97,11 @@ private:
     std::shared_ptr<ByteArrayOutputStream> buffer_;
     /** Current buffer read position. */
     size_t bufpos_ = 0;
-    /** Requested maximum number of bytes to buffer. */
-    size_t readlimit_ = 0;
+    /**
+     * Requested maximum number of bytes before the mark is invalidated. Will
+     * be -1 if the mark is not active.
+     */
+    size_t readlimit_ = -1;
     /** True if stream is closed. */
     bool closed_ = false;
 };

--- a/core/src/main/cpp/io/ByteArrayInputStream.h
+++ b/core/src/main/cpp/io/ByteArrayInputStream.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,13 +65,13 @@ public:
     virtual void abort() {};
 
     /** @inheritDoc */
-    virtual bool close(int timeout = -1) { (void)timeout; closed_ = true; return true; }
+    virtual bool close(int timeout = -1);
 
     /** @inheritDoc */
-    virtual void mark(size_t /*readlimit*/) { mark_ = currentPosition_; }
+    virtual void mark(size_t readlimit);
 
     /** @inheritDoc */
-    virtual void reset() { currentPosition_ = mark_; }
+    virtual void reset();
 
     /** @inheritDoc */
     virtual bool markSupported() { return true; }
@@ -81,6 +81,9 @@ public:
 
     /** @inheritDoc */
     virtual int read(ByteArray& out, size_t offset, size_t len, int timeout = -1);
+
+    /** @inheritDoc */
+    virtual int skip(size_t n, int timeout = -1);
 
 private:
 	/** Backing data. */

--- a/core/src/main/cpp/io/ByteArrayInputStream.h
+++ b/core/src/main/cpp/io/ByteArrayInputStream.h
@@ -85,7 +85,7 @@ public:
     /** @inheritDoc */
     virtual int skip(size_t n, int timeout = -1);
 
-private:
+protected:
 	/** Backing data. */
 	std::shared_ptr<ByteArray> data_;
 	/** Closed. */

--- a/core/src/main/cpp/io/InputStream.h
+++ b/core/src/main/cpp/io/InputStream.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,30 @@ public:
      *         is closed.
      */
     virtual int read(ByteArray& out, size_t offset, size_t len, int timeout = -1) = 0;
+
+    /**
+     * <p>Skips over and discards <code>n</code> bytes of data from this
+     * input stream. The <code>skip</code> method may, for a variety of
+     * reasons, end up skipping over some smaller number of bytes, possibly
+     * <code>0</code>.</p>
+     *
+     * <p>Skipped bytes must still be accounted for by mark() and
+     * reset().</p>
+     *
+     * <p>The default implementation calls read() with the requested number
+     * of bytes.</p>
+     *
+     * @param the number of bytes to be skipped.
+     * @param timeout skip timeout in milliseconds or -1 for no timeout.
+     * @return the actual number of bytes skipped.
+     * @throws IOException if skip is not supported, if there is an error
+     *         skipping over the data, or if the stream is closed.
+     */
+    virtual int skip(size_t n, int timeout = -1)
+    {
+        ByteArray data(n);
+        return read(data, timeout);
+    }
 };
 
 }}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/MslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/MslEncoderFactory.cpp
@@ -126,8 +126,8 @@ shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStre
     shared_ptr<InputStream> bufferedSource = source->markSupported() ? source : make_shared<BufferedInputStream>(source);
     const int WIDTH = 1;
     ByteArray buffer(WIDTH);
-    source->mark(1);
-    const int count = source->read(buffer, 0, WIDTH, TIMEOUT); // TODO: Someone has to tell me this timeout.
+    bufferedSource->mark(1);
+    const int count = bufferedSource->read(buffer, 0, WIDTH, TIMEOUT); // TODO: Someone has to tell me this timeout.
     if (count == -1)
         throw new MslEncoderException("End of stream reached when attempting to read the byte stream identifier.");
     if (count == 0)
@@ -143,8 +143,8 @@ shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStre
     }
 
     // Reset the input stream and return the tokenizer.
-    source->reset();
-    return generateTokenizer(source, format);
+    bufferedSource->reset();
+    return generateTokenizer(bufferedSource, format);
 }
 
 }}} // namespace netflix::msl::io

--- a/core/src/main/cpp/io/MslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/MslEncoderFactory.cpp
@@ -123,7 +123,7 @@ MslEncoderFormat MslEncoderFactory::parseFormat(shared_ptr<ByteArray> encoding)
 shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStream> source)
 {
     // Read the byte stream identifier (and only the identifier).
-    shared_ptr<InputStream> bufferedSource = source->markSupported() ? source : make_shared<BufferedInputStream>(source);
+    shared_ptr<InputStream> bufferedSource = source->markSupported() ? source : make_shared<BufferedInputStream>(source, 1);
     const int WIDTH = 1;
     ByteArray buffer(WIDTH);
     bufferedSource->mark(1);

--- a/core/src/main/cpp/io/MslEncoderFactory.cpp
+++ b/core/src/main/cpp/io/MslEncoderFactory.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include <io/InputStream.h>
+#include <io/BufferedInputStream.h>
 #include <io/MslArray.h>
 #include <io/MslEncoderFactory.h>
 #include <io/MslEncoderFormat.h>
 #include <io/MslObject.h>
+
 #include <iomanip>
 #include <iosfwd>
 #include <sstream>
@@ -120,7 +122,8 @@ MslEncoderFormat MslEncoderFactory::parseFormat(shared_ptr<ByteArray> encoding)
 
 shared_ptr<MslTokenizer> MslEncoderFactory::createTokenizer(shared_ptr<InputStream> source)
 {
-    // Read the byte stream identifier.
+    // Read the byte stream identifier (and only the identifier).
+    shared_ptr<InputStream> bufferedSource = source->markSupported() ? source : make_shared<BufferedInputStream>(source);
     const int WIDTH = 1;
     ByteArray buffer(WIDTH);
     source->mark(1);

--- a/core/src/main/cpp/io/MslTokenizer.cpp
+++ b/core/src/main/cpp/io/MslTokenizer.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ namespace io {
 
 bool MslTokenizer::more(int timeout)
 {
-    if (aborted_)
+    if (aborted_ || closed_)
         return false;
     if (next_)
         return true;
@@ -35,7 +35,7 @@ bool MslTokenizer::more(int timeout)
 
 shared_ptr<MslObject> MslTokenizer::nextObject(int timeout)
 {
-    if (aborted_)
+    if (aborted_ || closed_)
         return shared_ptr<MslObject>();
     if (next_)
     {

--- a/core/src/main/cpp/io/MslTokenizer.h
+++ b/core/src/main/cpp/io/MslTokenizer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,15 @@ public:
     /**
      * <p>Create a new tokenizer.</p>
      */
-    MslTokenizer() : aborted_(false) {}
+    MslTokenizer() : closed_(false), aborted_(false) {}
+
+    /**
+     * <p>Closes the tokenizer, cleaning up any resources and preventing future
+     * use.</p>
+     *
+     * @throws MslEncoderException if there is an error closing the tokenizer.
+     */
+    virtual void close() { closed_ = true; }
 
     /**
      * <p>Aborts future reading off the tokenizer.</p>
@@ -49,7 +57,7 @@ public:
      *
      * @param timeout read timeout in milliseconds or -1 for no timeout (default).
      * @return true if more objects are available from the data source, false
-     *         if the tokenizer has been aborted.
+     *         if the tokenizer has been aborted or closed.
      * @throws MslEncoderException if the next object cannot be read or the
      *         source data at the current position is invalid.
      */
@@ -78,13 +86,15 @@ public:
      *
      * @param timeout read timeout in milliseconds or -1 for no timeout (default).
      * @return the next object or an empty object if there are no more or the
-     *         tokenizer has been aborted.
+     *         tokenizer has been aborted or closed;
      * @throws MslEncoderException if the next object cannot be read or the
      *         source data at the current position is invalid.
      */
     virtual std::shared_ptr<MslObject> nextObject(int timeout = -1);
 
 private:
+    /** Closed. */
+    bool closed_;
     /** Aborted. */
     bool aborted_;
     /** Cached next object. */

--- a/core/src/main/cpp/io/Url.h
+++ b/core/src/main/cpp/io/Url.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,25 +26,73 @@ namespace io {
 
 class Connection;
 
+/**
+ * The URL interface provides access to an input stream and output stream tied
+ * to a specific URL.
+ */
 class Url
 {
 public:
     virtual ~Url() {};
-    
-    virtual std::shared_ptr<Connection> openConnection() = 0;
 
+    /**
+     * Open a new connection to the target location.
+     *
+     * @return a {@link #Connection} linking to the URL.
+     * @throws IOException if an I/O exception occurs.
+     */
     virtual void setTimeout(int64_t timeout) = 0;
+
+    /**
+     * Open a new connection to the target location.
+     *
+     * @return a {@link #Connection} linking to the URL.
+     * @throws IOException if an I/O exception occurs.
+     */
+    virtual std::shared_ptr<Connection> openConnection() = 0;
 };
 
+/**
+ * The Connection interface represents a communication link between the
+ * application and a URL.
+ */
 class Connection
 {
 public:
     virtual ~Connection() {};
-    
+
+    /**
+     * <p>Returns an input stream that reads from this connection.</p>
+     *
+     * <p>Asking for the input stream must not prevent use of the output
+     * stream, but reading from the input stream may prevent further
+     * writing to the output stream.</p>
+     *
+     * <p>The returned input stream must support
+     * {@link InputStream#mark(int)}, {@link InputStream#reset()}, and
+     * {@link InputStream#skip(long)} if you wish to use it for more than
+     * one MSL message.</p>
+     *
+     * @return an input stream that reads from this connection.
+     * @throws IOException if an I/O error occurs while creating the input
+     *         stream.
+     */
     virtual std::shared_ptr<InputStream> getInputStream() = 0;
+
+    /**
+     * <p>Returns an output stream that writes to this connection.</p>
+     *
+     * <p>Asking for the output stream must not prevent use of the input
+     * stream, but writing to the output stream may prevent further reading
+     * from the input stream.</p>
+     *
+     * @return an output stream that writes to this connection.
+     * @throws IOException if an I/O error occurs while creating the output
+     *         stream.
+     */
     virtual std::shared_ptr<OutputStream> getOutputStream() = 0;
 };
-    
+
 }}} // namespace netflix::msl::io
 
 #endif /* SRC_IO_URL_H_ */

--- a/core/src/main/cpp/msg/ConsoleFilterStreamFactory.cpp
+++ b/core/src/main/cpp/msg/ConsoleFilterStreamFactory.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,18 +74,24 @@ public:
 
     /** @inheritDoc */
     virtual int read(ByteArray& out, int timeout = -1) {
-    	return read(out, 0, out.size(), timeout);
+        return read(out, 0, out.size(), timeout);
     }
 
     /** @inheritDoc */
     virtual int read(ByteArray& out, size_t offset, size_t len, int timeout) {
         int r = in_->read(out, offset, len, timeout);
         if (r > 0) {
-        	cout.write(reinterpret_cast<const char*>(&out[0]), r);
-        	cout.flush();
+            cout.write(reinterpret_cast<const char*>(&out[0]), r);
+            cout.flush();
         }
         return r;
     }
+
+    /** @inheritDoc */
+    virtual int skip(size_t n, int timeout = -1) {
+        return in_->skip(n, timeout);
+    }
+
 private:
     /** Backing input stream. */
     shared_ptr<InputStream> in_;
@@ -114,9 +120,9 @@ public:
 
     /** @inheritDoc */
     virtual bool close() {
-    	cout << endl;
-    	cout.flush();
-    	return out_->close();
+        cout << endl;
+        cout.flush();
+        return out_->close();
     }
 
     /** @inheritDoc */
@@ -124,19 +130,19 @@ public:
 
     /** @inheritDoc */
     virtual size_t write(const ByteArray& data, size_t off, size_t len, int timeout) {
-    	if (off + len > data.size()) {
-    		stringstream ss;
-    		ss << "offset " << off << " plus length " << len << " exceeds data size " << data.size();
-    		throw RangeException(ss.str());
-    	}
-    	cout.write(reinterpret_cast<const char*>(&data[off]), static_cast<streamsize>(len));
-    	cout.flush();
-    	return out_->write(data, off, len, timeout);
+        if (off + len > data.size()) {
+            stringstream ss;
+            ss << "offset " << off << " plus length " << len << " exceeds data size " << data.size();
+            throw RangeException(ss.str());
+        }
+        cout.write(reinterpret_cast<const char*>(&data[off]), static_cast<streamsize>(len));
+        cout.flush();
+        return out_->write(data, off, len, timeout);
     }
 
     /** @inheritDoc */
     virtual bool flush(int timeout) {
-    	return out_->flush(timeout);
+        return out_->flush(timeout);
     }
 
 private:

--- a/core/src/main/cpp/msg/MessageBuilder.h
+++ b/core/src/main/cpp/msg/MessageBuilder.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,23 @@ public:
      */
     static std::shared_ptr<MessageBuilder> createResponse(std::shared_ptr<util::MslContext> ctx,
                                                           std::shared_ptr<MessageHeader> requestHeader);
+
+    /**
+     * Create a new message builder that will craft a new message in response
+     * to another message without issuing or renewing any master tokens or user
+     * ID tokens. The constructed message may be used as a request.
+     *
+     * @param ctx MSL context.
+     * @param requestHeader message header to respond to.
+     * @return the message builder.
+     * @throws MslCryptoException if there is an error accessing the remote
+     *         entity identity.
+     * @throws MslException if any of the request's user ID tokens is not bound
+     *         to its master token.
+     */
+    static std::shared_ptr<MessageBuilder> createIdempotentResponse(std::shared_ptr<util::MslContext> ctx,
+                                                                    std::shared_ptr<MessageHeader> requestHeader);
+
     /**
      * <p>Create a new message builder that will craft a new error message in
      * response to another message. If the message ID of the request is not
@@ -240,6 +257,19 @@ public:
      * @throws MslException should not happen.
      */
     std::shared_ptr<MessageHeader> getHeader();
+
+    /**
+     * <p>Set the message ID.</p>
+     *
+     * <p>This method will override the message ID that was computed when the
+     * message builder was created, and should not need to be called in most
+     * cases.</p>
+     *
+     * @param messageId the message ID.
+     * @return this.
+     * @throws MslInternalException if the message ID is out of range.
+     */
+    std::shared_ptr<MessageBuilder> setMessageId(int64_t messageId);
 
     /**
      * @return true if the message will be marked non-replayable.
@@ -506,7 +536,7 @@ private:
     /** Message recipient. */
     const std::string recipient_;
     /** Header data message ID. */
-    const int64_t messageId_;
+    int64_t messageId_;
     /** Key exchange data. */
     std::shared_ptr<keyx::KeyExchangeFactory::KeyExchangeData> keyExchangeData_;
     /** Message non-replayable. */

--- a/core/src/main/cpp/msg/MessageInputStream.cpp
+++ b/core/src/main/cpp/msg/MessageInputStream.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -457,8 +457,9 @@ bool MessageInputStream::close(int timeout)
 {
 	// Only close the source if instructed to do so because we might want
 	// to reuse the connection.
-	if (closeSource_)
+	if (closeSource_) {
 		source_->close(timeout);
+	}
 
 	// Otherwise if this is not a handshake message or error message then
 	// consume all payloads that may still be on the source input stream.
@@ -473,6 +474,13 @@ bool MessageInputStream::close(int timeout)
 		} catch (const MslException& e) {
 			// Ignore exceptions.
 		}
+	}
+
+	// Close the tokenizer.
+	try {
+	    tokenizer_->close();
+	} catch (const MslEncoderException& e) {
+	    // Ignore exceptions.
 	}
 
 	// Success.

--- a/core/src/main/cpp/msg/ServerReceiveMessageContext.h
+++ b/core/src/main/cpp/msg/ServerReceiveMessageContext.h
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SRC_MSG_SERVERRECEIVEMESSAGECONTEXT_H_
+#define SRC_MSG_SERVERRECEIVEMESSAGECONTEXT_H_
+
+#include <msg/PublicMessageContext.h>
+
+#include <map>
+#include <string>
+
+namespace netflix {
+namespace msl {
+namespace crypto { class ICryptoContext; }
+namespace keyx { class KeyRequestData; }
+namespace tokens { class MslUser; }
+namespace userauth { class UserAuthenticationData; }
+namespace msg {
+class MessageDebugContext; class MessageOutputStream; class MessageServiceTokenBuilder;
+
+/**
+ * <p>A trusted services network message context used to receive client
+ * messages suitable for use with
+ * {@link MslControl#receive(com.netflix.msl.util.MslContext, MessageContext, java.io.InputStream, java.io.OutputStream, int)}.
+ * Since this message context is only used for receiving messages, it cannot be
+ * used to send application data back to the client and does not require
+ * encryption or integrity protection.</p>
+ *
+ * <p>The application may wish to override
+ * {@link #updateServiceTokens(MessageServiceTokenBuilder, boolean)} to
+ * modify any service tokens sent in handshake responses.</p>
+ *
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+class ServerReceiveMessageContext : public PublicMessageContext
+{
+public:
+    virtual ~ServerReceiveMessageContext() {}
+
+    /**
+     * <p>Create a new receive message context.</p>
+     *
+     * @param cryptoContexts service token crypto contexts. May be
+     *        {@code null}.
+     * @param dbgCtx optional message debug context. May be {@code null}.
+     */
+    ServerReceiveMessageContext(std::map<std::string,std::shared_ptr<crypto::ICryptoContext>> cryptoContexts, std::shared_ptr<MessageDebugContext> dbgCtx)
+        : cryptoContexts_(cryptoContexts)
+        , dbgCtx_(dbgCtx)
+    {}
+
+    /** @inheritDoc */
+    std::map<std::string,std::shared_ptr<crypto::ICryptoContext>> getCryptoContexts() {
+        return std::map<std::string,std::shared_ptr<crypto::ICryptoContext>>(cryptoContexts_);
+    }
+
+    /** @inheritDoc */
+    std::string getRecipient() { return std::string(); }
+
+    /** @inheritDoc */
+    bool isRequestingTokens() { return false; }
+
+    /** @inheritDoc */
+    std::string getUserId() { return std::string(); }
+
+    /** @inheritDoc */
+    std::shared_ptr<userauth::UserAuthenticationData> getUserAuthData(const ReauthCode& reauthCode, bool renewable, bool required) { return std::shared_ptr<userauth::UserAuthenticationData>(); }
+
+    /** @inheritDoc */
+    std::shared_ptr<tokens::MslUser> getUser() { return std::shared_ptr<tokens::MslUser>(); }
+
+    /** @inheritDoc */
+    std::set<keyx::KeyRequestData> getKeyRequestData() { return std::set<keyx::KeyRequestData>(); }
+
+    /** @inheritDoc */
+    void updateServiceTokens(std::shared_ptr<MessageServiceTokenBuilder> builder, bool handshake) {}
+
+    /** @inheritDoc */
+    void write(std::shared_ptr<MessageOutputStream> output) {}
+
+    /** @inheritDoc */
+    std::shared_ptr<MessageDebugContext> getDebugContext() { return dbgCtx_; }
+
+protected:
+    /** Service token crypto contexts. */
+    std::map<std::string,crypto::ICryptoContext> cryptoContexts_;
+    /** Message debug context. */
+    std::shared_ptr<MessageDebugContext> dbgCtx_;
+};
+
+}}} // namespace netflix::msl::msg
+
+#endif /* SRC_MSG_SERVERRECEIVEMESSAGECONTEXT_H_ */

--- a/core/src/main/java/com/netflix/msl/io/JavaUrl.java
+++ b/core/src/main/java/com/netflix/msl/io/JavaUrl.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.msl.io;
 
+import java.io.BufferedInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,10 +29,124 @@ import java.net.URLConnection;
  */
 public class JavaUrl implements Url {
     /**
+     * <p>A delayed input stream does not open the real input stream until one
+     * of its methods is called. This class may be useful in situations where
+     * the connection will not permit use of its output stream after the input
+     * stream is requested.</p>
+     * 
+     * <p>The input stream itself will be a {@link BufferedInputStream} which
+     * will read ahead for improved performance, and support the
+     * {@link #mark(int)}, {@link #reset()}, and {@link #skip(long)}
+     * methods. This is necessary to facilitate stream reuse across multiple
+     * MSL messages.</p>
+     */
+    public class DelayedInputStream extends FilterInputStream {
+        /**
+         * Create a new delayed input stream that will not attempt to
+         * construct the input stream from the URL connection until it is
+         * actually needed (i.e. read from).
+         * 
+         * @param conn backing URL connection.
+         */
+        public DelayedInputStream(final URLConnection conn) {
+            super(null);
+            this.conn = conn;
+        }
+        
+        /**
+         * <p>If the connection input stream has not already been opened, open
+         * it and wrap it inside a {@link BufferedInputStream}, then assign it
+         * to the parent member variable {@link FilterInputStream#in}.</p>
+         * 
+         * <p>If mark was called and delayed, also mark the input stream.</p>
+         * 
+         * @throws IOException any exception thrown by
+         *         {@link URLConnection#getInputStream()}.
+         */
+        private void openOnce() throws IOException {
+            // Return immediately if already open.
+            if (in != null) return;
+            
+            // Open and wrap the input stream.
+            final InputStream source = conn.getInputStream();
+            in = new BufferedInputStream(source);
+                
+            // If mark had been called earlier, mark the input stream now.
+            if (readlimit != -1)
+                in.mark(readlimit);
+        }
+        
+        @Override
+        public int available() throws IOException {
+            openOnce();
+            return super.available();
+        }
+
+        @Override
+        public void close() throws IOException {
+            openOnce();
+            super.close();
+        }
+
+        @Override
+        public synchronized void mark(final int readlimit) {
+            // Mark the BufferedInputStream if it is already open.
+            if (in != null)
+                super.mark(readlimit);
+            
+            // Otherwise remember that mark was called so it can be called on
+            // the BufferedInputStream once opened.
+            else
+                this.readlimit = readlimit;
+        }
+
+        @Override
+        public boolean markSupported() {
+            // BufferedInputStream supports mark.
+            return true;
+        }
+
+        @Override
+        public int read() throws IOException {
+            openOnce();
+            return super.read();
+        }
+
+        @Override
+        public int read(final byte[] b, final int off, final int len) throws IOException {
+            openOnce();
+            return super.read(b, off, len);
+        }
+
+        @Override
+        public int read(final byte[] b) throws IOException {
+            openOnce();
+            return super.read(b);
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+            openOnce();
+            super.reset();
+        }
+
+        @Override
+        public long skip(final long n) throws IOException {
+            openOnce();
+            return super.skip(n);
+        }
+        
+        /** Connection providing the input stream. */
+        private final URLConnection conn;
+        /** Mark read limit. -1 if no mark is set. */
+        private int readlimit = -1;
+    }
+    
+    /**
      * An implementation of the {@link Connection} interface backed by the
      * built-in Java {@link URLConnection} class.
      */
-    public class JavaConnection implements Connection {
+    private class JavaConnection implements Connection {
         /**
          * Create a new Java connection with the backing URL connection.
          * 
@@ -45,7 +161,9 @@ public class JavaUrl implements Url {
          */
         @Override
         public InputStream getInputStream() throws IOException {
-            return conn.getInputStream();
+            // Asking for the URL connection's input stream prevents further
+            // writing to the output stream, so return a delayed input stream.
+            return new DelayedInputStream(conn);
         }
 
         /* (non-Javadoc)

--- a/core/src/main/java/com/netflix/msl/io/MslEncoderFactory.java
+++ b/core/src/main/java/com/netflix/msl/io/MslEncoderFactory.java
@@ -157,8 +157,8 @@ public abstract class MslEncoderFactory {
      *         is not supported.
      */
     public MslTokenizer createTokenizer(final InputStream source) throws IOException, MslEncoderException {
-        // Read the byte stream identifier.
-        final InputStream bufferedSource = source.markSupported() ? source : new BufferedInputStream(source);
+        // Read the byte stream identifier (and only the identifier).
+        final InputStream bufferedSource = source.markSupported() ? source : new BufferedInputStream(source, 1);
         bufferedSource.mark(1);
         final byte id = (byte)bufferedSource.read();
         if (id == -1)

--- a/core/src/main/java/com/netflix/msl/io/MslTokenizer.java
+++ b/core/src/main/java/com/netflix/msl/io/MslTokenizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,13 @@ package com.netflix.msl.io;
  */
 public abstract class MslTokenizer {
     /**
-     * <p>Create a new tokenizer.</p>
+     * <p>Closes the tokenizer, cleaning up any resources and preventing future
+     * use.</p>
+     * 
+     * @throws MslEncoderException if there is an error closing the tokenizer.
      */
-    protected MslTokenizer() {
-        this.aborted = false;
-        this.next = null;
+    public void close() throws MslEncoderException {
+        closed = true;
     }
     
     /**
@@ -43,12 +45,12 @@ public abstract class MslTokenizer {
      * 
      * @param timeout read timeout in milliseconds or -1 for no timeout.
      * @return true if more objects are available from the data source, false
-     *         if the tokenizer has been aborted.
+     *         if the tokenizer has been aborted or closed.
      * @throws MslEncoderException if the next object cannot be read or the
      *         source data at the current position is invalid.
      */
     public boolean more(final int timeout) throws MslEncoderException {
-        if (aborted) return false;
+        if (aborted || closed) return false;
         if (next != null) return true;
         next = nextObject(timeout);
         return (next != null);
@@ -77,12 +79,12 @@ public abstract class MslTokenizer {
      * 
      * @param timeout read timeout in milliseconds or -1 for no timeout.
      * @return the next object or {@code null} if there are no more or the
-     *         tokenizer has been aborted.
+     *         tokenizer has been aborted or closed.
      * @throws MslEncoderException if the next object cannot be read or the
      *         source data at the current position is invalid.
      */
     public MslObject nextObject(final int timeout) throws MslEncoderException {
-        if (aborted) return null;
+        if (aborted || closed) return null;
         if (next != null) {
             final MslObject mo = next;
             next = null;
@@ -91,8 +93,10 @@ public abstract class MslTokenizer {
         return next(timeout);
     }
     
+    /** Closed. */
+    private boolean closed = false;
     /** Aborted. */
-    private boolean aborted;
+    private boolean aborted = false;
     /** Cached next object. */
-    private MslObject next;
+    private MslObject next = null;
 }

--- a/core/src/main/java/com/netflix/msl/io/ThriftyUtf8Reader.java
+++ b/core/src/main/java/com/netflix/msl/io/ThriftyUtf8Reader.java
@@ -1,0 +1,485 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+/**
+ * <p>A specialized UTF-8 reader that only reads exactly the number of bytes
+ * necessary to decode the character, and does not close the underlying input
+ * stream. This ensures any unneeded bytes remain on the input stream, which
+ * can then be reused.</p>
+ * 
+ * <p>Based on Andy Clark's
+ * {@code com.sun.org.apache.xerces.internal.impl.io.UTF8Reader}.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class ThriftyUtf8Reader extends Reader {
+    /** Default byte buffer size (8192). */
+    public static final int DEFAULT_BUFFER_SIZE = 8192;
+    
+    /** Input stream. */
+    private final InputStream fInputStream;
+    /** Byte buffer. */
+    private final byte[] fBuffer = new byte[DEFAULT_BUFFER_SIZE];
+    /** Offset into buffer. */
+    private int fOffset = 0;
+    /** Surrogate character. */
+    private int fSurrogate = -1;
+    
+    public ThriftyUtf8Reader(final InputStream inputStream) {
+        fInputStream = inputStream;
+    }
+    
+    @Override
+    public int read() throws IOException {
+        // decode character
+        int c = fSurrogate;
+        if (fSurrogate == -1) {
+            // NOTE: We use the index into the buffer if there are remaining
+            //       bytes from the last block read. -Ac
+            int index = 0;
+
+            // get first byte
+            final int b0 = index == fOffset
+                   ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+            if (b0 == -1) {
+                return -1;
+            }
+
+            // UTF-8:   [0xxx xxxx]
+            // Unicode: [0000 0000] [0xxx xxxx]
+            if (b0 < 0x80) {
+                c = (char)b0;
+            }
+
+            // UTF-8:   [110y yyyy] [10xx xxxx]
+            // Unicode: [0000 0yyy] [yyxx xxxx]
+            else if ((b0 & 0xE0) == 0xC0 && (b0 & 0x1E) != 0) {
+                final int b1 = index == fOffset
+                       ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+                if (b1 == -1) {
+                    expectedByte(2, 2);
+                }
+                if ((b1 & 0xC0) != 0x80) {
+                    invalidByte(2, 2, b1);
+                }
+                c = ((b0 << 6) & 0x07C0) | (b1 & 0x003F);
+            }
+
+            // UTF-8:   [1110 zzzz] [10yy yyyy] [10xx xxxx]
+            // Unicode: [zzzz yyyy] [yyxx xxxx]
+            else if ((b0 & 0xF0) == 0xE0) {
+                final int b1 = index == fOffset
+                       ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+                if (b1 == -1) {
+                    expectedByte(2, 3);
+                }
+                if ((b1 & 0xC0) != 0x80
+                    || (b0 == 0xED && b1 >= 0xA0)
+                    || ((b0 & 0x0F) == 0 && (b1 & 0x20) == 0)) {
+                    invalidByte(2, 3, b1);
+                }
+                final int b2 = index == fOffset
+                       ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+                if (b2 == -1) {
+                    expectedByte(3, 3);
+                }
+                if ((b2 & 0xC0) != 0x80) {
+                    invalidByte(3, 3, b2);
+                }
+                c = ((b0 << 12) & 0xF000) | ((b1 << 6) & 0x0FC0) |
+                    (b2 & 0x003F);
+            }
+
+            // UTF-8:   [1111 0uuu] [10uu zzzz] [10yy yyyy] [10xx xxxx]*
+            // Unicode: [1101 10ww] [wwzz zzyy] (high surrogate)
+            //          [1101 11yy] [yyxx xxxx] (low surrogate)
+            //          * uuuuu = wwww + 1
+            else if ((b0 & 0xF8) == 0xF0) {
+                final int b1 = index == fOffset
+                       ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+                if (b1 == -1) {
+                    expectedByte(2, 4);
+                }
+                if ((b1 & 0xC0) != 0x80
+                    || ((b1 & 0x30) == 0 && (b0 & 0x07) == 0)) {
+                    invalidByte(2, 3, b1);
+                }
+                final int b2 = index == fOffset
+                       ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+                if (b2 == -1) {
+                    expectedByte(3, 4);
+                }
+                if ((b2 & 0xC0) != 0x80) {
+                    invalidByte(3, 3, b2);
+                }
+                final int b3 = index == fOffset
+                       ? fInputStream.read() : fBuffer[index++] & 0x00FF;
+                if (b3 == -1) {
+                    expectedByte(4, 4);
+                }
+                if ((b3 & 0xC0) != 0x80) {
+                    invalidByte(4, 4, b3);
+                }
+                final int uuuuu = ((b0 << 2) & 0x001C) | ((b1 >> 4) & 0x0003);
+                if (uuuuu > 0x10) {
+                    invalidSurrogate(uuuuu);
+                }
+                final int wwww = uuuuu - 1;
+                final int hs = 0xD800 |
+                         ((wwww << 6) & 0x03C0) | ((b1 << 2) & 0x003C) |
+                         ((b2 >> 4) & 0x0003);
+                final int ls = 0xDC00 | ((b2 << 6) & 0x03C0) | (b3 & 0x003F);
+                c = hs;
+                fSurrogate = ls;
+            }
+
+            // error
+            else {
+                invalidByte(1, 1, b0);
+            }
+        }
+
+        // use surrogate
+        else {
+            fSurrogate = -1;
+        }
+
+        // return character
+        return c;
+    }
+
+    @Override
+    public int read(final char ch[], final int offset, int length) throws IOException {
+        // handle surrogate
+        int out = offset;
+        if (fSurrogate != -1) {
+            ch[offset + 1] = (char)fSurrogate;
+            fSurrogate = -1;
+            length--;
+            out++;
+        }
+
+        // read bytes
+        int count = 0;
+        if (fOffset == 0) {
+            // adjust length to read
+            if (length > fBuffer.length) {
+                length = fBuffer.length;
+            }
+
+            // perform read operation
+            count = fInputStream.read(fBuffer, 0, length);
+            if (count == -1) {
+                return -1;
+            }
+            count += out - offset;
+        }
+
+        // skip read; last character was in error
+        // NOTE: Having an offset value other than zero means that there was
+        //       an error in the last character read. In this case, we have
+        //       skipped the read so we don't consume any bytes past the
+        //       error. By signalling the error on the next block read we
+        //       allow the method to return the most valid characters that
+        //       it can on the previous block read. -Ac
+        else {
+            count = fOffset;
+            fOffset = 0;
+        }
+
+        // convert bytes to characters
+        final int total = count;
+        int in;
+        byte byte1;
+        final byte byte0 = 0;
+        for (in = 0; in < total; in++) {
+            byte1 = fBuffer[in];
+            if (byte1 >= byte0) {
+                ch[out++] = (char)byte1;
+            }
+            else   {
+                break;
+            }
+        }
+        for ( ; in < total; in++) {
+            byte1 = fBuffer[in];
+
+            // UTF-8:   [0xxx xxxx]
+            // Unicode: [0000 0000] [0xxx xxxx]
+            if (byte1 >= byte0) {
+                ch[out++] = (char)byte1;
+                continue;
+            }
+
+            // UTF-8:   [110y yyyy] [10xx xxxx]
+            // Unicode: [0000 0yyy] [yyxx xxxx]
+            final int b0 = byte1 & 0x0FF;
+            if ((b0 & 0xE0) == 0xC0 && (b0 & 0x1E) != 0) {
+                int b1 = -1;
+                if (++in < total) {
+                    b1 = fBuffer[in] & 0x00FF;
+                }
+                else {
+                    b1 = fInputStream.read();
+                    if (b1 == -1) {
+                        if (out > offset) {
+                            fBuffer[0] = (byte)b0;
+                            fOffset = 1;
+                            return out - offset;
+                        }
+                        expectedByte(2, 2);
+                    }
+                    count++;
+                }
+                if ((b1 & 0xC0) != 0x80) {
+                    if (out > offset) {
+                        fBuffer[0] = (byte)b0;
+                        fBuffer[1] = (byte)b1;
+                        fOffset = 2;
+                        return out - offset;
+                    }
+                    invalidByte(2, 2, b1);
+                }
+                final int c = ((b0 << 6) & 0x07C0) | (b1 & 0x003F);
+                ch[out++] = (char)c;
+                count -= 1;
+                continue;
+            }
+
+            // UTF-8:   [1110 zzzz] [10yy yyyy] [10xx xxxx]
+            // Unicode: [zzzz yyyy] [yyxx xxxx]
+            if ((b0 & 0xF0) == 0xE0) {
+                int b1 = -1;
+                if (++in < total) {
+                    b1 = fBuffer[in] & 0x00FF;
+                }
+                else {
+                    b1 = fInputStream.read();
+                    if (b1 == -1) {
+                        if (out > offset) {
+                            fBuffer[0] = (byte)b0;
+                            fOffset = 1;
+                            return out - offset;
+                        }
+                        expectedByte(2, 3);
+                    }
+                    count++;
+                }
+                if ((b1 & 0xC0) != 0x80
+                    || (b0 == 0xED && b1 >= 0xA0)
+                    || ((b0 & 0x0F) == 0 && (b1 & 0x20) == 0)) {
+                    if (out > offset) {
+                        fBuffer[0] = (byte)b0;
+                        fBuffer[1] = (byte)b1;
+                        fOffset = 2;
+                        return out - offset;
+                    }
+                    invalidByte(2, 3, b1);
+                }
+                int b2 = -1;
+                if (++in < total) {
+                    b2 = fBuffer[in] & 0x00FF;
+                }
+                else {
+                    b2 = fInputStream.read();
+                    if (b2 == -1) {
+                        if (out > offset) {
+                            fBuffer[0] = (byte)b0;
+                            fBuffer[1] = (byte)b1;
+                            fOffset = 2;
+                            return out - offset;
+                        }
+                        expectedByte(3, 3);
+                    }
+                    count++;
+                }
+                if ((b2 & 0xC0) != 0x80) {
+                    if (out > offset) {
+                        fBuffer[0] = (byte)b0;
+                        fBuffer[1] = (byte)b1;
+                        fBuffer[2] = (byte)b2;
+                        fOffset = 3;
+                        return out - offset;
+                    }
+                    invalidByte(3, 3, b2);
+                }
+                final int c = ((b0 << 12) & 0xF000) | ((b1 << 6) & 0x0FC0) |
+                        (b2 & 0x003F);
+                ch[out++] = (char)c;
+                count -= 2;
+                continue;
+            }
+
+            // UTF-8:   [1111 0uuu] [10uu zzzz] [10yy yyyy] [10xx xxxx]*
+            // Unicode: [1101 10ww] [wwzz zzyy] (high surrogate)
+            //          [1101 11yy] [yyxx xxxx] (low surrogate)
+            //          * uuuuu = wwww + 1
+            if ((b0 & 0xF8) == 0xF0) {
+                int b1 = -1;
+                if (++in < total) {
+                    b1 = fBuffer[in] & 0x00FF;
+                }
+                else {
+                    b1 = fInputStream.read();
+                    if (b1 == -1) {
+                        if (out > offset) {
+                            fBuffer[0] = (byte)b0;
+                            fOffset = 1;
+                            return out - offset;
+                        }
+                        expectedByte(2, 4);
+                    }
+                    count++;
+                }
+                if ((b1 & 0xC0) != 0x80
+                    || ((b1 & 0x30) == 0 && (b0 & 0x07) == 0)) {
+                    if (out > offset) {
+                        fBuffer[0] = (byte)b0;
+                        fBuffer[1] = (byte)b1;
+                        fOffset = 2;
+                        return out - offset;
+                    }
+                    invalidByte(2, 4, b1);
+                }
+                int b2 = -1;
+                if (++in < total) {
+                    b2 = fBuffer[in] & 0x00FF;
+                }
+                else {
+                    b2 = fInputStream.read();
+                    if (b2 == -1) {
+                        if (out > offset) {
+                            fBuffer[0] = (byte)b0;
+                            fBuffer[1] = (byte)b1;
+                            fOffset = 2;
+                            return out - offset;
+                        }
+                        expectedByte(3, 4);
+                    }
+                    count++;
+                }
+                if ((b2 & 0xC0) != 0x80) {
+                    if (out > offset) {
+                        fBuffer[0] = (byte)b0;
+                        fBuffer[1] = (byte)b1;
+                        fBuffer[2] = (byte)b2;
+                        fOffset = 3;
+                        return out - offset;
+                    }
+                    invalidByte(3, 4, b2);
+                }
+                int b3 = -1;
+                if (++in < total) {
+                    b3 = fBuffer[in] & 0x00FF;
+                }
+                else {
+                    b3 = fInputStream.read();
+                    if (b3 == -1) {
+                        if (out > offset) {
+                            fBuffer[0] = (byte)b0;
+                            fBuffer[1] = (byte)b1;
+                            fBuffer[2] = (byte)b2;
+                            fOffset = 3;
+                            return out - offset;
+                        }
+                        expectedByte(4, 4);
+                    }
+                    count++;
+                }
+                if ((b3 & 0xC0) != 0x80) {
+                    if (out > offset) {
+                        fBuffer[0] = (byte)b0;
+                        fBuffer[1] = (byte)b1;
+                        fBuffer[2] = (byte)b2;
+                        fBuffer[3] = (byte)b3;
+                        fOffset = 4;
+                        return out - offset;
+                    }
+                    invalidByte(4, 4, b2);
+                }
+
+                // check if output buffer is large enough to hold 2 surrogate chars
+                if (out + 1 >= ch.length) {
+                    fBuffer[0] = (byte)b0;
+                    fBuffer[1] = (byte)b1;
+                    fBuffer[2] = (byte)b2;
+                    fBuffer[3] = (byte)b3;
+                    fOffset = 4;
+                    return out - offset;
+                }
+
+                // decode bytes into surrogate characters
+                final int uuuuu = ((b0 << 2) & 0x001C) | ((b1 >> 4) & 0x0003);
+                if (uuuuu > 0x10) {
+                    invalidSurrogate(uuuuu);
+                }
+                final int wwww = uuuuu - 1;
+                final int zzzz = b1 & 0x000F;
+                final int yyyyyy = b2 & 0x003F;
+                final int xxxxxx = b3 & 0x003F;
+                final int hs = 0xD800 | ((wwww << 6) & 0x03C0) | (zzzz << 2) | (yyyyyy >> 4);
+                final int ls = 0xDC00 | ((yyyyyy << 6) & 0x03C0) | xxxxxx;
+
+                // set characters
+                ch[out++] = (char)hs;
+                ch[out++] = (char)ls;
+                count -= 2;
+                continue;
+            }
+
+            // error
+            if (out > offset) {
+                fBuffer[0] = (byte)b0;
+                fOffset = 1;
+                return out - offset;
+            }
+            invalidByte(1, 1, b0);
+        }
+
+        // return number of characters converted
+        return count;
+    }
+
+    @Override
+    public void reset() {
+        fOffset = 0;
+        fSurrogate = -1;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /** Throws an exception for expected byte. */
+    private void expectedByte(final int position, final int count) throws IOException {
+        throw new IOException("Expected byte " + position + " for " + count + " byte sequence.");
+    }
+
+    /** Throws an exception for invalid byte. */
+    private void invalidByte(final int position, final int count, final int c) throws IOException {
+        throw new IOException("Invalid byte " + c + " at position " + position + " of " + count + " byte sequence.");
+    }
+
+    /** Throws an exception for invalid surrogate bits. */
+    private void invalidSurrogate(final int uuuuu) throws IOException {
+        throw new IOException("Invalid high surrogate " + uuuuu + ".");
+    }
+}

--- a/core/src/main/java/com/netflix/msl/io/Url.java
+++ b/core/src/main/java/com/netflix/msl/io/Url.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2016 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/netflix/msl/io/Url.java
+++ b/core/src/main/java/com/netflix/msl/io/Url.java
@@ -32,7 +32,16 @@ public interface Url {
      */
     public static interface Connection {
         /**
-         * Returns an input stream that reads from this connection.
+         * <p>Returns an input stream that reads from this connection.</p>
+         * 
+         * <p>Asking for the input stream must not prevent use of the output
+         * stream, but reading from the input stream may prevent further
+         * writing to the output stream.</p>
+         * 
+         * <p>The returned input stream must support
+         * {@link InputStream#mark(int)}, {@link InputStream#reset()}, and
+         * {@link InputStream#skip(long)} if you wish to use it for more than
+         * one MSL message.</p> 
          * 
          * @return an input stream that reads from this connection.
          * @throws IOException if an I/O error occurs while creating the input
@@ -41,7 +50,11 @@ public interface Url {
         public InputStream getInputStream() throws IOException;
         
         /**
-         * Returns an output stream that writes to this connection.
+         * <p>Returns an output stream that writes to this connection.</p>
+         * 
+         * <p>Asking for the output stream must not prevent use of the input
+         * stream, but writing to the output stream may prevent further reading
+         * from the input stream.</p>
          * 
          * @return an output stream that writes to this connection.
          * @throws IOException if an I/O error occurs while creating the output

--- a/core/src/main/java/com/netflix/msl/msg/ConsoleFilterStreamFactory.java
+++ b/core/src/main/java/com/netflix/msl/msg/ConsoleFilterStreamFactory.java
@@ -59,7 +59,7 @@ public class ConsoleFilterStreamFactory implements FilterStreamFactory {
          */
         @Override
         public int read() throws IOException {
-            int c = super.read();
+            final int c = in.read();
             System.out.write(c);
             System.out.flush();
             return c;
@@ -70,8 +70,8 @@ public class ConsoleFilterStreamFactory implements FilterStreamFactory {
          */
         @Override
         public int read(final byte[] b, final int off, final int len) throws IOException {
-            int r = super.read(b, off, len);
-            System.out.write(b, off,len);
+            final int r = in.read(b, off, len);
+            System.out.write(b, off, len);
             System.out.flush();
             return r;
         }
@@ -109,7 +109,7 @@ public class ConsoleFilterStreamFactory implements FilterStreamFactory {
         public void write(final byte[] b, final int off, final int len) throws IOException {
             System.out.write(b, off, len);
             System.out.flush();
-            super.write(b, off, len);
+            out.write(b, off, len);
         }
 
         /* (non-Javadoc)
@@ -119,7 +119,7 @@ public class ConsoleFilterStreamFactory implements FilterStreamFactory {
         public void write(final int b) throws IOException {
             System.out.write(b);
             System.out.flush();
-            super.write(b);
+            out.write(b);
         }
     }
     

--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -359,6 +359,61 @@ public class MessageBuilder {
     }
     
     /**
+     * Create a new message builder that will craft a new message in response
+     * to another message without issuing or renewing any master tokens or user
+     * ID tokens. The constructed message may be used as a request.
+     * 
+     * @param ctx MSL context.
+     * @param requestHeader message header to respond to.
+     * @return the message builder.
+     * @throws MslCryptoException if there is an error accessing the remote
+     *         entity identity.
+     * @throws MslException if any of the request's user ID tokens is not bound
+     *         to its master token.
+     */
+    public static MessageBuilder createIdempotentResponse(final MslContext ctx, final MessageHeader requestHeader) throws MslCryptoException, MslException {
+        final MasterToken masterToken = requestHeader.getMasterToken();
+        final EntityAuthenticationData entityAuthData = requestHeader.getEntityAuthenticationData();
+        final UserIdToken userIdToken = requestHeader.getUserIdToken();
+        final UserAuthenticationData userAuthData = requestHeader.getUserAuthenticationData();
+        
+        // The response recipient is the requesting entity.
+        final String recipient = (masterToken != null) ? masterToken.getIdentity() : entityAuthData.getIdentity();
+        
+        // The response message ID must be equal to the request message ID + 1.
+        final long requestMessageId = requestHeader.getMessageId();
+        final long messageId = incrementMessageId(requestMessageId);
+        
+        // Compute the intersection of the request and response message
+        // capabilities.
+        final MessageCapabilities capabilities = MessageCapabilities.intersection(requestHeader.getMessageCapabilities(), ctx.getMessageCapabilities());
+
+        // Create the message builder.
+        //
+        // Peer-to-peer responses swap the tokens.
+        try {
+            final KeyResponseData keyResponseData = requestHeader.getKeyResponseData();
+            final Set<ServiceToken> serviceTokens = requestHeader.getServiceTokens();
+            if (ctx.isPeerToPeer()) {
+                final MasterToken peerMasterToken = (keyResponseData != null) ? keyResponseData.getMasterToken() : requestHeader.getPeerMasterToken();
+                final UserIdToken peerUserIdToken = requestHeader.getPeerUserIdToken();
+                final Set<ServiceToken> peerServiceTokens = requestHeader.getPeerServiceTokens();
+                return new MessageBuilder(ctx, recipient, messageId, capabilities, peerMasterToken, peerUserIdToken, peerServiceTokens, masterToken, userIdToken, serviceTokens, null);
+            } else {
+                final MasterToken localMasterToken = (keyResponseData != null) ? keyResponseData.getMasterToken() : masterToken;
+                return new MessageBuilder(ctx, recipient, messageId, capabilities, localMasterToken, userIdToken, serviceTokens, null, null, null, null);
+            }
+        } catch (final MslException e) {
+            e.setMasterToken(masterToken);
+            e.setEntityAuthenticationData(entityAuthData);
+            e.setUserIdToken(userIdToken);
+            e.setUserAuthenticationData(userAuthData);
+            e.setMessageId(requestMessageId);
+            throw e;
+        }
+    }
+    
+    /**
      * <p>Create a new message builder that will craft a new error message in
      * response to another message. If the message ID of the request is not
      * specified (i.e. unknown) then a random message ID will be generated.</p>
@@ -575,6 +630,24 @@ public class MessageBuilder {
         final HeaderPeerData peerData = new HeaderPeerData(peerMasterToken, peerUserIdToken, peerTokens);
         
         return new MessageHeader(ctx, ctx.getEntityAuthenticationData(null), masterToken, headerData, peerData);
+    }
+    
+    /**
+     * <p>Set the message ID.</p>
+     * 
+     * <p>This method will override the message ID that was computed when the
+     * message builder was created, and should not need to be called in most
+     * cases.</p>
+     * 
+     * @param messageId the message ID.
+     * @return this.
+     * @throws MslInternalException if the message ID is out of range.
+     */
+    public MessageBuilder setMessageId(final long messageId) {
+        if (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE)
+            throw new MslInternalException("Message ID " + messageId + " is out of range.");
+        this.messageId = messageId;
+        return this;
     }
     
     /**
@@ -1070,7 +1143,7 @@ public class MessageBuilder {
     /** Message recipient. */
     private final String recipient;
     /** Header data message ID. */
-    private final long messageId;
+    private long messageId;
     /** Key exchange data. */
     private final KeyExchangeData keyExchangeData;
     /** Message non-replayable. */

--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -592,8 +592,9 @@ public class MessageInputStream extends InputStream {
     public void close() throws IOException {
         // Only close the source if instructed to do so because we might want
         // to reuse the connection.
-        if (closeSource)
+        if (closeSource) {
             source.close();
+        }
 
         // Otherwise if this is not a handshake message or error message then
         // consume all payloads that may still be on the source input stream.
@@ -608,6 +609,13 @@ public class MessageInputStream extends InputStream {
             } catch (final MslException e) {
                 // Ignore exceptions.
             }
+        }
+        
+        // Close the tokenizer.
+        try {
+            tokenizer.close();
+        } catch (final MslEncoderException e) {
+            // Ignore exceptions.
         }
     }
 

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.msl.msg;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -91,6 +90,7 @@ import com.netflix.msl.userauth.UserAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslStore;
+import com.netflix.msl.util.MslUtils;
 import com.netflix.msl.util.NullMslStore;
 
 /**
@@ -670,6 +670,31 @@ public class MslControl {
     }
     
     /**
+     * This message context is used to send messages that will not expect a
+     * response.
+     */
+    private static class SendMessageContext extends FilterMessageContext {
+        /**
+         * Creates a message context used to send messages that do not expect a
+         * response by ensuring that the message context conforms to those
+         * expectations.
+         * 
+         * @param appCtx the application's message context.
+         */
+        public SendMessageContext(final MessageContext appCtx) {
+            super(appCtx);
+        }
+
+        /* (non-Javadoc)
+         * @see com.netflix.msl.msg.MslControl.FilterMessageContext#isRequestingTokens()
+         */
+        @Override
+        public boolean isRequestingTokens() {
+            return false;
+        }
+    }
+    
+    /**
      * This message context is used to send a handshake response.
      */
     private static class KeyxResponseMessageContext extends FilterMessageContext {
@@ -1120,10 +1145,9 @@ public class MslControl {
      * request or after sending the message if no response is expected.</p>
      * 
      * <p>In peer-to-peer mode if a master token is being used to build the new
-     * message but there is no user ID token set or the user ID token is not
-     * bound to the and a user ID is provided by the message context the user
-     * ID token for that user ID will be used to build the message if the user
-     * ID token is bound to the master token.</p>
+     * message and a user ID is provided by the message context, the user ID
+     * token for that user ID will be used to build the message if the user ID
+     * token is bound to the master token.</p>
      * 
      * @param ctx MSL context.
      * @param msgCtx message context.
@@ -1183,6 +1207,29 @@ public class MslControl {
 
         // Set the authentication tokens.
         builder.setAuthTokens(masterToken, userIdToken);
+        return builder;
+    }
+    
+    /**
+     * <p>Create a new message builder that will craft a new message based on
+     * another message. The constructed message will have a randomly assigned
+     * message ID, thus detaching it from the message being responded to, and
+     * may be used as a request.</p>
+     * 
+     * @param ctx MSL context.
+     * @param msgCtx message context.
+     * @param request message header to respond to.
+     * @return the message builder.
+     * @throws MslCryptoException if there is an error accessing the remote
+     *         entity identity.
+     * @throws MslException if any of the request's user ID tokens is not bound
+     *         to its master token.
+     */
+    private MessageBuilder buildDetachedResponse(final MslContext ctx, final MessageContext msgCtx, final MessageHeader request) throws MslCryptoException, MslException {
+        // Create an idempotent response. Assign a random message ID.
+        final MessageBuilder builder = MessageBuilder.createIdempotentResponse(ctx, request);
+        builder.setNonReplayable(msgCtx.isNonReplayable());
+        builder.setMessageId(MslUtils.getRandomLong(ctx));
         return builder;
     }
     
@@ -1796,6 +1843,18 @@ public class MslControl {
         // Return the result.
         return response;
     }
+    
+    /**
+     * Indicates response expectations for a specific request.
+     */
+    private static enum Receive {
+        /** A response is always expected. */
+        ALWAYS,
+        /** A response is only expected if tokens are being renewed. */
+        RENEWING,
+        /** A response is never expected. */
+        NEVER
+    }
 
     /**
      * The result of sending and receiving messages.
@@ -1835,7 +1894,9 @@ public class MslControl {
      * @param in remote entity input stream.
      * @param out remote entity output stream.
      * @param builder request message builder.
-     * @param receive if a response is expected.
+     * @param receive indicates if a response should always be expected, should
+     *        only be expected if the master token or user ID token will be
+     *        renewed, or should never be expected. 
      * @param closeStreams true if the remote entity input and output streams
      *        must be closed when the constructed message input and output
      *        streams are closed.
@@ -1873,7 +1934,7 @@ public class MslControl {
      * @throws TimeoutException if the thread timed out while trying to acquire
      *         a master token from a renewing thread.
      */
-    private SendReceiveResult sendReceive(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final MessageBuilder builder, final boolean receive, final boolean closeStreams, final int timeout) throws IOException, MslEncodingException, MslCryptoException, MslEntityAuthException, MslUserAuthException, MslMessageException, MslMasterTokenException, MslKeyExchangeException, MslException, InterruptedException, TimeoutException {
+    private SendReceiveResult sendReceive(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final MessageBuilder builder, final Receive receive, final boolean closeStreams, final int timeout) throws IOException, MslEncodingException, MslCryptoException, MslEntityAuthException, MslUserAuthException, MslMessageException, MslMasterTokenException, MslKeyExchangeException, MslException, InterruptedException, TimeoutException {
         // Attempt to acquire the renewal lock.
         final BlockingQueue<MasterToken> renewalQueue = new ArrayBlockingQueue<MasterToken>(1, true);
         final boolean renewing;
@@ -1900,12 +1961,15 @@ public class MslControl {
             sent = send(ctx, msgCtx, out, builder, closeStreams);
             
             // Receive the response if expected, if we sent a handshake request,
-            // if key request data was included, or if a master token and user
+            // or if we expect a response when renewing tokens and either key
+            // request data was included or a master token and user
             // authentication data was included in a renewable message.
             final MessageHeader requestHeader = sent.request.getMessageHeader();
             final Set<KeyRequestData> keyRequestData = requestHeader.getKeyRequestData();
-            if (receive || sent.handshake || !keyRequestData.isEmpty() ||
-                (requestHeader.isRenewable() && requestHeader.getMasterToken() != null && requestHeader.getUserAuthenticationData() != null))
+            if (receive == Receive.ALWAYS || sent.handshake ||
+                (receive == Receive.RENEWING &&
+                 (!keyRequestData.isEmpty() ||
+                  (requestHeader.isRenewable() && requestHeader.getMasterToken() != null && requestHeader.getUserAuthenticationData() != null))))
             {
                 response = receive(ctx, msgCtx, in, requestHeader);
                 response.closeSource(closeStreams);
@@ -2537,17 +2601,17 @@ public class MslControl {
      */
     private class RespondService implements Callable<MslChannel> {
         /** MSL context. */
-        private final MslContext ctx;
+        protected final MslContext ctx;
         /** Message context. */
-        private final MessageContext msgCtx;
+        protected final MessageContext msgCtx;
         /** Request message input stream. */
-        private final MessageInputStream request;
+        protected final MessageInputStream request;
         /** Remote entity input stream. */
-        private final InputStream in;
+        protected final InputStream in;
         /** Remote entity output stream. */
-        private final OutputStream out;
+        protected final OutputStream out;
         /** Read timeout in milliseconds. */
-        private final int timeout;
+        protected final int timeout;
         
         /**
          * Create a new message respond service.
@@ -2589,7 +2653,7 @@ public class MslControl {
          *         trying to delete an old master token the sent message is
          *         replacing.
          */
-        private MslChannel trustedNetworkExecute(final MessageBuilder builder, final int msgCount) throws MslException, MslErrorResponseException, IOException, InterruptedException {
+        protected MslChannel trustedNetworkExecute(final MessageBuilder builder, final int msgCount) throws MslException, MslErrorResponseException, IOException, InterruptedException {
             try {
                 final MessageDebugContext debugCtx = msgCtx.getDebugContext();
                 final MessageHeader requestHeader = request.getMessageHeader();
@@ -2672,7 +2736,7 @@ public class MslControl {
          * @throws TimeoutException if the thread timed out while trying to
          *         acquire the renewal lock.
          */
-        private MslChannel peerToPeerExecute(final MessageContext msgCtx, final MessageBuilder builder, int msgCount) throws MslException, IOException, InterruptedException, MslErrorResponseException, TimeoutException {
+        protected MslChannel peerToPeerExecute(final MessageContext msgCtx, final MessageBuilder builder, int msgCount) throws MslException, IOException, InterruptedException, MslErrorResponseException, TimeoutException {
             final MessageDebugContext debugCtx = msgCtx.getDebugContext();
             final MessageHeader requestHeader = request.getMessageHeader();
             
@@ -2708,7 +2772,7 @@ public class MslControl {
             // This adds two to our message count.
             //
             // This will release the master token lock.
-            final SendReceiveResult result = sendReceive(ctx, msgCtx, in, out, builder, false, false, timeout);
+            final SendReceiveResult result = sendReceive(ctx, msgCtx, in, out, builder, Receive.RENEWING, false, timeout);
             final MessageInputStream response = result.response;
             msgCount += 2;
             
@@ -2902,7 +2966,6 @@ public class MslControl {
                 throw new MslInternalException("Error sending the response.", t);
             }
         }
-        
     }
     
     /**
@@ -3005,85 +3068,6 @@ public class MslControl {
      * clients, and peer-to-peer servers.</p>
      */
     private class RequestService implements Callable<MslChannel> {
-        /**
-         * A delayed input stream does not open the real input stream until
-         * one of its methods is called.
-         */
-        private class DelayedInputStream extends FilterInputStream {
-            /**
-             * Create a new delayed input stream that will not attempt to
-             * construct the input stream from the URL connection until it is
-             * actually needed (i.e. read from).
-             * 
-             * @param conn backing URL connection.
-             */
-            public DelayedInputStream(final Connection conn) {
-                super(null);
-                this.conn = conn;
-            }
-            
-            @Override
-            public int available() throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                return super.available();
-            }
-
-            @Override
-            public void close() throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                super.close();
-            }
-
-            @Override
-            public synchronized void mark(final int readlimit) {
-            }
-
-            @Override
-            public boolean markSupported() {
-                return false;
-            }
-
-            @Override
-            public int read() throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                return in.read();
-            }
-
-            @Override
-            public int read(final byte[] b, final int off, final int len) throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                return super.read(b, off, len);
-            }
-
-            @Override
-            public int read(final byte[] b) throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                return super.read(b);
-            }
-
-            @Override
-            public synchronized void reset() throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                super.reset();
-            }
-
-            @Override
-            public long skip(final long n) throws IOException {
-                if (in == null)
-                    in = conn.getInputStream();
-                return super.skip(n);
-            }
-            
-            /** Connection providing the input stream. */
-            private final Connection conn;
-        }
-        
         /** MSL context. */
         private final MslContext ctx;
         /** Message context. */
@@ -3098,6 +3082,8 @@ public class MslControl {
         private boolean openedStreams;
         /** Request message builder. */
         private MessageBuilder builder;
+        /** Response expectation. */
+        private final Receive expectResponse;
         /** Connect and read timeout in milliseconds. */
         private final int timeout;
         /** Number of messages sent or received so far. */
@@ -3112,10 +3098,11 @@ public class MslControl {
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param remoteEntity remote entity URL.
+         * @param expectResponse response expectation.
          * @param timeout connect, read, and renewal lock acquisition timeout
          *        in milliseconds.
          */
-        public RequestService(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final int timeout) {
+        public RequestService(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final Receive expectResponse, final int timeout) {
             this.ctx = ctx;
             this.msgCtx = msgCtx;
             this.remoteEntity = remoteEntity;
@@ -3123,6 +3110,7 @@ public class MslControl {
             this.out = null;
             this.openedStreams = false;
             this.builder = null;
+            this.expectResponse = expectResponse;
             this.timeout = timeout;
             this.msgCount = 0;
         }
@@ -3134,9 +3122,11 @@ public class MslControl {
          * @param msgCtx message context.
          * @param in remote entity input stream.
          * @param out remote entity output stream.
-         * @param timeout read acquisition timeout in milliseconds.
+         * @param expectResponse response expectation.
+         * @param timeout read and renewal lock acquisition timeout in
+         *        milliseconds.
          */
-        public RequestService(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final int timeout) {
+        public RequestService(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final Receive expectResponse, final int timeout) {
             this.ctx = ctx;
             this.msgCtx = msgCtx;
             this.remoteEntity = null;
@@ -3144,6 +3134,7 @@ public class MslControl {
             this.out = out;
             this.openedStreams = false;
             this.builder = null;
+            this.expectResponse = expectResponse;
             this.timeout = timeout;
             this.msgCount = 0;
         }
@@ -3155,12 +3146,13 @@ public class MslControl {
          * @param msgCtx message context.
          * @param remoteEntity remote entity URL.
          * @param builder request message builder.
+         * @param expectResponse response expectation.
          * @param timeout connect, read, and renewal lock acquisition timeout
          *        in milliseconds.
          * @param msgCount number of messages that have already been sent or
          *        received.
          */
-        public RequestService(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final MessageBuilder builder, final int timeout, final int msgCount) {
+        private RequestService(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final MessageBuilder builder, final Receive expectResponse, final int timeout, final int msgCount) {
             this.ctx = ctx;
             this.msgCtx = msgCtx;
             this.remoteEntity = remoteEntity;
@@ -3168,6 +3160,7 @@ public class MslControl {
             this.out = null;
             this.openedStreams = false;
             this.builder = builder;
+            this.expectResponse = expectResponse;
             this.timeout = timeout;
             this.msgCount = msgCount;
         }
@@ -3192,6 +3185,7 @@ public class MslControl {
             this.out = out;
             this.openedStreams = false;
             this.builder = builder;
+            this.expectResponse = Receive.ALWAYS;
             this.timeout = timeout;
             this.msgCount = msgCount;
         }
@@ -3232,10 +3226,15 @@ public class MslControl {
             // message count.
             //
             // This will release the master token lock.
-            final SendReceiveResult result = sendReceive(ctx, msgCtx, in, out, builder, true, openedStreams, timeout);
+            final SendReceiveResult result = sendReceive(ctx, msgCtx, in, out, builder, expectResponse, openedStreams, timeout);
             final MessageOutputStream request = result.request;
             final MessageInputStream response = result.response;
             msgCount += 2;
+            
+            // If we did not receive a response then we're done. Return the
+            // new message output stream.
+            if (response == null)
+                return new MslChannel(response, request);
 
             // If the response is an error see if we can handle the error and
             // retry.
@@ -3275,7 +3274,7 @@ public class MslControl {
                 if (!ctx.isPeerToPeer()) {
                     // The master token lock acquired from buildErrorResponse()
                     // will be released when the service executes.
-                    final RequestService service = new RequestService(ctx, resendMsgCtx, remoteEntity, requestBuilder, timeout, msgCount);
+                    final RequestService service = new RequestService(ctx, resendMsgCtx, remoteEntity, requestBuilder, expectResponse, timeout, msgCount);
                     newChannel = service.call();
                     maxMessagesHit = service.maxMessagesHit;
                 } else {
@@ -3329,7 +3328,7 @@ public class MslControl {
                 // released when the service executes.
                 final MessageContext resendMsgCtx = new ResendMessageContext(null, msgCtx);
                 final MessageBuilder requestBuilder = buildResponse(ctx, msgCtx, responseHeader);
-                final RequestService service = new RequestService(ctx, resendMsgCtx, remoteEntity, requestBuilder, timeout, msgCount);
+                final RequestService service = new RequestService(ctx, resendMsgCtx, remoteEntity, requestBuilder, expectResponse, timeout, msgCount);
                 return service.call();
             }
             
@@ -3462,7 +3461,7 @@ public class MslControl {
                     final long start = System.currentTimeMillis();
                     final Connection conn = remoteEntity.openConnection();
                     out = conn.getOutputStream();
-                    in = new DelayedInputStream(conn);
+                    in = conn.getInputStream();
                     lockTimeout = timeout - (int)(System.currentTimeMillis() - start);
                     openedStreams = true;
                 } catch (final IOException e) {
@@ -3521,6 +3520,15 @@ public class MslControl {
                 // If the channel was established clear the cached payloads.
                 if (channel != null && channel.output != null)
                     channel.output.stopCaching();
+                    
+                // Close the input stream if we opened it and there is no
+                // response. This may be necessary to transmit data
+                // buffered in the output stream, and the caller will not
+                // be given a message input stream by which to close it.
+                //
+                // We don't care about an I/O exception on close.
+                if (openedStreams && (channel == null || channel.input == null))
+                    try { in.close(); } catch (final IOException ioe) { }
                 
                 // Return the established channel.
                 return channel;
@@ -3550,15 +3558,364 @@ public class MslControl {
     }
     
     /**
+     * <p>This service sends a message to a remote entity.</p>
+     *
+     * <p>This class is only used from trusted network clients and peer-to-peer
+     * entities.</p>
+     */
+    private class SendService implements Callable<MessageOutputStream> {
+        /** The request service. */
+        private final RequestService requestService;
+        
+        /**
+         * Create a new message send service.
+         * 
+         * @param ctx MSL context.
+         * @param msgCtx message context.
+         * @param remoteEntity remote entity URL.
+         * @param timeout connect, read, and renewal lock acquisition timeout
+         *        in milliseconds.
+         */
+        public SendService(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final int timeout) {
+            this.requestService = new RequestService(ctx, msgCtx, remoteEntity, Receive.NEVER, timeout);
+        }
+        
+        /**
+         * Create a new message send service.
+         * 
+         * @param ctx MSL context.
+         * @param msgCtx message context.
+         * @param in remote entity input stream.
+         * @param out remote entity output stream.
+         * @param timeout read and renewal lock acquisition timeout in
+         *        milliseconds.
+         */
+        public SendService(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final int timeout) {
+            this.requestService = new RequestService(ctx, msgCtx, in, out, Receive.NEVER, timeout);
+        }
+
+        /* (non-Javadoc)
+         * @see java.util.concurrent.Callable#call()
+         */
+        @Override
+        public MessageOutputStream call() throws MslException, IOException, TimeoutException {
+            final MslChannel channel = this.requestService.call();
+            return (channel != null) ? channel.output : null;
+        }
+    }
+
+    /**
+     * <p>This service sends a message to the remote entity using a request as
+     * the basis for the response.</p>
+     * 
+     * <p>This class will only be used trusted network servers.</p>
+     */
+    public class PushService extends RespondService {    
+        /**
+         * Create a new message push service.
+         * 
+         * @param ctx MSL context.
+         * @param msgCtx message context.
+         * @param in remote entity input stream.
+         * @param out remote entity output stream.
+         * @param request request message input stream.
+         * @param timeout renewal lock acquisition timeout in milliseconds.
+         */
+        public PushService(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final MessageInputStream request, final int timeout) {
+            super(ctx, msgCtx, in, out, request, timeout);
+        }
+        
+        /**
+         * @return a {@link MslChannel} on success or {@code null} if cancelled,
+         *         interrupted, if the response could not be sent encrypted or
+         *         integrity protected when required, or if the maximum number
+         *         of messages is hit.
+         * @throws MslException if there was an error creating the response.
+         * @throws MslErrorResponseException if there was an error sending an
+         *         automatically generated error response.
+         * @throws IOException if there was an error writing the message.
+         * @see java.util.concurrent.Callable#call()
+         */
+        @Override
+        public MslChannel call() throws MslException, MslErrorResponseException, IOException {
+            final MessageDebugContext debugCtx = msgCtx.getDebugContext();
+            
+            final MessageHeader requestHeader = request.getMessageHeader();
+            final MessageBuilder builder;
+            try {
+                builder = buildDetachedResponse(ctx, msgCtx, requestHeader);
+            } catch (final MslException e) {
+                // If we were cancelled then return null.
+                if (cancelled(e)) return null;
+                
+                try {
+                    final String recipient = MslControl.getIdentity(request);
+                    final MslError error = e.getError();
+                    final MessageCapabilities caps = requestHeader.getMessageCapabilities();
+                    final List<String> languages = (caps != null) ? caps.getLanguages() : null;
+                    final String userMessage = messageRegistry.getUserMessage(error, languages);
+                    sendError(ctx, debugCtx, requestHeader, recipient, e.getMessageId(), error, userMessage, out);
+                } catch (final Throwable rt) {
+                    throw new MslErrorResponseException("Error building the message.", rt, e);
+                }
+                throw e;
+            } catch (final Throwable t) {
+                // If we were cancelled then return null.
+                if (cancelled(t)) return null;
+                
+                try {
+                    final String recipient = MslControl.getIdentity(request);
+                    sendError(ctx, debugCtx, requestHeader, recipient, null, MslError.INTERNAL_EXCEPTION, null, out);
+                } catch (final Throwable rt) {
+                    throw new MslErrorResponseException("Error building the message.", rt, t);
+                }
+                throw new MslInternalException("Error building the message.", t);
+            }
+            
+            try {
+                // Send the message. This will release the master token lock.
+                final MslChannel channel = trustedNetworkExecute(builder, 0);
+                
+                // Clear any cached payloads.
+                if (channel != null)
+                    channel.output.stopCaching();
+                
+                // Return the established channel.
+                return channel;
+            } catch (final InterruptedException e) {
+                // We were cancelled so return null.
+                return null;
+            } catch (final IOException e) {
+                // If we were cancelled then return null.
+                if (cancelled(e)) return null;
+
+                // Maybe we can send an error response.
+                try {
+                    final String recipient = MslControl.getIdentity(request);
+                    final long requestMessageId = MessageBuilder.decrementMessageId(builder.getMessageId());
+                    sendError(ctx, debugCtx, requestHeader, recipient, requestMessageId, MslError.MSL_COMMS_FAILURE, null, out);
+                } catch (final Throwable rt) {
+                    // If we were cancelled then return null.
+                    if (cancelled(rt)) return null;
+                    
+                    throw new MslErrorResponseException("Error pushing the message.", rt, e);
+                }
+                throw e;
+            } catch (final MslException e) {
+                // If we were cancelled then return null.
+                if (cancelled(e)) return null;
+
+                // Maybe we can send an error response.
+                try {
+                    final String recipient = MslControl.getIdentity(request);
+                    final long requestMessageId = MessageBuilder.decrementMessageId(builder.getMessageId());
+                    final MslError error = e.getError();
+                    final MessageCapabilities caps = requestHeader.getMessageCapabilities();
+                    final List<String> languages = (caps != null) ? caps.getLanguages() : null;
+                    final String userMessage = messageRegistry.getUserMessage(error, languages);
+                    sendError(ctx, debugCtx, requestHeader, recipient, requestMessageId, error, userMessage, out);
+                } catch (final Throwable rt) {
+                    // If we were cancelled then return null.
+                    if (cancelled(rt)) return null;
+
+                    throw new MslErrorResponseException("Error pushing the message.", rt, e);
+                }
+                throw e;
+            } catch (final Throwable t) {
+                // If we were cancelled then return null.
+                if (cancelled(t)) return null;
+
+                // Maybe we can send an error response.
+                try {
+                    final String recipient = MslControl.getIdentity(request);
+                    final long requestMessageId = MessageBuilder.decrementMessageId(builder.getMessageId());
+                    sendError(ctx, debugCtx, requestHeader, recipient, requestMessageId, MslError.INTERNAL_EXCEPTION, null, out);
+                } catch (final Throwable rt) {
+                    // If we were cancelled then return null.
+                    if (cancelled(rt)) return null;
+
+                    throw new MslErrorResponseException("Error pushing the message.", rt, t);
+                }
+                throw new MslInternalException("Error pushing the message.", t);
+            }
+        }
+    }
+    
+    /**
+     * <p>Send a message to the entity at the provided URL.</p>
+     * 
+     * <p>Use of this method is not recommended as it does not confirm delivery
+     * or acceptance of the message. Establishing a MSL channel to send
+     * application data without requiring the remote entity to acknowledge
+     * receipt in the response application data is the recommended approach.
+     * Only use this method if guaranteed receipt is not required.</p>
+     * 
+     * <p>This method should only be used by trusted network clients and per-
+     * to-peer entities when no response is expected from the remote entity.
+     * The remote entity should be using
+     * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
+     * and should not attempt to send a response.</p>
+     * 
+     * <p>The returned {@code Future} will return a {@code MessageOutputStream}
+     * containing the final {@code MessageOutputStream} that should be used to
+     * send any additional application data not already sent via
+     * {@link MessageContext#write(MessageOutputStream)}.</p>
+     * 
+     * <p>The returned {@code Future} will return {@code null} if
+     * {@link #cancelled(Throwable) cancelled or interrupted}, if an error
+     * response was received resulting in a failure to send the message, or if
+     * the maximum number of messages is hit without sending the message.</p>
+     * 
+     * <p>The {@code Future} may throw an {@code ExecutionException} whose
+     * cause is a {@code MslException}, {@code IOException}, or
+     * {@code TimeoutException}.</p>
+     * 
+     * <p>The caller must close the returned message output stream.</p>
+     * 
+     * @param ctx MSL context.
+     * @param msgCtx message context.
+     * @param remoteEntity remote entity URL.
+     * @param timeout connect, read, and renewal lock acquisition timeout in
+     *        milliseconds.
+     * @return a future for the message output stream.
+     */
+    public Future<MessageOutputStream> send(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final int timeout) {
+        final MessageContext sendMsgCtx = new SendMessageContext(msgCtx);
+        final SendService service = new SendService(ctx, sendMsgCtx, remoteEntity, timeout);
+        return executor.submit(service);
+    }
+    
+    /**
+     * <p>Send a message over the provided output stream.</p>
+     * 
+     * <p>Use of this method is not recommended as it does not confirm delivery
+     * or acceptance of the message. Establishing a MSL channel to send
+     * application data without requiring the remote entity to acknowledge
+     * receipt in the response application data is the recommended approach.
+     * Only use this method if guaranteed receipt is not required.</p>
+     * 
+     * <p>This method should only be used by trusted network clients and peer-
+     * to-peer entities when no response is expected from the remote entity.
+     * The remote entity should be using
+     * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
+     * and should not attempt to send a response.</p>
+     * 
+     * <p>The returned {@code Future} will return a {@code MessageOutputStream}
+     * containing the final {@code MessageOutputStream} that should be used to
+     * send any additional application data not already sent via
+     * {@link MessageContext#write(MessageOutputStream)}.</p>
+     * 
+     * <p>The returned {@code Future} will return {@code null} if
+     * {@link #cancelled(Throwable) cancelled or interrupted}, if an error
+     * response was received resulting in a failure to send the message, or if
+     * the maximum number of messages is hit without sending the message.</p>
+     * 
+     * <p>The {@code Future} may throw an {@code ExecutionException} whose
+     * cause is a {@code MslException}, {@code IOException}, or
+     * {@code TimeoutException}.</p>
+     * 
+     * <p>The caller must close the returned message output stream. The remote
+     * entity output stream will not be closed when the message output stream
+     * is closed, in case the caller wishes to reuse them.</p>
+     * 
+     * TODO once Java supports the WebSocket protocol we can remove this method
+     * in favor of the one accepting a URL parameter. (Or is it the other way
+     * around?)
+     *
+     * @param ctx MSL context.
+     * @param msgCtx message context.
+     * @param in remote entity input stream.
+     * @param out remote entity output stream.
+     * @param timeout connect, read, and renewal lock acquisition timeout in
+     *        milliseconds.
+     * @return a future for the message output stream.
+     */
+    public Future<MessageOutputStream> send(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final int timeout) {
+        final MessageContext sendMsgCtx = new SendMessageContext(msgCtx);
+        final SendService service = new SendService(ctx, sendMsgCtx, in, out, timeout);
+        return executor.submit(service);
+    }
+
+    /**
+     * <p>Push a message over the provided output stream based on a message
+     * received from the remote entity.</p>
+     * 
+     * <p>Use of this method is not recommended as it does not perform master
+     * token or user ID token issuance or renewal which the remote entity may
+     * be attempting to perform. Only use this method if there is some other
+     * means by which the client will be able to acquire and renew its master
+     * token or user ID token on a regular basis.</p>
+     * 
+     * <p>This method should only be used by trusted network servers that wish
+     * to send multiple responses to a trusted network client. The remote
+     * entity should be using
+     * {@link #send(MslContext, MessageContext, Url, int)} or
+     * {@link #send(MslContext, MessageContext, InputStream, OutputStream, int)}
+     * and
+     * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
+     * 
+     * <p>This method must not be used if
+     * {@link MslControl#respond(MslContext, MessageContext, InputStream, OutputStream, MessageInputStream, int)}
+     * has already been used with the same {@code MessageInputStream}.</p>
+     * 
+     * <p>The returned {@code Future} will return a {@code MslChannel}
+     * containing the same {@code MessageInputStream} that was provided and the
+     * final {@code MessageOutputStream} that should be used to send any
+     * additional application data not already sent via
+     * {@link MessageContext#write(MessageOutputStream)} to the remote
+     * entity.</p>
+     * 
+     * <p>The returned {@code Future} will return {@code null} if
+     * {@link #cancelled(Throwable) canncelled or interrupted}, if the message
+     * could not be sent with encryption or integrity protection when required,
+     * if a user cannot be attached to the respond to the response due to lack
+     * of a master token, or if the maximum number of messages is hit without
+     * sending the message. In these cases the local entity should wait for a
+     * new message from the remote entity to be received by a call to
+     * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
+     * before attempting to push another message.</p>
+     * 
+     * <p>The {@code Future} may throw an {@code ExecutionException} whose
+     * cause is a {@code MslException}, {@code MslErrorResponseException},
+     * {@code IOException}, or {@code TimeoutException}.</p>
+     * 
+     * <p>The remote entity input and output streams will not be closed in case
+     * the caller wishes to reuse them.</p>
+     * 
+     * @param ctx MSL context.
+     * @param msgCtx message context.
+     * @param in remote entity input stream.
+     * @param out remote entity output stream.
+     * @param request message input stream used to create the message.
+     * @param timeout renewal lock acquisition timeout in milliseconds.
+     * @return a future for the communication channel.
+     * @throws IllegalStateException if used in peer-to-peer mode.
+     * @throws IllegalArgumentException if the request message input stream is
+     *         an error message.
+     */
+    public Future<MslChannel> push(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final MessageInputStream request, final int timeout) {
+        if (ctx.isPeerToPeer())
+            throw new IllegalStateException("This method cannot be used in peer-to-peer mode.");
+        if (request.getErrorHeader() != null)
+            throw new IllegalArgumentException("Request message input stream cannot be for an error message.");
+        final PushService service = new PushService(ctx, msgCtx, in, out, request, timeout);
+        return executor.submit(service);
+    }
+    
+    /**
      * <p>Receive a request over the provided input stream.</p>
      * 
      * <p>If there is an error with the message an error response will be sent
      * over the provided output stream.</p>
      * 
-     * <p>This method should only be used by trusted network servers and peer-
-     * to-peer entities to receive a request initiated by the remote entity.
-     * The remote entity should have used
-     * {@link #request(MslContext, MessageContext, Url, int)}.<p>
+     * <p>This method should only be used to receive a request initiated by the
+     * remote entity. The remote entity should have used one of the request
+     * methods
+     * {@link #request(MslContext, MessageContext, Url, int)} or
+     * {@link #request(MslContext, MessageContext, InputStream, OutputStream, int)}
+     * or one of the send methods
+     * {@link #send(MslContext, MessageContext, Url, int)} or
+     * {@link #send(MslContext, MessageContext, InputStream, OutputStream, int)}.<p>
      * 
      * <p>The returned {@code Future} will return the received
      * {@code MessageInputStream} on completion or {@code null} if a reply was
@@ -3592,8 +3949,9 @@ public class MslControl {
      * <p>This method should only be used by trusted network servers and peer-
      * to-peer entities after receiving a request via
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.
-     * The remote entity should have used
-     * {@link #request(MslContext, MessageContext, Url, int)}.</p>
+     * The remote entity should have used one of the request methods
+     * {@link #request(MslContext, MessageContext, Url, int)} or
+     * {@link #request(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
      * 
      * <p>The returned {@code Future} will return a {@code MslChannel}
      * containing the final {@code MessageOutputStream} that should be used to
@@ -3720,7 +4078,7 @@ public class MslControl {
     public Future<MslChannel> request(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final int timeout) {
         if (ctx.isPeerToPeer())
             throw new IllegalStateException("This method cannot be used in peer-to-peer mode.");
-        final RequestService service = new RequestService(ctx, msgCtx, remoteEntity, timeout);
+        final RequestService service = new RequestService(ctx, msgCtx, remoteEntity, Receive.ALWAYS, timeout);
         return executor.submit(service);
     }
     
@@ -3770,7 +4128,7 @@ public class MslControl {
     public Future<MslChannel> request(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final int timeout) {
         if (!ctx.isPeerToPeer())
             throw new IllegalStateException("This method cannot be used in trusted network mode.");
-        final RequestService service = new RequestService(ctx, msgCtx, in, out, timeout);
+        final RequestService service = new RequestService(ctx, msgCtx, in, out, Receive.ALWAYS, timeout);
         return executor.submit(service);
     }
     

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -3594,7 +3594,15 @@ public class MslControl {
             this.requestService = new RequestService(ctx, msgCtx, in, out, Receive.NEVER, timeout);
         }
 
-        /* (non-Javadoc)
+        /**
+         * @return the established MSL channel or {@code null} if cancelled or
+         *         interrupted.
+         * @throws MslException if there was an error creating or processing
+         *         a message.
+         * @throws IOException if there was an error reading or writing a
+         *         message.
+         * @throws TimeoutException if the thread timed out while trying to
+         *         acquire the renewal lock.
          * @see java.util.concurrent.Callable#call()
          */
         @Override

--- a/core/src/main/java/com/netflix/msl/msg/ServerReceiveMessageContext.java
+++ b/core/src/main/java/com/netflix/msl/msg/ServerReceiveMessageContext.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.msg;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.keyx.KeyRequestData;
+import com.netflix.msl.tokens.MslUser;
+import com.netflix.msl.userauth.UserAuthenticationData;
+
+/**
+ * <p>A trusted services network message context used to receive client
+ * messages suitable for use with
+ * {@link MslControl#receive(com.netflix.msl.util.MslContext, MessageContext, java.io.InputStream, java.io.OutputStream, int)}.
+ * Since this message context is only used for receiving messages, it cannot be
+ * used to send application data back to the client and does not require
+ * encryption or integrity protection.</p>
+ * 
+ * <p>The application may wish to override
+ * {@link #updateServiceTokens(MessageServiceTokenBuilder, boolean)} to
+ * modify any service tokens sent in handshake responses.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class ServerReceiveMessageContext extends PublicMessageContext {
+    /**
+     * <p>Create a new receive message context.</p>
+     * 
+     * @param cryptoContexts service token crypto contexts. May be
+     *        {@code null}.
+     * @param dbgCtx optional message debug context. May be {@code null}.
+     */
+    public ServerReceiveMessageContext(final Map<String,ICryptoContext> cryptoContexts, final MessageDebugContext dbgCtx) {
+        this.cryptoContexts = (cryptoContexts != null) ? new HashMap<String,ICryptoContext>(cryptoContexts) : new HashMap<String,ICryptoContext>();
+        this.dbgCtx = dbgCtx;
+    }
+
+    @Override
+    public Map<String, ICryptoContext> getCryptoContexts() {
+        return Collections.unmodifiableMap(cryptoContexts);
+    }
+
+    @Override
+    public String getRecipient() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestingTokens() {
+        return false;
+    }
+
+    @Override
+    public String getUserId() {
+        return null;
+    }
+
+    @Override
+    public UserAuthenticationData getUserAuthData(final ReauthCode reauthCode, final boolean renewable, final boolean required) {
+        return null;
+    }
+
+    @Override
+    public MslUser getUser() {
+        return null;
+    }
+
+    @Override
+    public Set<KeyRequestData> getKeyRequestData() throws MslKeyExchangeException {
+        return Collections.emptySet();
+    }
+    
+    @Override
+    public void updateServiceTokens(final MessageServiceTokenBuilder builder, final boolean handshake) {
+    }
+
+    @Override
+    public void write(final MessageOutputStream output) throws IOException {
+    }
+
+    @Override
+    public MessageDebugContext getDebugContext() {
+        return dbgCtx;
+    }
+    
+    /** Service token crypto contexts. */
+    protected final Map<String,ICryptoContext> cryptoContexts;
+    /** Message debug context. */
+    protected final MessageDebugContext dbgCtx;
+}

--- a/core/src/main/javascript/io/BufferedInputStream.js
+++ b/core/src/main/javascript/io/BufferedInputStream.js
@@ -60,6 +60,12 @@
 			     * @type {number}
 			     */
 			    _readlimit: { value: -1, writable: true, enumerable: false, configurable: false },
+			    /**
+			     * True if stream is closed.
+			     * 
+			     * @type {boolean}
+			     */
+			    _closed: { value: false, writable: true, enumerable: false, configurable: false },
 			};
 			Object.defineProperties(this, props);
 		},
@@ -71,7 +77,8 @@
 		
 		/** @inheritDoc */
 		close: function close(timeout, callback) {
-			this._source.close(timeout, callback);
+            this._closed = true;
+            this._source.close(timeout, callback);
 		},
 		
 		/** @inheritDoc */
@@ -85,7 +92,7 @@
 			}
 			
 			// If there is data buffered and the current mark position is not
-			// zero (at the beginning) then truncate the the buffer.
+			// zero (at the beginning) then truncate the buffer.
 			if (this._bufpos > 0) {
 				var data = this._buffer.toByteArray();
 				this._buffer = new ByteArrayOutputStream();
@@ -100,6 +107,9 @@
 			}
 			
 			// Otherwise the existing buffer contains the correct data.
+			//
+			// Set the new read limit.
+			this._readlimit = readlimit;
 		},
 		
 		/** @inheritDoc */

--- a/core/src/main/javascript/io/BufferedInputStream.js
+++ b/core/src/main/javascript/io/BufferedInputStream.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,27 @@
 			// The properties.
 			var props = {
 			    _source: { value: source, writable: false, enumerable: false, configurable: false },
+			    /**
+			     * Buffer of data read since the last call to mark(). Null if
+			     * mark() has not been called or if the read limit has been
+			     * exceeded.
+			     * 
+			     * @type {?ByteArrayOutputStream}
+			     */
 			    _buffer: { value: null, writable: true, enumerable: false, configurable: false },
-			    _markpos: { value: 0, writable: true, enumerable: false, configurable: false },
+			    /**
+			     * Current buffer read position.
+			     * 
+			     * @type {number}
+			     */
+			    _bufpos: { value: 0, writable: true, enumerable: false, configurable: false },
+			    /**
+			     * Requested maximum number of bytes to buffer. -1 for no
+			     * maximum.
+			     * 
+			     * @type {number}
+			     */
+			    _readlimit: { value: -1, writable: true, enumerable: false, configurable: false },
 			};
 			Object.defineProperties(this, props);
 		},
@@ -56,27 +75,28 @@
 		},
 		
 		/** @inheritDoc */
-		mark: function mark() {
+		mark: function mark(readlimit) {
 			// If there is no current mark, then start buffering.
 			if (!this._buffer) {
 				this._buffer = new ByteArrayOutputStream();
-				this._markpos = 0;
+				this._bufpos = 0;
+				this._readlimit = readlimit;
 				return;
 			}
 			
 			// If there is data buffered and the current mark position is not
 			// zero (at the beginning) then truncate the the buffer.
-			if (this._markpos > 0) {
+			if (this._bufpos > 0) {
 				var data = this._buffer.toByteArray();
 				this._buffer = new ByteArrayOutputStream();
 				// ByteArrayOutputStream.write() is synchronous so we can get
 				// away with this.
-				this._buffer.write(data, this._markpos, data.length - this._markpos, -1, {
+				this._buffer.write(data, this._bufpos, data.length - this._bufpos, -1, {
 					result: function() {},
 					timeout: function() {},
 					error: function() {}
 				});
-				this._markpos = 0;
+				this._bufpos = 0;
 			}
 			
 			// Otherwise the existing buffer contains the correct data.
@@ -85,10 +105,10 @@
 		/** @inheritDoc */
 		reset: function reset() {
 			if (!this._buffer)
-				throw new MslIoException("Cannot reset before input stream has been marked.");
+				throw new MslIoException("Cannot reset before input stream has been marked or if mark has been invalidated.");
 			
 			// Start reading from the beginning of the buffer. 
-			this._markpos = 0;
+			this._bufpos = 0;
 		},
 		
 		/** @inheritDoc */
@@ -106,7 +126,7 @@
 	            
 				// If we have any data in the buffer, read it first.
 				var bufferedData;
-				if (this._buffer && this._buffer.size() > this._markpos) {
+				if (this._buffer && this._buffer.size() > this._bufpos) {
 					// If no length was specified, read everything remaining
 					// in the buffer.
 					var endpos;
@@ -116,12 +136,12 @@
 					// Otherwise read the amount requested but no more than
 					// what remains in the buffer. 
 					else {
-						endpos = Math.min(this._buffer.size(), this._markpos + len);
+						endpos = Math.min(this._buffer.size(), this._bufpos + len);
 					}
 					
 					// Extract the buffered data.
-					bufferedData = this._buffer.toByteArray().subarray(this._markpos, endpos);
-					this._markpos += bufferedData.length;
+					bufferedData = this._buffer.toByteArray().subarray(this._bufpos, endpos);
+					this._bufpos += bufferedData.length;
 					
 					// If the data is of sufficient size, return it.
 					if (bufferedData.length >= len)
@@ -159,18 +179,28 @@
 						return bufferedData;
 					
 					// Append to the buffer if we are buffering.
-					//
-					// ByteArrayOutputStream.write() is synchronous so
-					// we can get away with this.
 					if (self._buffer) {
-						self._buffer.write(sourceData, 0, sourceData.length, -1, {
-							result: function() {},
-							timeout: function() {},
-							error: function() {}
-						});
-						self._markpos += sourceData.length;
-						// The mark position should now be equal to the
-						// buffer length.
+					    // Stop buffering if a read limit is set and the
+					    // additional data would exceed it.
+					    if (self._readlimit != -1 && self._buffer.size() + sourceData.length > self._readlimit) {
+					        self._buffer = null;
+					        self._bufpos = 0;
+					        self._readlimit = -1;
+					    }
+					    
+					    // Otherwise append.
+					    else {
+					        // ByteArrayOutputStream.write() is synchronous so
+					        // we can get away with this.
+					        self._buffer.write(sourceData, 0, sourceData.length, -1, {
+					            result: function() {},
+					            timeout: function() {},
+					            error: function() {}
+					        });
+					        self._bufpos += sourceData.length;
+					        // The mark position should now be equal to the
+					        // buffer length.
+					    }
 					}
 					
 					// If we didn't have any buffered data, return the
@@ -186,6 +216,44 @@
 					return result;
 				}
 			}, self);
+		},
+		
+		/** @inheritDoc */
+		skip: function skip(n, timeout, callback) {
+		    var self = this;
+		    
+		    InterruptibleExecutor(callback, function() {
+		        if (this._closed)
+		            throw new MslIoException("Stream is already closed.");
+		        
+		        // If we have any data in the buffer, skip it first.
+		        var skipcount = 0;
+		        if (this._buffer && this._buffer.size() > this._bufpos) {
+		            skipcount = Math.min(n, this._buffer.size() - this._bufpos);
+		            this._bufpos += skipcount;
+		            
+		            // If we skipped as much as requested return immediately.
+		            if (skipcount == n)
+		                return skipcount;
+		        }
+		        
+		        // We were not able to skip enough using just buffered data.
+		        this._read(n - skipcount, timeout, {
+		            result: function(data) {
+		                InterruptibleExecutor(callback, function() {
+		                    if (!data) return skipcount;
+		                    return data.length + skipcount;
+		                }, self);
+		            },
+		            timeout: function(data) {
+                        InterruptibleExecutor(callback, function() {
+                            if (!data) return skipcount;
+                            return data.length + skipcount;
+                        }, self);
+		            },
+		            error: callback.error,
+		        });
+		    }, self);
 		},
 	});
 })(require, (typeof module !== 'undefined') ? module : mkmodule('BufferedInputStream'));

--- a/core/src/main/javascript/io/ByteArrayInputStream.js
+++ b/core/src/main/javascript/io/ByteArrayInputStream.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,102 +20,99 @@
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 (function(require, module) {
-	"use strict";
-	
-	var InputStream = require('../io/InputStream.js');
-	var InterruptibleExecutor = require('../util/InterruptibleExecutor.js');
-	var MslIoException = require("../MslIoException.js");
-		
-	var ByteArrayInputStream = module.exports = InputStream.extend({
-	    /**
-	     * Create a new byte array input stream from the provided data.
-	     *
-	     * @param {Uint8Array} data the data.
-	     */
-	    init: function init(data) {
-	        // The properties.
-	        var props = {
-	            _data: { value: data, writable: false, enumerable: false, configurable: false },
-	            _closed: { value: false, writable: true, enumerable: false, configurable: false },
-	            _currentPosition: { value: 0, writable: true, enumerable: false, configurable: false },
-	            _mark: { value: 0, writable: true, enumerable: false, configurable: false },
-	        };
-	        Object.defineProperties(this, props);
-	    },
-	
-	    /** @inheritDoc */
-	    abort: function abort() {},
-	
-	    /** @inheritDoc */
-	    close: function close(timeout, callback) {
-	    	InterruptibleExecutor(callback, function() {
-	    		this._closed = true;
-	    		return true;
-	    	});
-	    },
-	
-	    /**
-	     * Marks the current position in this input stream. A subsequent call to
-	     * the reset method repositions this stream at the last marked position so
-	     * that subsequent reads re-read the same bytes.
-	     *
-	     * @see #reset()
-	     */
-	    mark: function mark() {
-	        this._mark = this._currentPosition;
-	    },
-	
-	    /**
-	     * Repositions this stream to the position at the time the mark method was
-	     * last called on this input stream. If the mark method has never been
-	     * called then the stream will be reset to the beginning.
-	     *
-	     * @see #mark()
-	     */
-	    reset: function reset() {
-	        this._currentPosition = this._mark;
-	    },
-	
-	    /**
-	     * @return {boolean} true if the mark and reset operations are supported.
-	     */
-	    markSupported: function markSupported() {
-	        return true;
-	    },
-	
-	    /**
-	     * Returns the requested number of bytes from the input stream. If -1
-	     * is specified for the length then this function returns any bytes
-	     * that are available but at least one unless the timeout is hit.
-	     *
-	     * If fewer bytes than requested are available then all available
-	     * bytes are returned. If zero bytes are available the method
-	     * blocks until at least one character is available or the timeout is hit.
-	     *
-	     * If there are no more bytes available (i.e. end of stream is hit)
-	     * then null is returned.
-	     *
-	     * @param {number} len the number of bytes to read.
-	     * @param {number} timeout read timeout in milliseconds.
-	     * @param {{result: function(Uint8Array), timeout: function(Uint8Array), error: function(Error)}}
-	     *        callback the callback that will receive the bytes or null, be
-	     *        notified of timeouts, or any thrown exceptions.
-	     */
-	    read: function read(len, timeout, callback) {
-	        InterruptibleExecutor(callback, function() {
-	            if (this._closed)
-	                throw new MslIoException("Stream is already closed.");
-	
-	            if (this._currentPosition == this._data.length)
-	                return null;
-	
-	            if (len == -1)
-	                len = this._data.length - this._currentPosition;
-	            var endPosition = this._currentPosition + len;
-	            var data = this._data.subarray(this._currentPosition, endPosition);
-	            this._currentPosition += data.length;
-	            return data;
-	        }, this);
-	    },
-	});
+    "use strict";
+    
+    var InputStream = require('../io/InputStream.js');
+    var InterruptibleExecutor = require('../util/InterruptibleExecutor.js');
+    var MslIoException = require("../MslIoException.js");
+        
+    var ByteArrayInputStream = module.exports = InputStream.extend({
+        /**
+         * Create a new byte array input stream from the provided data.
+         *
+         * @param {Uint8Array} data the data.
+         */
+        init: function init(data) {
+            // The properties.
+            var props = {
+                _data: { value: data, writable: false, enumerable: false, configurable: false },
+                _closed: { value: false, writable: true, enumerable: false, configurable: false },
+                _currentPosition: { value: 0, writable: true, enumerable: false, configurable: false },
+                _mark: { value: -1, writable: true, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+    
+        /** @inheritDoc */
+        abort: function abort() {},
+    
+        /** @inheritDoc */
+        close: function close(timeout, callback) {
+            InterruptibleExecutor(callback, function() {
+                this._closed = true;
+                return true;
+            });
+        },
+
+        /** @inheritDoc */
+        mark: function mark(readlimit) {
+            this._mark = this._currentPosition;
+        },
+    
+        /** @inheritDoc */
+        reset: function reset() {
+            if (this._mark == -1)
+                throw new MslIoException("Cannot reset before input stream has been marked or if mark has been invalidated.");
+            this._currentPosition = this._mark;
+        },
+    
+        /** @inheritDoc */
+        markSupported: function markSupported() {
+            return true;
+        },
+    
+        /**
+         * Returns the requested number of bytes from the input stream. If -1
+         * is specified for the length then this function returns any bytes
+         * that are available but at least one unless the timeout is hit.
+         *
+         * If fewer bytes than requested are available then all available
+         * bytes are returned. If zero bytes are available the method
+         * blocks until at least one character is available or the timeout is hit.
+         *
+         * If there are no more bytes available (i.e. end of stream is hit)
+         * then null is returned.
+         *
+         * @param {number} len the number of bytes to read.
+         * @param {number} timeout read timeout in milliseconds.
+         * @param {{result: function(Uint8Array), timeout: function(Uint8Array), error: function(Error)}}
+         *        callback the callback that will receive the bytes or null, be
+         *        notified of timeouts, or any thrown exceptions.
+         */
+        read: function read(len, timeout, callback) {
+            InterruptibleExecutor(callback, function() {
+                if (this._closed)
+                    throw new MslIoException("Stream is already closed.");
+    
+                if (this._currentPosition == this._data.length)
+                    return null;
+    
+                if (len == -1)
+                    len = this._data.length - this._currentPosition;
+                var endPosition = this._currentPosition + len;
+                var data = this._data.subarray(this._currentPosition, endPosition);
+                this._currentPosition += data.length;
+                return data;
+            }, this);
+        },
+        
+        /** @inheritDoc */
+        skip: function(n, timeout, callback) {
+            InterruptibleExecutor(callback, function() {
+                var originalPosition = this._currentPosition;
+                this._currentPosition = Math.min(this._currentPosition + n, this._data.length);
+                return this._currentPosition - originalPosition;
+            }, this);
+        },
+    });
 })(require, (typeof module !== 'undefined') ? module : mkmodule('ByteArrayInputStream'));

--- a/core/src/main/javascript/io/ByteArrayOutputStream.js
+++ b/core/src/main/javascript/io/ByteArrayOutputStream.js
@@ -53,23 +53,23 @@
     	    
         /** @inheritDoc */
         write: function(data, off, len, timeout, callback) {
-        	try {
+            try {
                 if (this._closed)
                     throw new MslIoException("Stream is already closed.");
-    
+
                 if (off < 0)
                     throw new RangeError("Offset cannot be negative.");
                 if (len < 0)
                     throw new RangeError("Length cannot be negative.");
                 if (off + len > data.length)
                     throw new RangeError("Offset plus length cannot be greater than the array length.");
-    
+
                 var endpos = Math.min(data.length, off + len);
                 var segment = data.subarray(off, endpos);
                 this._buffered.push(segment);
                 callback.result(segment.length);
             } catch (e) {
-            	callback.error(e);
+                callback.error(e);
             }
         },
     

--- a/core/src/main/javascript/io/DefaultMslEncoderFactory.js
+++ b/core/src/main/javascript/io/DefaultMslEncoderFactory.js
@@ -66,16 +66,16 @@
 
 	    /** @inheritDoc */
         encodeObject: function encodeObject(object, format, callback) {
-        	AsyncExecutor(callback, function() {
-	            // JSON.
-	            if (MslEncoderFormat.JSON == format) {
-	                JsonMslObject.encode(this, object, callback);
-	                return;
-	            }
-	            
-	            // Unsupported encoder format.
-	            throw new MslEncoderException("Unsupported encoder format: " + format + ".");
-        	}, this);
+            AsyncExecutor(callback, function() {
+                // JSON.
+                if (MslEncoderFormat.JSON == format) {
+                    JsonMslObject.encode(this, object, callback);
+                    return;
+                }
+
+                // Unsupported encoder format.
+                throw new MslEncoderException("Unsupported encoder format: " + format + ".");
+            }, this);
         },
 	});
 })(require, (typeof module !== 'undefined') ? module : mkmodule('DefaultMslEncoderFactory'));

--- a/core/src/main/javascript/io/InputStream.js
+++ b/core/src/main/javascript/io/InputStream.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 	"use strict";
 	
 	var Class = require('../util/Class.js');
+	var InterruptibleExecutor = require('../util/InterruptibleExecutor.js');
 	
 	var InputStream = module.exports = Class.create({
 	    /**
@@ -73,7 +74,8 @@
 	     * Repositions this stream to the position at the time the mark method was
 	     * last called on this input stream.
 	     *
-	     * @throws IOException if this stream has not been marked.
+	     * @throws IOException if this stream has not been marked or if the
+	     *         read limit has been exceeded.
 	     * @see #mark()
 	     */
 	    reset: function() {},
@@ -110,5 +112,43 @@
 	     *         is closed.
 	     */
 	    read: function(len, timeout, callback) {},
+	    
+	    /**
+	     * <p>Skips over and discards <code>n</code> bytes of data from this
+	     * input stream. The <code>skip</code> method may, for a variety of
+	     * reasons, end up skipping over some smaller number of bytes, possibly
+	     * <code>0</code>.</p>
+	     * 
+	     * <p>Skipped bytes must still be accounted for by mark() and
+	     * reset().</p>
+	     * 
+	     * <p>The default implementation calls read() with the requested number
+	     * of bytes.</p>
+	     * 
+	     * @param {number} n the number of bytes to be skipped.
+	     * @param {number} timeout skip timeout in milliseconds or -1 for no
+	     *        timeout.
+	     * @param {{result: function(number), timeout: function(number), error: function(Error)}}
+	     *        callback the callback that will receive the actual number of
+	     *        bytes skipped, be notified of timeouts, or any thrown
+	     *        exceptions.
+	     * @throws IOException if skip is not supported, if there is an error
+	     *         skipping over the data, or if the stream is closed.
+	     */
+	    skip: function(n, timeout, callback) {
+            this.read(n, timeout, {
+                result: function(data) {
+                    InterruptibleExecutor(callback, function() {
+                        return (data) ? data.length : 0;
+                    });
+                },
+                timeout: function(data) {
+                    InterruptibleExecutor(callback, function() {
+                        return (data) ? data.length : 0;
+                    });
+                },
+                error: callback.error,
+            });
+	    },
 	});
 })(require, (typeof module !== 'undefined') ? module : mkmodule('InputStream'));

--- a/core/src/main/javascript/io/JsonMslTokenizer.js
+++ b/core/src/main/javascript/io/JsonMslTokenizer.js
@@ -31,22 +31,31 @@
 	var JsonMslObject = require('../io/JsonMslObject.js');
 	var MslConstants = require('../MslConstants.js');
 	var TextEncoding = require('../util/TextEncoding.js');
+	
+	/**
+	 * Source input stream read size in bytes (64KiB). The larger the read
+	 * size, the shorter the recursive call stack.
+	 * 
+	 * @const
+	 * @type {number}
+	 */
+	var READ_SIZE = 64 * 1024;
 
     /**
-     * Delay time between read attempts in milliseconds.
-     *
-     * @const
-     * @type {number}
-     */
-    var READ_DELAY = 10;
-
-    /**
-     * Maximum JSON value size in characters (10MB).
+     * Maximum JSON value size in characters (10MiB).
      *
      * @const
      * @type {number}
      */
     var MAX_CHARACTERS = 10 * 1024 * 1024;
+    
+    /**
+     * Closing curly brace character code.
+     * 
+     * @const
+     * @type {number}
+     */
+    var CLOSING_BRACE = 125;
     
     var JsonMslTokenizer = module.exports = MslTokenizer.extend({
         /**
@@ -61,18 +70,59 @@
             
             // The properties.
             var props = {
-            	/** @type {MslEncoderFactory} */
-            	_encoder: { value: encoder, writable: false, enumerable: false, configurable: false },
+                /** @type {MslEncoderFactory} */
+                _encoder: { value: encoder, writable: false, enumerable: false, configurable: false },
                 /** @type {InputStream} */
                 _source: { value: source, writable: false, enumerable: false, configurable: false },
                 /** @type {string} */
                 _charset: { value: TextEncoding.Encoding.UTF_8, writable: false, enumerable: false, configurable: false },
                 /** @type {string} */
-                _remainingData: { value: '', writable: true, enumerable: false, configurable: false },
+                _lastJson: { value: 0, writable: true, enumerable: false, configurable: false },
                 /** @type {ClarinetParser} */
-                _parser: { value: undefined, writable: true, enumerable: false, configurable: false },
+                _parser: { value: new ClarinetParser(), writable: false, enumerable: false, configurable: false },
             };
             Object.defineProperties(this, props);
+        },
+        
+        /** @inheritDoc */
+        close: function close(timeout, callback) {
+            var self = this;
+            
+            InterruptibleExecutor(callback, function() {
+                // If there is no unparsed data then there is nothing to clean
+                // up.
+                if (this._parser.unparsedCount() == 0)
+                    return true;
+                
+                // Otherwise reset the source input stream and skip bytes equal
+                // to the parsed data length in encoded bytes. This will allow
+                // the input stream to be used again by a different MSL
+                // tokenizer.
+                //
+                // If we did the right thing in this class' other functions,
+                // calling reset() should not throw an exception.
+                var parsedCount = this._lastJson.length - this._parser.unparsedCount();
+                var parsedJson = this._lastJson.substring(0, parsedCount);
+                var encodedData = TextEncoding.getBytes(parsedJson, this._charset);
+                this._source.reset();
+                this._source.skip(encodedData.length, timeout, {
+                    result: function(count) {
+                        AsyncExecutor(callback, function() {
+                            if (count != encodedData.length)
+                                throw new MslEncoderException("Only skipped " + count + " of " + encodedData.length + " bytes. Source input stream may not be reusable for additional MSL messages.");
+                            return true;
+                        }, self);
+                    },
+                    timeout: function(count) {
+                        AsyncExecutor(callback, function() {
+                            if (count != encodedData.length)
+                                throw new MslEncoderException("Only skipped " + count + " of " + encodedData.length + " bytes. Source input stream may not be reusable for additional MSL messages.");
+                            return true;
+                        }, self);
+                    },
+                    error: callback.error,
+                });
+            }, self);
         },
         
         /** @inheritDoc */
@@ -82,92 +132,72 @@
         },
         
         /**
+         * <p>Feed more data from the source input stream into the parser until
+         * another value has been found. This value is returned.</p>
+         * 
          * @param {number} read timeout in milliseconds.
-         * @param {{result: function(ClarinetParser), error: function(Error)}}
-         *        callback the callback that will receive the new Clarinet JSON
-         *        parser or any thrown exceptions.
+         * @param {{result: function(*), timeout: function(), error: function(Error)}}
+         *        callback the callback that will receive the next parsed
+         *        value, be notified of timeout, or any thrown exceptions.
          * @throws MslEncoderException if a JSON object exceeds the maximum
          *         permitted size or there is an error reading from the source
          *         input stream.
          */
-        nextParser: function nextParser(timeout, callback) {
+        parseData: function parseData(timeout, callback) {
             var self = this;
             
-            this._source.read(-1, timeout, {
-                result: function(data) {
-                    AsyncExecutor(callback, function() {
-                        // On end of stream return null for the parser.
-                        if (!data) return null;
+            InterruptibleExecutor(callback, function() {
+                // Mark the source input stream. We will need to return to this
+                // position when we suceed in parsing the JSON.
+                this._source.mark(READ_SIZE);
+                
+                // Read the next chunk of data.
+                this._source.read(READ_SIZE, timeout, {
+                    result: function(data) {
+                        InterruptibleExecutor(callback, function() {
+                            // On end of stream return null for the value.
+                            if (!data) return null;
+        
+                            // Aborted responses send valid but empty data, treat
+                            // it as end of stream.
+                            if (!data.length) return null;
+                            
+                            // Convert the collected bytes to a string.
+                            this._lastJson = TextEncoding.getString(data, this._charset);
+                            
+                            // If the new unparsed data size exceeds the maximum
+                            // allowed then error.
+                            var unparsedCount = this._parser.unparsedCount() + this._lastJson.length;
+                            if (unparsedCount > MAX_CHARACTERS)
+                                throw new MslEncoderException("JSON parsing stopped after reaching " + unparsedCount + " unparsed characters.");
+                            
+                            // Attempt to parse the JSON.
+                            this._parser.write(this._lastJson);
     
-                        // Aborted responses send valid but empty data, treat
-                        // it as end of stream.
-                        if (!data.length) return null;
-                        
-                        // Append the new data to the previous data and attempt
-                        // to parse the JSON.
-                        var json;
-                        try {
-                        	json = this._remainingData.concat(TextEncoding.getString(data, this._charset));
-                        } catch (e) {
-                        	throw new MslEncoderException("Invalid JSON text encoding.", e);
-                        }
-                        var parser = new ClarinetParser(json);
-    
-                        // If we got something then return the parser and
-                        // remaining data.
-                        var lastIndex = parser.lastIndex();
-                        if (lastIndex > 0) {
-                            this._remainingData = json.substring(lastIndex);
-                            return parser;
-                        }
-    
-                        // If the new data size exceeds the maximum allowed
-                        // then error.
-                        if (json.length > MAX_CHARACTERS)
-                            throw new MslEncoderException("No JSON parsed after receiving " + json.length + " characters.");
-    
-                        // Otherwise schedule a retry.
-                        this._remainingData = json;
-                        setTimeout(function() {
-                            self.nextParser(timeout, callback);
-                        }, READ_DELAY);
-                    }, self);
-                },
-                timeout: function(data) {
-                    AsyncExecutor(callback, function() {
-                        // If we didn't get any data notify the caller and stop.
-                        if (!data || data.length == 0) {
-                            callback.timeout(this._remainingData);
-                            return;
-                        }
-    
-                        // Append the new data to the previous data and attempt
-                        // to parse the JSON.
-                        var json;
-                        try {
-                        	json = this._remainingData.concat(TextEncoding.getString(data, this._charset));
-                        } catch (e) {
-                        	throw new MslEncoderException("Invalid JSON text encoding.");
-                        }
-                        var parser = new ClarinetParser(json);
-    
-                        // If we got something then return the parser and
-                        // remaining data.
-                        var lastIndex = parser.lastIndex();
-                        if (lastIndex > 0) {
-                            this._remainingData = json.substring(lastIndex);
-                            return parser;
-                        }
-    
-                        // Otherwise notify the caller of the timeout and stop.
-                        this._remainingData = json;
-                        callback.timeout(this._remainingData);
-                    }, self);
-                },
-                error: function(e) {
-                    callback.error(new MslEncoderException("Error reading from the source input stream.", e));
-                },
-            });
+                            // If we got something then return the value.
+                            var value = this._parser.nextValue();
+                            if (value !== undefined)
+                                return value;
+        
+                            // Otherwise retry. This will discard the current
+                            // mark position which is okay as we definitely
+                            // need to read past the read limit.
+                            //
+                            // Use setTimeout to avoid blowing the stack, which
+                            // is also faster.
+                            setTimeout(function() {
+                                self.parseData(timeout, callback);
+                            }, 0);
+                        }, self);
+                    },
+                    timeout: callback.timeout,
+                    error: function(e) {
+                        AsyncExecutor(callback, function() {
+                            throw new MslEncoderException("Error reading from the source input stream.", e);
+                        }, self);
+                    },
+                });
+            }, self);
         },
         
         /** @inheritDoc */
@@ -175,38 +205,45 @@
             var self = this;
             
             InterruptibleExecutor(callback, function() {
-                var value = (this._parser) ? this._parser.nextValue() : undefined;
-                if (value !== undefined)
-                    return new JsonMslObject(this._encoder, value);
+                // Ask the parser for the next value.
+                var value = this._parser.nextValue();
+                
+                // If we received a value, wrap it.
+                if (value !== undefined) {
+                    wrapValue(value);
+                    return;
+                }
 
-                this.nextParser(this._timeout, {
-                    result: function(parser) {
+                // Otherwise try to parse more data.
+                this.parseData(this._timeout, {
+                    result: function(value) {
                         InterruptibleExecutor(callback, function() {
                             // If aborted then return null.
                             if (this._aborted)
                                 return null;
 
-                            this._parser = parser;
-
                             // If we've reached the end of the stream then
                             // return null.
-                            if (!this._parser)
+                            if (!value)
                                 return null;
 
-                            // Grab the next value.
-                            var value = this._parser.nextValue();
-                            if (typeof value !== 'object')
-                                throw new MslEncoderException("Malformed MSL message. Parsed " + typeof value + " instead of object.");
-                            return new JsonMslObject(this._encoder, value);
+                            // Wrap the value.
+                            wrapValue(value);
                         }, self);
                     },
-                    timeout: function(remainingData) {
-                        self._remainingData = remainingData;
-                        callback.timeout();
-                    },
+                    timeout: callback.timeout,
                     error: callback.error,
                 });
             }, self);
+            
+            function wrapValue(value) {
+                InterruptibleExecutor(callback, function() {
+                    // Error if the value is not an object.
+                    if (typeof value !== 'object')
+                        throw new MslEncoderException("Malformed MSL message. Parsed " + typeof value + " instead of object.");
+                    return new JsonMslObject(this._encoder, value);
+                }, self);
+            }
         },
     });
 })(require, (typeof module !== 'undefined') ? module : mkmodule('JsonMslTokenizer'));

--- a/core/src/main/javascript/keyx/KeyExchangeFactory.js
+++ b/core/src/main/javascript/keyx/KeyExchangeFactory.js
@@ -204,10 +204,10 @@
                         result: function(hmacKey) {
                             callback.result({ encryptionKey: encryptionKey, hmacKey: hmacKey });
                         },
-                        error: function(e) { callback.error(e); }
+                        error: callback.error,
                     });
                 },
-                error: function(e) { callback.error(e); }
+                error: callback.error,
             });
         },
     });

--- a/core/src/main/javascript/msg/ConsoleFilterStreamFactory.js
+++ b/core/src/main/javascript/msg/ConsoleFilterStreamFactory.js
@@ -21,12 +21,12 @@
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 (function(require, module) {
-	"use strict";
-	
-	var InputStream = require('../io/InputStream.js');
-	var OutputStream = require('../io/OutputStream.js');
-	var FilterStreamFactory = require('../msg/FilterStreamFactory.js');
-	
+    "use strict";
+    
+    var InputStream = require('../io/InputStream.js');
+    var OutputStream = require('../io/OutputStream.js');
+    var FilterStreamFactory = require('../msg/FilterStreamFactory.js');
+    
     /**
      * A filter input stream that outputs read data to stdout. A new line is
      * output when the stream is closed.
@@ -40,15 +40,15 @@
          */
         init: function init(input) {
             // The properties.
-        	var props = {
-        		_input: { value: input, writable: false, enumerable: false, configurable: false },
-        	};
-        	Object.defineProperties(this, props);
+            var props = {
+                _input: { value: input, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
         },
     
         /** @inheritDoc */
         close: function close(timeout, callback) {
-        	this._input.close(timeout, callback);
+            this._input.close(timeout, callback);
         },
         
         /** @inheritDoc */
@@ -58,27 +58,32 @@
         
         /** @inheritDoc */
         reset: function reset() {
-        	this._input.reset();
+            this._input.reset();
         },
         
         /** @inheritDoc */
         markSupported: function markSupported() {
-        	return this._input.markSupported();
+            return this._input.markSupported();
         },
 
         /** @inheritDoc */
         read: function read(len, timeout, callback) {
-        	this._input.read(len, timeout, {
-        		result: function(data) {
-        			console.log(data);
-        			callback.result(data);
-        		},
-        		timeout: function(data) {
-        			console.log(data);
-        			callback.timeout(data);
-        		},
-        		error: function(e) { callback.error(e); },
-        	});
+            this._input.read(len, timeout, {
+                result: function(data) {
+                    console.log(data);
+                    callback.result(data);
+                },
+                timeout: function(data) {
+                    console.log(data);
+                    callback.timeout(data);
+                },
+                error: callback.error,
+            });
+        },
+        
+        /** @inheritDoc */
+        skip: function skip(n, timeout, callback) {
+            this._input.skip(n, timeout, callback);
         },
     });
     
@@ -95,38 +100,38 @@
          */
         init: function init(output) {
             // The properties.
-        	var props = {
-        		_output: { value: output, writable: false, enumerable: false, configurable: false },
-        	};
-        	Object.defineProperties(this, props);
+            var props = {
+                _output: { value: output, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
         },
 
         /** @inheritDoc */
         close: function close(timeout, callback) {
-        	this._output.close(timeout, callback);
+            this._output.close(timeout, callback);
         },
 
         /** @inheritDoc */
         write: function write(data, off, len, timeout, callback) {
-        	console.log(data.subarray(off, off + len));
-        	this._output.write(data, off, len, timeout, callback);
+            console.log(data.subarray(off, off + len));
+            this._output.write(data, off, len, timeout, callback);
         },
 
         /** @inheritDoc */
         flush: function flush(timeout, callback) {
-        	this._output.flush(timeout, callback);
+            this._output.flush(timeout, callback);
         },
     });
     
     var ConsoleFilterStreamFactory = module.exports = FilterStreamFactory.extend({
-	    /** @inheritDoc */
-	    getInputStream: function getInputStream(input) {
-	        return new ConsoleInputStream(input);
-	    },
-	
-	    /** @inheritDoc */
-	    getOutputStream: function getOutputStream(output) {
-	        return new ConsoleOutputStream(output);
-	    },
+        /** @inheritDoc */
+        getInputStream: function getInputStream(input) {
+            return new ConsoleInputStream(input);
+        },
+    
+        /** @inheritDoc */
+        getOutputStream: function getOutputStream(output) {
+            return new ConsoleOutputStream(output);
+        },
     });
 })(require, (typeof module !== 'undefined') ? module : mkmodule('ConsoleFilterStreamFactory'));

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -255,7 +255,7 @@
                         return new MessageBuilder(ctx, recipient, messageId, capabilities, entityAuthData, masterToken, userIdToken, null, null, null, null, null);
                     });
                 },
-                error: function(e) { callback.error(e); }
+                error: callback.error,
             });
         });
     };
@@ -440,6 +440,67 @@
     };
 
     /**
+     * Create a new message builder that will craft a new message in response
+     * to another message without issuing or renewing any master tokens or user
+     * ID tokens. The constructed message may be used as a request.
+     * 
+     * @param {MslContext} ctx MSL context.
+     * @param {MessageHeader} requestHeader message header to respond to.
+     * @param {{result: function(MessageBuilder), error: function(Error)}}
+     *        callback the callback that will receive the message builder or
+     *        any thrown exceptions.
+     * @throws MslCryptoException if there is an error accessing the remote
+     *         entity identity.
+     * @throws MslException if any of the request's user ID tokens is not bound
+     *         to its master token.
+     */
+    var MessageBuilder$createIdempotentResponse = function MessageBuilder$createIdempotentResponse(ctx, requestHeader, callback) {
+        AsyncExecutor(callback, function() {
+            var masterToken = requestHeader.masterToken;
+            var entityAuthData = requestHeader.entityAuthenticationData;
+            var userIdToken = requestHeader.userIdToken;
+            var userAuthData = requestHeader.userAuthenticationData;
+            
+            // The response recipient is the requesting entity.
+            var recipient = (masterToken) ? masterToken.identity : entityAuthData.getIdentity();
+            
+            // The response message ID must be equal to the request message ID + 1.
+            var requestMessageId = requestHeader.messageId;
+            var messageId = MessageBuilder$incrementMessageId(requestMessageId);
+            
+            // Compute the intersection of the request and response message
+            // capabilities.
+            var capabilities = MessageCapabilities.intersection(requestHeader.messageCapabilities, ctx.getMessageCapabilities());
+            
+            // Create the message builder.
+            //
+            // Peer-to-peer responses swap the tokens.
+            try {
+                var keyResponseData = requestHeader.keyResponseData;
+                var serviceTokens = requestHeader.serviceTokens;
+                if (ctx.isPeerToPeer()) {
+                    var peerMasterToken = (keyResponseData) ? keyResponseData.masterToken : requestHeader.peerMasterToken;
+                    var peerUserIdToken = requestHeader.peerUserIdToken;
+                    var peerServiceTokens = requestHeader.peerServiceTokens;
+                    return new MessageBuilder(ctx, recipient, messageId, capabilities, entityAuthData, peerMasterToken, peerUserIdToken, peerServiceTokens, masterToken, userIdToken, serviceTokens, null);
+                } else {
+                    var localMasterToken = (keyResponseData) ? keyResponseData.masterToken : masterToken;
+                    return new MessageBuilder(ctx, recipient, messageId, capabilities, entityAuthData, localMasterToken, userIdToken, serviceTokens, null, null, null, null);
+                }
+            } catch (e) {
+                if (e instanceof MslException) {
+                    e.setMasterToken(masterToken);
+                    e.setEntityAuthenticationData(entityAuthData);
+                    e.setUserIdToken(userIdToken);
+                    e.setUserAuthenticationData(userAuthData);
+                    e.setMessageId(requestMessageId);
+                }
+                throw e;
+            }
+        });
+    };
+
+    /**
      * <p>Create a new message builder that will craft a new error message in
      * response to another message. If the message ID of the request is not
      * specified (i.e. unknown) then a random message ID will be generated.</p>
@@ -480,7 +541,7 @@
                         ErrorHeader.create(ctx, entityAuthData, recipient, messageId, errorCode, internalCode, errorMsg, userMessage, callback);
                     });
                 },
-                error: function(e) { callback.error(e); }
+                error: callback.error,
             });
         });
     };
@@ -639,6 +700,24 @@
         getMessageId: function getMessageId() {
             return this._messageId;
         },
+        
+        /**
+         * <p>Set the message ID.</p>
+         * 
+         * <p>This method will override the message ID that was computed when the
+         * message builder was created, and should not need to be called in most
+         * cases.</p>
+         * 
+         * @param {number} messageId the message ID.
+         * @return {MessageBuilder} this.
+         * @throws MslInternalException if the message ID is out of range.
+         */
+        setMessageId: function setMessageId(messageId) {
+            if (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE)
+                throw new MslInternalException("Message ID " + messageId + " is out of range.");
+            this._messageId = messageId;
+            return this;
+        },
 
         /**
          * @return {MasterToken} the primary master token or null if the message will use entity
@@ -754,7 +833,7 @@
          * handshake flag to false.
          *
          * @param {boolean} nonReplayable true if the message should be non-replayable.
-         * @return this.
+         * @return {MessageBuilder} this.
          * @see #setHandshake(boolean)
          */
         setNonReplayable: function setNonReplayable(nonReplayable) {
@@ -948,7 +1027,7 @@
                             return true;
                         }, self);
                     },
-                    error: function(e) { callback.error(e); }
+                    error: callback.error,
                 });
             }, self);
         },
@@ -1283,5 +1362,6 @@
     module.exports.decrementMessageId = MessageBuilder$decrementMessageId;
     module.exports.createRequest = MessageBuilder$createRequest;
     module.exports.createResponse = MessageBuilder$createResponse;
+    module.exports.createIdempotentResponse = MessageBuilder$createIdempotentResponse;
     module.exports.createErrorResponse = MessageBuilder$createErrorResponse;
 })(require, (typeof module !== 'undefined') ? module : mkmodule('MessageBuilder'));

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -1027,6 +1027,7 @@
                 // to reuse the connection.
                 if (this._closeSource) {
                     this._source.close(timeout, callback);
+                    closeTokenizer();
                 }
 
                 // Otherwise if this is not a handshake message or error message then
@@ -1035,7 +1036,7 @@
                     if (!this.getMessageHeader()) return true;
                     this.isHandshake(timeout, {
                         result: function(handshake) {
-                            if (handshake) callback.result(true);
+                            if (handshake) closeTokenizer();
                             else consume();
                         },
                         timeout: callback.timeout,
@@ -1048,11 +1049,23 @@
                     self.nextData(timeout, {
                         result: function(data) {
                             if (data) consume();
-                            else callback.result(true);
+                            else closeTokenizer();
                         },
                         timeout: callback.timeout,
                         // Ignore exceptions.
                         error: function() { callback.result(true); },
+                    });
+                }
+                
+                function closeTokenizer() {
+                    // Close the tokenizer.
+                    self._tokenizer.close(timeout, {
+                        result: callback.result,
+                        timeout: callback.timeout,
+                        error: function(e) {
+                            // Ignore exceptions.
+                            callback.result(true);
+                        },
                     });
                 }
             }, self);
@@ -1116,7 +1129,7 @@
                             else initialChecks();
                         },
                         timeout: function() { callback.timeout(new Uint8Array(0)); },
-                        error: function(e) { callback.error(e); }
+                        error: callback.error,
                     });
                 } else {
                     initialChecks();

--- a/core/src/main/javascript/msg/MessageOutputStream.js
+++ b/core/src/main/javascript/msg/MessageOutputStream.js
@@ -527,7 +527,7 @@
                                                                     return true;
                                                                 }, self);
                                                             },
-                                                            timeout: function() { callback.timeout(); },
+                                                            timeout: callback.timeout,
                                                             error: function(e) {
                                                                 InterruptibleExecutor(callback, function() {
                                                                     if (e instanceof MslException)

--- a/core/src/main/javascript/msg/ServerReceiveMessageContext.js
+++ b/core/src/main/javascript/msg/ServerReceiveMessageContext.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>A trusted services network message context used to receive client
+ * messages suitable for use with
+ * {@link MslControl#receive(com.netflix.msl.util.MslContext, MessageContext, java.io.InputStream, java.io.OutputStream, int)}.
+ * Since this message context is only used for receiving messages, it cannot be
+ * used to send application data back to the client and does not require
+ * encryption or integrity protection.</p>
+ * 
+ * <p>The application may wish to override
+ * {@link #updateServiceTokens(MessageServiceTokenBuilder, boolean)} to
+ * modify any service tokens sent in handshake responses.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+(function(require, module) {
+    "use strict";
+    
+    var PublicMessageContext = require('../msg/PublicMessageContext.js');
+    
+    var ServerReceiveMessageContext = module.exports = PublicMessageContext.extend({
+        /**
+         * <p>Create a new receive message context.</p>
+         * 
+         * @param {Object<string,ICryptoContext>} cryptoContexts service token crypto contexts. May be
+         *        {@code null}.
+         * @param {MessageDebugContext} dbgCtx optional message debug context. May be {@code null}.
+         */
+        init: function init(cryptoContexts, dbgCtx) {
+            init.base.call(this);
+            
+            // Make a shallow copy of the crypto contexts.
+            var contexts = {};
+            if (cryptoContexts) {
+                for (var name in cryptoContexts)
+                    contexts[name] = cryptoContexts[name];
+            }
+            
+            // The properties.
+            var props = {
+                cryptoContexts: { value: contexts, writable: true, enumerable: false, configurable: false },
+                dbgCtx: { value: dbgCtx, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+
+        /** @inheritDoc */
+        getCryptoContexts: function getCryptoContexts() {
+            return {};
+        },
+
+        /** @inheritDoc */
+        getRecipient: function getRecipient() {
+            return null;
+        },
+
+        /** @inheritDoc */
+        isRequestingTokens: function isRequestingTokens() {
+            return false;
+        },
+
+        /** @inheritDoc */
+        getUserId: function getUserId() {
+            return null;
+        },
+
+        /** @inheritDoc */
+        getUserAuthData: function getUserAuthData(reauthCode, renewable, required, callback) {
+            callback.result(null);
+        },
+
+        /** @inheritDoc */
+        getUser: function getUser() {
+            return null;
+        },
+
+        /** @inheritDoc */
+        getKeyRequestData: function getKeyRequestData(callback) {
+            callback.result([]);
+        },
+        
+        /** @inheritDoc */
+        updateServiceTokens: function updateServiceTokens(builder, handshake, callback) {
+            callback.result(true);
+        },
+
+        /** @inheritDoc */
+        write: function write(output, timeout, callback) {
+            callback.result(true);
+        },
+
+        /** @inheritDoc */
+        getDebugContext: function getDebugContext() {
+            return this.dbgCtx;
+        },
+    });
+})(require, (typeof module !== 'undefined') ? module : mkmodule('ServerReceiveMessageContext'));

--- a/core/src/main/javascript/package.json
+++ b/core/src/main/javascript/package.json
@@ -38,7 +38,6 @@
     ]
   },
   "devDependencies": {
-    "clarinet": "^0.11.0",
     "jsrsasign": "^7.2.2",
     "jshint": "^2.9.5"
   }

--- a/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleFilterStreamFactory.js
@@ -73,30 +73,35 @@
 
             this._input.read(len, timeout, {
                 result: function(data) {
-                	AsyncExecutor(callback, function() {
-                		try {
-		                    if (data)
-		                        self._target.innerHTML += TextEncoding.getString(data, MslConstants.DEFAULT_CHARSET);
-		                    return data;
-                		} catch (e) {
-                			throw new MslIoException("Error encoding data into string.", e);
-                		}
-                	}, self);
+                    AsyncExecutor(callback, function() {
+                        try {
+                            if (data)
+                                self._target.innerHTML += TextEncoding.getString(data, MslConstants.DEFAULT_CHARSET);
+                            return data;
+                        } catch (e) {
+                            throw new MslIoException("Error encoding data into string.", e);
+                        }
+                    }, self);
                 },
                 timeout: function(data) {
-                	AsyncExecutor(callback, function() {
-                		try {
-		                    if (data)
-		                        self._target.innerHTML += TextEncoding.getString(data, MslConstants.DEFAULT_CHARSET);
-		                    return data;
-                		} catch (e) {
-                			throw new MslIoException("Error encoding data into string.", e);
-                		}
-                	}, self);
+                    AsyncExecutor(callback, function() {
+                        try {
+                            if (data)
+                                self._target.innerHTML += TextEncoding.getString(data, MslConstants.DEFAULT_CHARSET);
+                            return data;
+                        } catch (e) {
+                            throw new MslIoException("Error encoding data into string.", e);
+                        }
+                    }, self);
                 },
                 error: callback.error,
             });
         },
+        
+        /** @inheritDoc */
+        skip: function skip(n, timeout, callback) {
+            this._input.skip(n, timeout, callback);
+        }
     });
 
     /**
@@ -128,15 +133,15 @@
 
         /** @inheritDoc */
         write: function write(data, off, len, timeout, callback) {
-        	var self = this;
-        	AsyncExecutor(callback, function() {
-        		try {
-        			this._target.innerHTML += TextEncoding.getString(data.subarray(off, off + len), MslConstants.DEFAULT_CHARSET);
-        		} catch (e) {
-        			throw new MslIoException("Error encoding data into string.", e);
-        		}
-	            this._output.write(data, off, len, timeout, callback);
-        	}, self);
+            var self = this;
+            AsyncExecutor(callback, function() {
+                try {
+                    this._target.innerHTML += TextEncoding.getString(data.subarray(off, off + len), MslConstants.DEFAULT_CHARSET);
+                } catch (e) {
+                    throw new MslIoException("Error encoding data into string.", e);
+                }
+                this._output.write(data, off, len, timeout, callback);
+            }, self);
         },
 
         /** @inheritDoc */

--- a/integ-tests/src/main/java/com/netflix/msl/server/common/PushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/common/PushServlet.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MessageDebugContext;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.MslControl.MslChannel;
+import com.netflix.msl.msg.ServerReceiveMessageContext;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.userauth.UserAuthenticationScheme;
+
+/**
+ * <p>A servlet that first receives MSL message via POST, but then sends a push
+ * response instead of a normal response.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public abstract class PushServlet extends BaseServlet {
+    private static final long serialVersionUID = 8620410155638929311L;
+
+    /**
+     * @param entityAuthScheme server entity authentication scheme.
+     * @param type server token factory type.
+     * @param seqno initial master token sequence number.
+     * @param unsupportedEntityAuthSchemes unsupported entity authentication
+     *        schemes. May be {@code null}.
+     * @param unsupportedUserAuthSchemes unsupported user authentication
+     *        schemes. May be {@code null}.
+     * @param unsupportedKeyxSchemes unsupported key exchange schemes. May be
+     *        {@code null}.
+     * @param cryptoContexts service token crypto contexts.
+     * @param dbgCtx optional message debug context. May be {@code null}.
+     * @param nullCryptoContext true if the server MSL crypto context should
+     *        not perform encryption or integrity protection.
+     * @param console true message data should be written out to the console.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public PushServlet(final EntityAuthenticationScheme entityAuthScheme, final TokenFactoryType type,
+        final long seqno,
+        final List<EntityAuthenticationScheme> unsupportedEntityAuthSchemes,
+        final List<UserAuthenticationScheme> unsupportedUserAuthSchemes,
+        final List<KeyExchangeScheme> unsupportedKeyxSchemes,
+        final Map<String,ICryptoContext> cryptoContexts, final MessageDebugContext dbgCtx,
+        final boolean nullCryptoContext, final boolean console) throws Exception
+    {
+        super(0, entityAuthScheme, type, seqno, unsupportedEntityAuthSchemes, unsupportedUserAuthSchemes, unsupportedKeyxSchemes, nullCryptoContext, console);
+        recvMsgCtx = new ServerReceiveMessageContext(cryptoContexts, dbgCtx);
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        final InputStream in = req.getInputStream();
+        final OutputStream out = resp.getOutputStream();
+        
+        // Receive the message.
+        final Future<MessageInputStream> futureRecv = mslCtrl.receive(mslCtx, recvMsgCtx, in, out, TIMEOUT);
+        final MessageInputStream mis;
+        try {
+            mis = futureRecv.get();
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            if (debug) e.printStackTrace(System.out);
+            return;
+        }
+        
+        // If the message input stream is null, clean up and return.
+        if (mis == null) {
+            try { in.close(); } catch (final IOException e) {}
+            try { out.close(); } catch (final IOException e) {}
+            return;
+        }
+        
+        // Deliver the message input stream for processing.
+        final List<MessageContext> pushMsgCtxs;
+        try {
+            pushMsgCtxs = process(mis);
+        } catch (final Throwable t) {
+            try { in.close(); } catch (final IOException e) {}
+            try { out.close(); } catch (final IOException e) {}
+            return;
+        }
+        
+        // Push responses.
+        for (final MessageContext pushMsgCtx : pushMsgCtxs) {
+            final Future<MslChannel> futurePush = mslCtrl.push(mslCtx, pushMsgCtx, in, out, mis, TIMEOUT);
+            try {
+                futurePush.get();
+            } catch (final ExecutionException | InterruptedException | CancellationException e) {
+                if (debug) e.printStackTrace(System.out);
+                return;
+            }
+        }
+        
+        // Clean up.
+        try { in.close(); } catch (final IOException e) {}
+        try { out.close(); } catch (final IOException e) {}
+    }
+    
+    /**
+     * Called when a message input stream is received for further processing.
+     * 
+     * @param mis the message input stream.
+     * @return the message contexts used to push replies.
+     */
+    protected abstract List<MessageContext> process(final MessageInputStream mis) throws Throwable;
+    
+    /** Receive message context. */
+    protected MessageContext recvMsgCtx;
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/common/ReceiveServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/common/ReceiveServlet.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MessageDebugContext;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.ServerReceiveMessageContext;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.userauth.UserAuthenticationScheme;
+
+/**
+ * <p>A servlet that accepts POST requests but does not send a response.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public abstract class ReceiveServlet extends BaseServlet {
+    private static final long serialVersionUID = 849604555205123832L;
+
+    /**
+     * @param entityAuthScheme server entity authentication scheme.
+     * @param type server token factory type.
+     * @param seqno initial master token sequence number.
+     * @param unsupportedEntityAuthSchemes unsupported entity authentication
+     *        schemes. May be {@code null}.
+     * @param unsupportedUserAuthSchemes unsupported user authentication
+     *        schemes. May be {@code null}.
+     * @param unsupportedKeyxSchemes unsupported key exchange schemes. May be
+     *        {@code null}.
+     * @param cryptoContexts service token crypto contexts.
+     * @param dbgCtx optional message debug context. May be {@code null}.
+     * @param nullCryptoContext true if the server MSL crypto context should
+     *        not perform encryption or integrity protection.
+     * @param console true message data should be written out to the console.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public ReceiveServlet(final EntityAuthenticationScheme entityAuthScheme, final TokenFactoryType type,
+        final long seqno,
+        final List<EntityAuthenticationScheme> unsupportedEntityAuthSchemes,
+        final List<UserAuthenticationScheme> unsupportedUserAuthSchemes,
+        final List<KeyExchangeScheme> unsupportedKeyxSchemes,
+        final Map<String,ICryptoContext> cryptoContexts, final MessageDebugContext dbgCtx,
+        final boolean nullCryptoContext, final boolean console) throws Exception
+    {
+        super(0, entityAuthScheme, type, seqno, unsupportedEntityAuthSchemes, unsupportedUserAuthSchemes, unsupportedKeyxSchemes, nullCryptoContext, console);
+        msgCtx = new ServerReceiveMessageContext(cryptoContexts, dbgCtx);
+    }
+
+    /* (non-Javadoc)
+     * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
+        final InputStream in = req.getInputStream();
+        final OutputStream out = resp.getOutputStream();
+        
+        // Receive the message.
+        final Future<MessageInputStream> future = mslCtrl.receive(mslCtx, msgCtx, in, out, TIMEOUT);
+        final MessageInputStream mis;
+        try {
+            mis = future.get();
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            if (debug) e.printStackTrace(System.out);
+            return;
+        }
+        
+        // If the message input stream is null, clean up and return.
+        if (mis == null) {
+            try { in.close(); } catch (final IOException e) {}
+            try { out.close(); } catch (final IOException e) {}
+            return;
+        }
+        
+        // Deliver the message input stream for processing.
+        receive(mis);
+        
+        // Clean up.
+        try { in.close(); } catch (final IOException e) {}
+        try { out.close(); } catch (final IOException e) {}
+    }
+    
+    /**
+     * Called when a message input stream is received for further processing.
+     * 
+     * @param mis the message input stream.
+     */
+    protected abstract void receive(final MessageInputStream mis);
+    
+    /** Message context. */
+    protected MessageContext msgCtx;
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/common/RespondServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/common/RespondServlet.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslConstants;
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.server.configuration.msg.ServerMessageContext;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.userauth.UserAuthenticationScheme;
+
+/**
+ * <p>A servlet that accepts POST requests in order to send a response.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class RespondServlet extends BaseServlet {
+    private static final long serialVersionUID = -167726318549015539L;
+    
+    protected static final String payload = "Hello";
+    protected static final String error = "Error";
+    
+    /**
+     * @param numThreads
+     * @param entityAuthScheme
+     * @param tokenFactoryType
+     * @param initialSequenceNum
+     * @param isMessageEncrypted
+     * @param isIntegrityProtected
+     * @param unSupportedEntityAuthFactories
+     * @param unSupportedUserAuthFactories
+     * @param unSupportedKeyxFactories
+     * @param isNullCryptoContext
+     * @param setConsoleFilterStreamFactory
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data.
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws Exception if there is an error configuring the servlet.
+     */
+    public RespondServlet(final int numThreads, final EntityAuthenticationScheme entityAuthScheme, final TokenFactoryType tokenFactoryType,
+        final long initialSequenceNum, final boolean isMessageEncrypted, final boolean isIntegrityProtected,
+        final List<EntityAuthenticationScheme> unSupportedEntityAuthFactories,
+        final List<UserAuthenticationScheme> unSupportedUserAuthFactories,
+        final List<KeyExchangeScheme> unSupportedKeyxFactories,
+        final boolean isNullCryptoContext, final boolean setConsoleFilterStreamFactory) throws Exception
+    {
+        super(numThreads, entityAuthScheme, tokenFactoryType, initialSequenceNum,
+            unSupportedEntityAuthFactories, unSupportedUserAuthFactories, unSupportedKeyxFactories,
+            isNullCryptoContext, setConsoleFilterStreamFactory);
+        this.encrypted = isMessageEncrypted;
+        this.integrityProtected = isIntegrityProtected;
+    }
+    
+    /**
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data.
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws Exception if there is an error configuring the servlet.
+     */
+    @Override
+    protected void configure() throws Exception {
+        super.configure();
+        
+        /**
+         * Message Context Configuration
+         */
+        msgCtx = new ServerMessageContext(mslCtx, payload.getBytes(MslConstants.DEFAULT_CHARSET), encrypted);
+        msgCtx.setIntegrityProtected(integrityProtected);
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        final InputStream inStream = request.getInputStream();
+        final OutputStream outStream = response.getOutputStream();
+        InputStream mslInputStream = null;
+
+        final byte[] buffer = new byte[5];
+
+        try {
+            final Future<MessageInputStream> msgInputStream = mslCtrl.receive(mslCtx, msgCtx, inStream, outStream, TIMEOUT);
+
+            mslInputStream = msgInputStream.get();
+            if (mslInputStream == null) return;
+
+            do {
+                final int bytesRead = mslInputStream.read(buffer);
+                if (bytesRead == -1) break;
+            } while (true);
+
+            //Checking the the received payload is the same as the one the client sent
+            if (!Arrays.equals(payload.getBytes(MslConstants.DEFAULT_CHARSET), buffer)) {
+                msgCtx.setBuffer(error.getBytes(MslConstants.DEFAULT_CHARSET));
+                mslCtrl.respond(mslCtx, msgCtx, inStream, outStream, msgInputStream.get(), TIMEOUT);
+                throw new IllegalStateException("PayloadBytes is not as expected: " + Arrays.toString(buffer));
+            }
+            msgCtx.setBuffer(buffer);
+            mslCtrl.respond(mslCtx, msgCtx, inStream, outStream, msgInputStream.get(), TIMEOUT);
+
+        } catch (final Exception ex) {
+            if (debug)
+                ex.printStackTrace(System.out);
+        } finally {
+            if (mslInputStream != null) {
+                mslInputStream.close();
+            }
+        }
+    }
+    
+    @Override
+    protected void setPrivateVariable(final PrintWriter out, final String key, final String[] values) throws Exception {
+        if (key.equals("encrypted")) {
+            this.encrypted = Boolean.parseBoolean(values[0]);
+            out.println(key + ": " + values[0]);
+        } else if (key.equals("intProtected")) {
+            this.integrityProtected = Boolean.parseBoolean(values[0]);
+            out.println(key + ": " + values[0]);
+        } else {
+            super.setPrivateVariable(out, key, values);
+        }
+    }
+    
+    /** Message context. */
+    protected ServerMessageContext msgCtx;
+    /** Application data encrypted. */
+    protected boolean encrypted;
+    /** Application data integrity protected. */
+    protected boolean integrityProtected;
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/configuration/msg/ServerMessageContext.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/configuration/msg/ServerMessageContext.java
@@ -15,18 +15,17 @@
  */
 package com.netflix.msl.server.configuration.msg;
 
-import com.netflix.msl.MslCryptoException;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashSet;
+
 import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.keyx.KeyRequestData;
 import com.netflix.msl.msg.MessageOutputStream;
 import com.netflix.msl.msg.MockMessageContext;
 import com.netflix.msl.server.configuration.util.ServerMslContext;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
-
-import java.io.IOException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
-import java.util.HashSet;
 
 /**
  * User: skommidi
@@ -38,8 +37,18 @@ public class ServerMessageContext extends MockMessageContext {
 
     /**
      * Create a new test message context.
+     * 
+     * @param mslCtx MSL context.
+     * @param payloadBytes application data to write.
+     * @param messageEncrypted true if the message must be encrypted.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
      */
-    public ServerMessageContext(ServerMslContext mslCtx, byte[] payloadBytes, boolean messageEncrypted) throws MslCryptoException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public ServerMessageContext(final ServerMslContext mslCtx, final byte[] payloadBytes, final boolean messageEncrypted) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, MslKeyExchangeException {
         super(mslCtx, null, UserAuthenticationScheme.EMAIL_PASSWORD);
         super.setUserAuthData(null);
         super.setKeyRequestData(new HashSet<KeyRequestData>());
@@ -47,10 +56,11 @@ public class ServerMessageContext extends MockMessageContext {
         this.buffer = payloadBytes;
     }
 
-    public void setBuffer(byte[] buffer) {
+    public void setBuffer(final byte[] buffer) {
         this.buffer = buffer;
     }
 
+    @Override
     public void write(final MessageOutputStream output) throws IOException {
         output.write(buffer);
         output.flush();

--- a/integ-tests/src/main/java/com/netflix/msl/server/configuration/util/ServerMslContext.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/configuration/util/ServerMslContext.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.msl.server.configuration.util;
 
+import java.util.List;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.crypto.NullCryptoContext;
@@ -26,8 +28,6 @@ import com.netflix.msl.tokens.MockTokenFactory;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
 import com.netflix.msl.util.MockMslContext;
 
-import java.util.List;
-
 /**
  * User: skommidi
  * Date: 7/21/14
@@ -35,6 +35,11 @@ import java.util.List;
 public class ServerMslContext extends MockMslContext {
     /**
      * Create a new Server MSL context.
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data.
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
      */
     public ServerMslContext(final EntityAuthenticationScheme entityAuthScheme, final boolean peerToPeer,
                             final TokenFactoryType tokenFactoryType, final long initialSequenceNum,
@@ -44,7 +49,7 @@ public class ServerMslContext extends MockMslContext {
                             final boolean isNullCryptoContext) throws MslEncodingException, MslCryptoException {
         super(entityAuthScheme, peerToPeer);
         //Set Server TokenFactory with initialSequenceNumber
-        MockTokenFactory tokenFactory = new ServerTokenFactory(tokenFactoryType);
+        final MockTokenFactory tokenFactory = new ServerTokenFactory(tokenFactoryType);
         tokenFactory.setNewestMasterToken(initialSequenceNum);
         super.setTokenFactory(tokenFactory);
 
@@ -53,17 +58,17 @@ public class ServerMslContext extends MockMslContext {
         }
 
         if (unSupportedEntityAuthFactories != null) {
-            for (EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
+            for (final EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
                 super.removeEntityAuthenticationFactory(scheme);
             }
         }
         if (unSupportedUserAuthFactories != null) {
-            for (UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
+            for (final UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
                 super.removeUserAuthenticationFactory(scheme);
             }
         }
         if (unSupportedKeyxFactories != null) {
-            for (KeyExchangeScheme scheme : unSupportedKeyxFactories) {
+            for (final KeyExchangeScheme scheme : unSupportedKeyxFactories) {
                 super.removeKeyExchangeFactories(scheme);
             }
         }

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/EchoServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/EchoServlet.java
@@ -15,40 +15,35 @@
  */
 package com.netflix.msl.server.servlet;
 
-import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEncodingException;
-import com.netflix.msl.MslKeyExchangeException;
-import com.netflix.msl.entityauth.EntityAuthenticationScheme;
-import com.netflix.msl.server.common.BaseServlet;
-import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
+
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.server.common.RespondServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
 
 /**
  * User: skommidi
  * Date: 7/24/14
  */
-public class EchoServlet extends BaseServlet {
-
-    private static final long serialVersionUID = 1L;
-
+public class EchoServlet extends RespondServlet {
+    private static final long serialVersionUID = 3781170196441547122L;
+    
     private static final long SEQUENCE_NUMBER = 8L;
     private static final int NUM_THREADS = 0;
 
-    public EchoServlet() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public EchoServlet() throws Exception {
         super(NUM_THREADS, EntityAuthenticationScheme.NONE, TokenFactoryType.NOT_ACCEPT_NON_REPLAYABLE_ID,
                 SEQUENCE_NUMBER, false, false, null, null, null, false, false);
         System.out.println("======================>> Echo Servlet Initialization Ended <<======================");
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        PrintWriter out = response.getWriter();
+    protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+        final PrintWriter out = response.getWriter();
         //Doing raw output of request
         out.println("<<<<Start>>>>\n" + getBody(request) + "\n<<<<End>>>>");
         out.close();

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/LogServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/LogServlet.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.servlet;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Writer;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.msg.MessageHeader;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.server.common.ReceiveServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+
+/**
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class LogServlet extends ReceiveServlet {
+    private static final long serialVersionUID = 1030383316461016611L;
+    
+    /** Report the log message query string. */
+    public static final String REPORT = "report";
+    
+    /** Most recently received log message. */
+    private static String message = "";
+    
+    /**
+     * <p>Create a new log servlet that will log any received application data
+     * to stdout.</p>
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public LogServlet() throws Exception {
+        super(EntityAuthenticationScheme.RSA, TokenFactoryType.ACCEPT_NON_REPLAYABLE_ID, 0,
+            null, null, null, null, null, false, false);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.msl.server.common.BaseServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        final String query = request.getQueryString();
+        if (REPORT.equals(query)) {
+            response.setContentType("text/plain");
+            final Writer out = response.getWriter();
+            out.write(message);
+            out.close();
+        } else {
+            super.doGet(request, response);
+        }
+    }
+
+    @Override
+    protected void receive(final MessageInputStream mis) {
+        // Ignore error messages.
+        final MessageHeader header = mis.getMessageHeader();
+        if (header == null) return;
+        
+        try {
+            // Log the application data.
+            final InputStreamReader reader = new InputStreamReader(mis);
+            final StringBuffer sb = new StringBuffer();
+            final char[] buffer = new char[1 << 16];
+            while (true) {
+                final int count = reader.read(buffer);
+                if (count == -1) break;
+                sb.append(buffer, 0, count);
+            }
+            message = sb.toString();
+            System.out.println("LOG: [" + message + "]");
+        } catch (final IOException e) {
+            if (debug) e.printStackTrace(System.out);
+        } finally {
+            if (mis != null)
+                try { mis.close(); } catch (final IOException e) {}
+        }
+    }
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/MultiPushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/MultiPushServlet.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.servlet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyRequestData;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MessageDebugContext;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.MessageOutputStream;
+import com.netflix.msl.msg.MessageServiceTokenBuilder;
+import com.netflix.msl.msg.PublicMessageContext;
+import com.netflix.msl.server.common.PushServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.tokens.MslUser;
+import com.netflix.msl.userauth.UserAuthenticationData;
+
+/**
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class MultiPushServlet extends PushServlet {
+    private static final long serialVersionUID = -584699388668046804L;
+
+    /**
+     * <p>Create a new secret push servlet that will echo any received data in
+     * multiple push messages that require secrecy.</p>
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public MultiPushServlet() throws Exception {
+        super(EntityAuthenticationScheme.RSA, TokenFactoryType.ACCEPT_NON_REPLAYABLE_ID, 0,
+            null, null, null, null, null, false, false);
+    }
+
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.server.common.PushServlet#process(com.netflix.msl.msg.MessageInputStream)
+     */
+    @Override
+    protected List<MessageContext> process(final MessageInputStream mis) throws IOException {
+        // Read the request.
+        final ByteArrayOutputStream data = new ByteArrayOutputStream();
+        do {
+            final byte[] cbuf = new byte[1024];
+            final int count = mis.read(cbuf);
+            if (count == -1) break;
+            data.write(cbuf, 0, count);
+        } while (true);
+        
+        final MessageContext msgCtx = new PublicMessageContext() {
+            @Override
+            public Map<String, ICryptoContext> getCryptoContexts() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public String getRecipient() {
+                return null;
+            }
+
+            @Override
+            public boolean isRequestingTokens() {
+                return false;
+            }
+
+            @Override
+            public String getUserId() {
+                return null;
+            }
+
+            @Override
+            public UserAuthenticationData getUserAuthData(final ReauthCode reauthCode, final boolean renewable, final boolean required) {
+                return null;
+            }
+
+            @Override
+            public MslUser getUser() {
+                return null;
+            }
+
+            @Override
+            public Set<KeyRequestData> getKeyRequestData() throws MslKeyExchangeException {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public void updateServiceTokens(final MessageServiceTokenBuilder builder, final boolean handshake) {
+            }
+
+            @Override
+            public void write(final MessageOutputStream output) throws IOException {
+                output.write(data.toByteArray());
+                output.close();
+            }
+
+            @Override
+            public MessageDebugContext getDebugContext() {
+                return null;
+            }
+        };
+        return Arrays.asList(msgCtx, msgCtx, msgCtx);
+    }
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/NullServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/NullServlet.java
@@ -15,28 +15,21 @@
  */
 package com.netflix.msl.server.servlet;
 
-import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEncodingException;
-import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
-import com.netflix.msl.server.common.BaseServlet;
+import com.netflix.msl.server.common.RespondServlet;
 import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
-
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * User: skommidi
  * Date: 8/27/14
  */
-public class NullServlet extends BaseServlet {
-
-    private static final long serialVersionUID = 1L;
-
+public class NullServlet extends RespondServlet {
+    private static final long serialVersionUID = -2879936348232394823L;
+    
     private static final long SEQUENCE_NUMBER = 8L;
     private static final int NUM_THREADS = 0;
 
-    public NullServlet() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public NullServlet() throws Exception {
         super(NUM_THREADS, EntityAuthenticationScheme.NONE, TokenFactoryType.NOT_ACCEPT_NON_REPLAYABLE_ID,
                 SEQUENCE_NUMBER, false, false, null, null, null, true, true);
         System.out.println("======================>> Null Servlet Initialization Ended <<======================");

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/PublicPushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/PublicPushServlet.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.servlet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyRequestData;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MessageDebugContext;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.MessageOutputStream;
+import com.netflix.msl.msg.MessageServiceTokenBuilder;
+import com.netflix.msl.msg.PublicMessageContext;
+import com.netflix.msl.server.common.PushServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.tokens.MslUser;
+import com.netflix.msl.userauth.UserAuthenticationData;
+
+/**
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class PublicPushServlet extends PushServlet {
+    private static final long serialVersionUID = 5346709653657304340L;
+
+    /**
+     * <p>Create a new public push servlet that will echo any received data in
+     * a push message that does not require secrecy.</p>
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public PublicPushServlet() throws Exception {
+        super(EntityAuthenticationScheme.RSA, TokenFactoryType.ACCEPT_NON_REPLAYABLE_ID, 0,
+            null, null, null, null, null, false, false);
+    }
+
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.server.common.PushServlet#process(com.netflix.msl.msg.MessageInputStream)
+     */
+    @Override
+    protected List<MessageContext> process(final MessageInputStream mis) throws IOException {
+        // Read the request.
+        final ByteArrayOutputStream data = new ByteArrayOutputStream();
+        do {
+            final byte[] cbuf = new byte[1024];
+            final int count = mis.read(cbuf);
+            if (count == -1) break;
+            data.write(cbuf, 0, count);
+        } while (true);
+        
+        final MessageContext msgCtx = new PublicMessageContext() {
+            @Override
+            public Map<String, ICryptoContext> getCryptoContexts() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public String getRecipient() {
+                return null;
+            }
+
+            @Override
+            public boolean isRequestingTokens() {
+                return false;
+            }
+
+            @Override
+            public String getUserId() {
+                return null;
+            }
+
+            @Override
+            public UserAuthenticationData getUserAuthData(final ReauthCode reauthCode, final boolean renewable, final boolean required) {
+                return null;
+            }
+
+            @Override
+            public MslUser getUser() {
+                return null;
+            }
+
+            @Override
+            public Set<KeyRequestData> getKeyRequestData() throws MslKeyExchangeException {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public void updateServiceTokens(final MessageServiceTokenBuilder builder, final boolean handshake) {
+            }
+
+            @Override
+            public void write(final MessageOutputStream output) throws IOException {
+                output.write(data.toByteArray());
+                output.close();
+            }
+
+            @Override
+            public MessageDebugContext getDebugContext() {
+                return null;
+            }
+        };
+        return Arrays.asList(msgCtx);
+    }
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/SecretPushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/SecretPushServlet.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.server.servlet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.crypto.ICryptoContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.keyx.KeyRequestData;
+import com.netflix.msl.msg.MessageContext;
+import com.netflix.msl.msg.MessageDebugContext;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.MessageOutputStream;
+import com.netflix.msl.msg.MessageServiceTokenBuilder;
+import com.netflix.msl.msg.SecretMessageContext;
+import com.netflix.msl.server.common.PushServlet;
+import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
+import com.netflix.msl.tokens.MslUser;
+import com.netflix.msl.userauth.UserAuthenticationData;
+
+/**
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class SecretPushServlet extends PushServlet {
+    private static final long serialVersionUID = 5346709653657304340L;
+
+    /**
+     * <p>Create a new secret push servlet that will echo any received data in
+     * a push message that requires secrecy.</p>
+     * 
+     * @throws MslCryptoException if there is an error signing or creating the
+     *         entity authentication data or an error creating a key
+     * @throws MslEncodingException if there is an error creating the entity
+     *         authentication data.
+     * @throws MslKeyExchangeException if there is an error accessing Diffie-
+     *         Hellman parameters.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     */
+    public SecretPushServlet() throws Exception {
+        super(EntityAuthenticationScheme.RSA, TokenFactoryType.ACCEPT_NON_REPLAYABLE_ID, 0,
+            null, null, null, null, null, false, false);
+    }
+
+
+    /* (non-Javadoc)
+     * @see com.netflix.msl.server.common.PushServlet#process(com.netflix.msl.msg.MessageInputStream)
+     */
+    @Override
+    protected List<MessageContext> process(final MessageInputStream mis) throws IOException {
+        // Read the request.
+        final ByteArrayOutputStream data = new ByteArrayOutputStream();
+        do {
+            final byte[] cbuf = new byte[1024];
+            final int count = mis.read(cbuf);
+            if (count == -1) break;
+            data.write(cbuf, 0, count);
+        } while (true);
+        
+        final MessageContext msgCtx = new SecretMessageContext() {
+            @Override
+            public Map<String, ICryptoContext> getCryptoContexts() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public String getRecipient() {
+                return null;
+            }
+
+            @Override
+            public boolean isRequestingTokens() {
+                return false;
+            }
+
+            @Override
+            public String getUserId() {
+                return null;
+            }
+
+            @Override
+            public UserAuthenticationData getUserAuthData(final ReauthCode reauthCode, final boolean renewable, final boolean required) {
+                return null;
+            }
+
+            @Override
+            public MslUser getUser() {
+                return null;
+            }
+
+            @Override
+            public Set<KeyRequestData> getKeyRequestData() throws MslKeyExchangeException {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public void updateServiceTokens(final MessageServiceTokenBuilder builder, final boolean handshake) {
+            }
+
+            @Override
+            public void write(final MessageOutputStream output) throws IOException {
+                output.write(data.toByteArray());
+                output.close();
+            }
+
+            @Override
+            public MessageDebugContext getDebugContext() {
+                return null;
+            }
+        };
+        return Arrays.asList(msgCtx);
+    }
+}

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/TestServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/TestServlet.java
@@ -15,28 +15,21 @@
  */
 package com.netflix.msl.server.servlet;
 
-import com.netflix.msl.MslCryptoException;
-import com.netflix.msl.MslEncodingException;
-import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
-import com.netflix.msl.server.common.BaseServlet;
+import com.netflix.msl.server.common.RespondServlet;
 import com.netflix.msl.server.configuration.tokens.TokenFactoryType;
-
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * User: skommidi
  * Date: 7/21/14
  */
-public class TestServlet extends BaseServlet {
-
-    private static final long serialVersionUID = 1L;
-
+public class TestServlet extends RespondServlet {
+    private static final long serialVersionUID = 3747351784182184977L;
+    
     private static final long SEQUENCE_NUMBER = 8L;
     private static final int NUM_THREADS = 0;
 
-    public TestServlet() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+    public TestServlet() throws Exception {
         super(NUM_THREADS, EntityAuthenticationScheme.NONE, TokenFactoryType.NOT_ACCEPT_NON_REPLAYABLE_ID,
                 SEQUENCE_NUMBER, false, false, null, null, null, false, false);
         System.out.println("======================>> Test Servlet Initialization Ended <<======================");

--- a/integ-tests/src/main/webapp/WEB-INF/web.xml
+++ b/integ-tests/src/main/webapp/WEB-INF/web.xml
@@ -31,4 +31,40 @@
         <servlet-name>EchoServlet</servlet-name>
         <url-pattern>/echo</url-pattern>
     </servlet-mapping>
+    
+    <servlet>
+        <servlet-name>LogServlet</servlet-name>
+        <servlet-class>com.netflix.msl.server.servlet.LogServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>LogServlet</servlet-name>
+        <url-pattern>/log</url-pattern>
+    </servlet-mapping>
+    
+    <servlet>
+        <servlet-name>SecretPushServlet</servlet-name>
+        <servlet-class>com.netflix.msl.server.servlet.SecretPushServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>SecretPushServlet</servlet-name>
+        <url-pattern>/secret-push</url-pattern>
+    </servlet-mapping>
+    
+    <servlet>
+        <servlet-name>PublicPushServlet</servlet-name>
+        <servlet-class>com.netflix.msl.server.servlet.PublicPushServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>PublicPushServlet</servlet-name>
+        <url-pattern>/public-push</url-pattern>
+    </servlet-mapping>
+    
+    <servlet>
+        <servlet-name>MultiPushServlet</servlet-name>
+        <servlet-class>com.netflix.msl.server.servlet.MultiPushServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MultiPushServlet</servlet-name>
+        <url-pattern>/multi-push</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/integ-tests/src/test/java/com/netflix/msl/client/common/BaseTestClass.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/common/BaseTestClass.java
@@ -15,8 +15,8 @@
  */
 package com.netflix.msl.client.common;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Date;
 import java.util.HashSet;
@@ -43,7 +43,6 @@ import com.netflix.msl.entityauth.MockPresharedAuthenticationFactory;
 import com.netflix.msl.io.MslEncoderException;
 import com.netflix.msl.io.MslEncoderFactory;
 import com.netflix.msl.io.MslObject;
-import com.netflix.msl.io.Url.Connection;
 import com.netflix.msl.keyx.KeyRequestData;
 import com.netflix.msl.msg.MessageBuilder;
 import com.netflix.msl.msg.MessageHeader;
@@ -241,7 +240,7 @@ public class BaseTestClass {
         return null;
     }
 
-    public MessageInputStream sendReceive(final OutputStream out, final DelayedInputStream in,
+    public MessageInputStream sendReceive(final OutputStream out, final InputStream in,
                                           final MasterToken masterToken, final UserIdToken userIdToken, final Set<ServiceToken> serviceTokens,
                                           final boolean isRenewable, final boolean addKeyRequestData) throws MslException, IOException {
         final MessageBuilder builder = MessageBuilder.createRequest(clientConfig.getMslContext(), masterToken, userIdToken, null);
@@ -279,84 +278,5 @@ public class BaseTestClass {
         MASTER_BOUND,
         BOTH,
         NONE
-    }
-
-    /**
-     * A delayed input stream does not open the real input stream until
-     * one of its methods is called.
-     */
-    protected static class DelayedInputStream extends FilterInputStream {
-        /**
-         * Create a new delayed input stream that will not attempt to
-         * construct the input stream from the URL connection until it is
-         * actually needed (i.e. read from).
-         *
-         * @param conn backing URL connection.
-         */
-        public DelayedInputStream(final Connection conn) {
-            super(null);
-            this.conn = conn;
-        }
-
-        @Override
-        public int available() throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            return super.available();
-        }
-
-        @Override
-        public void close() throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            super.close();
-        }
-
-        @Override
-        public synchronized void mark(final int readlimit) {
-        }
-
-        @Override
-        public boolean markSupported() {
-            return false;
-        }
-
-        @Override
-        public int read() throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            return in.read();
-        }
-
-        @Override
-        public int read(final byte[] b, final int off, final int len) throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            return super.read(b, off, len);
-        }
-
-        @Override
-        public int read(final byte[] b) throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            return super.read(b);
-        }
-
-        @Override
-        public synchronized void reset() throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            super.reset();
-        }
-
-        @Override
-        public long skip(final long n) throws IOException {
-            if (in == null)
-                in = conn.getInputStream();
-            return super.skip(n);
-        }
-
-        /** URL connection providing the input stream. */
-        private final Connection conn;
     }
 }

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
@@ -25,19 +25,19 @@ import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.client.configuration.entityauth.TestEccAuthenticationFactory;
 import com.netflix.msl.client.configuration.entityauth.TestPresharedAuthenticationFactory;
 import com.netflix.msl.client.configuration.entityauth.TestRsaAuthenticationFactory;
-import com.netflix.msl.client.configuration.entityauth.TestEccAuthenticationFactory;
 import com.netflix.msl.client.configuration.entityauth.TestX509AuthenticationFactory;
 import com.netflix.msl.client.configuration.msg.ClientMessageContext;
 import com.netflix.msl.client.configuration.msg.InvalidUserAuthScheme;
 import com.netflix.msl.client.configuration.util.ClientMslContext;
+import com.netflix.msl.entityauth.EccAuthenticationData;
 import com.netflix.msl.entityauth.EntityAuthenticationData;
 import com.netflix.msl.entityauth.EntityAuthenticationFactory;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.entityauth.PresharedAuthenticationData;
 import com.netflix.msl.entityauth.RsaAuthenticationData;
-import com.netflix.msl.entityauth.EccAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
 import com.netflix.msl.entityauth.UnauthenticatedAuthenticationFactory;
 import com.netflix.msl.entityauth.X509AuthenticationData;
@@ -68,7 +68,7 @@ public class ClientConfiguration {
     private String scheme = "http";
     private String remoteHost = "localhost";
     private String path = "";
-    private static final String USER_ID = "userid";
+    private String userId = null;
     private boolean isPeerToPeer = false;
     private EntityAuthenticationScheme entityAuthenticationScheme = EntityAuthenticationScheme.PSK;
     private UserAuthenticationScheme userAuthenticationScheme = UserAuthenticationScheme.EMAIL_PASSWORD;
@@ -86,31 +86,36 @@ public class ClientConfiguration {
     private boolean isIntegrityProtected = true;
     private boolean clearKeyRequestData = false;
 
-    public ClientConfiguration setEntityAuthenticationScheme(EntityAuthenticationScheme scheme) {
+    public ClientConfiguration setEntityAuthenticationScheme(final EntityAuthenticationScheme scheme) {
         entityAuthenticationScheme = scheme;
         return this;
     }
 
 
 
-    public ClientConfiguration setUserAuthenticationScheme(UserAuthenticationScheme scheme) {
+    public ClientConfiguration setUserAuthenticationScheme(final UserAuthenticationScheme scheme) {
         userAuthenticationScheme = scheme;
+        return this;
+    }
+    
+    public ClientConfiguration setUserId(final String userId) {
+        this.userId = userId;
         return this;
     }
 
 
-    public ClientConfiguration setIsMessageEncrypted(boolean messageEncrypted) {
+    public ClientConfiguration setIsMessageEncrypted(final boolean messageEncrypted) {
         this.isMessageEncrypted = messageEncrypted;
         return this;
     }
 
 
-    public ClientConfiguration setIsIntegrityProtected(boolean integrityProtected) {
+    public ClientConfiguration setIsIntegrityProtected(final boolean integrityProtected) {
         this.isIntegrityProtected = integrityProtected;
         return this;
     }
 
-    public ClientConfiguration setKeyRequestData(KeyExchangeScheme scheme) {
+    public ClientConfiguration setKeyRequestData(final KeyExchangeScheme scheme) {
         keyExchangeScheme = scheme;
         return this;
     }
@@ -123,12 +128,12 @@ public class ClientConfiguration {
         return this;
     }
 
-    public ClientConfiguration setInvalidUserAuthData(InvalidUserAuthScheme scheme) {
+    public ClientConfiguration setInvalidUserAuthData(final InvalidUserAuthScheme scheme) {
         setInvalidUserAuthData = scheme;
         return this;
     }
 
-    public ClientConfiguration setMaxEntityAuthRetryCount(int value) {
+    public ClientConfiguration setMaxEntityAuthRetryCount(final int value) {
         this.entityAuthRetryCount = value;
         return this;
     }
@@ -139,7 +144,7 @@ public class ClientConfiguration {
         return this;
     }
 
-    public ClientConfiguration setMaxUserAuthRetryCount(int value) {
+    public ClientConfiguration setMaxUserAuthRetryCount(final int value) {
         this.userAuthRetryCount = value;
         return this;
     }
@@ -149,32 +154,32 @@ public class ClientConfiguration {
         return this;
     }
 
-    public ClientConfiguration setScheme(String scheme) {
+    public ClientConfiguration setScheme(final String scheme) {
         this.scheme = scheme;
         return this;
     }
 
-    public ClientConfiguration setHost(String remoteHost) {
+    public ClientConfiguration setHost(final String remoteHost) {
         this.remoteHost = remoteHost;
         return this;
     }
 
-    public ClientConfiguration setPath(String path) {
+    public ClientConfiguration setPath(final String path) {
         this.path = path;
         return this;
     }
 
-    public ClientConfiguration setIsPeerToPeer(boolean isPeerToPeer) {
+    public ClientConfiguration setIsPeerToPeer(final boolean isPeerToPeer) {
         this.isPeerToPeer = isPeerToPeer;
         return this;
     }
 
-    public ClientConfiguration setMessageNonReplayable(boolean nonReplayable) {
+    public ClientConfiguration setMessageNonReplayable(final boolean nonReplayable) {
         this.nonReplayable = nonReplayable;
         return this;
     }
 
-    public ClientConfiguration setIsNullCryptoContext(boolean isNullCryptoContext) {
+    public ClientConfiguration setIsNullCryptoContext(final boolean isNullCryptoContext) {
         this.isNullCryptoContext = isNullCryptoContext;
         return this;
     }
@@ -230,7 +235,7 @@ public class ClientConfiguration {
         }
 
         /** create message context and configure */
-        messageContext = new ClientMessageContext(mslContext, USER_ID, userAuthenticationScheme, isMessageEncrypted, isIntegrityProtected);
+        messageContext = new ClientMessageContext(mslContext, userId, userAuthenticationScheme, isMessageEncrypted, isIntegrityProtected);
         messageContext.resetKeyRequestData(keyExchangeScheme);
         if(this.clearKeyRequestData) {
             messageContext.clearKeyRequestData();
@@ -273,7 +278,7 @@ public class ClientConfiguration {
         }
     }
 
-    public ClientConfiguration setNumThreads(int numThreads) {
+    public ClientConfiguration setNumThreads(final int numThreads) {
         mslControl = new MslControl(numThreads);
         //mslControl.setFilterFactory(new TestConsoleFilterStreamFactory());
         return this;

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/ServerConfiguration.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/ServerConfiguration.java
@@ -36,7 +36,7 @@ import com.netflix.msl.userauth.UserAuthenticationScheme;
  */
 public class ServerConfiguration {
     private static class NameValuePair {
-        public NameValuePair(String name, String value) {
+        public NameValuePair(final String name, final String value) {
             try {
                 this.name = URLEncoder.encode(name, "UTF-8");
                 this.value = URLEncoder.encode(value, "UTF-8");
@@ -49,7 +49,7 @@ public class ServerConfiguration {
         private final String value;
     }
     
-    private String scheme = "http";
+    private final String scheme = "http";
     private String path;
     private String host;
     private int numThreads;
@@ -63,7 +63,7 @@ public class ServerConfiguration {
     private List<EntityAuthenticationScheme> unSupportedEntityAuthFactories;
     private List<UserAuthenticationScheme> unSupportedUserAuthFactories;
     private List<KeyExchangeScheme> unSupportedKeyxFactories;
-    private List<NameValuePair> nvps;
+    private final List<NameValuePair> nvps;
 
     private static final String NUM_THREADS = "numthreads";
     private static final String ENTITY_AUTH_SCHEME = "entityauthscheme";
@@ -108,89 +108,89 @@ public class ServerConfiguration {
         nvps.add(new NameValuePair(NULL_CRYPTO_CONTEXT, String.valueOf(isNullCryptoContext)));
         nvps.add(new NameValuePair(CONSOLE_FILTER_STREAM_FACTORY, String.valueOf(setConsoleFilterStreamFactory)));
         if(unSupportedEntityAuthFactories!=null) {
-            for(EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
+            for(final EntityAuthenticationScheme scheme : unSupportedEntityAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_ENTITY_SCHEMES, String.valueOf(scheme)));
             }
         }
         if(unSupportedUserAuthFactories!=null) {
-            for(UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
+            for(final UserAuthenticationScheme scheme : unSupportedUserAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_USER_SCHEMES, String.valueOf(scheme)));
             }
         }
         if(unSupportedKeyxFactories!=null) {
-            for(KeyExchangeScheme scheme : unSupportedKeyxFactories) {
+            for(final KeyExchangeScheme scheme : unSupportedKeyxFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_KEY_EXCHANGE_SCHEMES, String.valueOf(scheme)));
             }
         }
     }
 
-    public ServerConfiguration isMessageEncrypted(boolean isMessageEncrypted) {
+    public ServerConfiguration isMessageEncrypted(final boolean isMessageEncrypted) {
         this.isMessageEncrypted = isMessageEncrypted;
         setParameter(ENCRYPTED, String.valueOf(this.isMessageEncrypted));
         return this;
     }
 
-    public ServerConfiguration isIntegrityProtected(boolean isIntegrityProtected) {
+    public ServerConfiguration isIntegrityProtected(final boolean isIntegrityProtected) {
         this.isIntegrityProtected = isIntegrityProtected;
         setParameter(INTEGRITY_PROTECTED, String.valueOf(this.isIntegrityProtected));
         return this;
     }
 
-    public ServerConfiguration setHost(String host) {
+    public ServerConfiguration setHost(final String host) {
         this.host = host;
         return this;
     }
 
-    public ServerConfiguration setPath(String path) {
+    public ServerConfiguration setPath(final String path) {
         this.path = path;
         return this;
     }
 
-    public ServerConfiguration setIsNullCryptoContext(boolean isNullCryptoContext) {
+    public ServerConfiguration setIsNullCryptoContext(final boolean isNullCryptoContext) {
         this.isNullCryptoContext = isNullCryptoContext;
         setParameter(NULL_CRYPTO_CONTEXT, String.valueOf(this.isNullCryptoContext));
         return this;
     }
 
-    public ServerConfiguration setInitialSequenceNumber(long initialSequenceNumber) {
+    public ServerConfiguration setInitialSequenceNumber(final long initialSequenceNumber) {
         this.initialSequenceNum = initialSequenceNumber;
         setParameter(INITIAL_SEQUENCE_NUM, String.valueOf(this.initialSequenceNum));
         return this;
     }
 
-    public ServerConfiguration setSetConsoleFilterStreamFactory(boolean setConsoleFilterStreamFactory) {
+    public ServerConfiguration setSetConsoleFilterStreamFactory(final boolean setConsoleFilterStreamFactory) {
         this.setConsoleFilterStreamFactory = setConsoleFilterStreamFactory;
         setParameter(CONSOLE_FILTER_STREAM_FACTORY, String.valueOf(this.setConsoleFilterStreamFactory));
         return this;
     }
 
-    public ServerConfiguration setUnsupportedEntityAuthenticationSchemes(List<EntityAuthenticationScheme> unSupportedEntityAuthFactories) {
+    public ServerConfiguration setUnsupportedEntityAuthenticationSchemes(final List<EntityAuthenticationScheme> unSupportedEntityAuthFactories) {
         this.unSupportedEntityAuthFactories = unSupportedEntityAuthFactories;
         clearParameter(UNSUPPORTED_ENTITY_SCHEMES);
         if(this.unSupportedEntityAuthFactories!=null) {
-            for(EntityAuthenticationScheme scheme : this.unSupportedEntityAuthFactories) {
+            for(final EntityAuthenticationScheme scheme : this.unSupportedEntityAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_ENTITY_SCHEMES, String.valueOf(scheme)));
             }
         }
         return this;
     }
 
-    public ServerConfiguration setUnsupportedUserAuthenticationSchemes(List<UserAuthenticationScheme> unSupportedUserAuthFactories) {
+    public ServerConfiguration setUnsupportedUserAuthenticationSchemes(final List<UserAuthenticationScheme> unSupportedUserAuthFactories) {
         this.unSupportedUserAuthFactories = unSupportedUserAuthFactories;
         clearParameter(UNSUPPORTED_USER_SCHEMES);
         if(this.unSupportedUserAuthFactories!=null) {
-            for(UserAuthenticationScheme scheme : this.unSupportedUserAuthFactories) {
+            for(final UserAuthenticationScheme scheme : this.unSupportedUserAuthFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_USER_SCHEMES, String.valueOf(scheme)));
             }
         }
         return this;
     }
 
-    public ServerConfiguration setUnsupportedKeyExchangeSchemes(List<KeyExchangeScheme> unSupportedKeyxFactories) {
+    public ServerConfiguration setUnsupportedKeyExchangeSchemes(final List<KeyExchangeScheme> unSupportedKeyxFactories) {
         this.unSupportedKeyxFactories = unSupportedKeyxFactories;
         clearParameter(UNSUPPORTED_KEY_EXCHANGE_SCHEMES);
         if(this.unSupportedKeyxFactories != null) {
-            for(KeyExchangeScheme scheme : this.unSupportedKeyxFactories) {
+            for(final KeyExchangeScheme scheme : this.unSupportedKeyxFactories) {
                 nvps.add(new NameValuePair(UNSUPPORTED_KEY_EXCHANGE_SCHEMES, String.valueOf(scheme)));
             }
         }
@@ -202,7 +202,7 @@ public class ServerConfiguration {
         return this;
     }
 
-    public ServerConfiguration clearParameter(String name) {
+    public ServerConfiguration clearParameter(final String name) {
         if (!nvps.isEmpty()) {
             for (final Iterator<NameValuePair> it = nvps.iterator(); it.hasNext(); ) {
                 final NameValuePair nvp = it.next();
@@ -215,19 +215,19 @@ public class ServerConfiguration {
         return this;
     }
 
-    public ServerConfiguration setParameter(String name, String value) {
+    public ServerConfiguration setParameter(final String name, final String value) {
         clearParameter(name);
         nvps.add(new NameValuePair(name, value));
         return this;
     }
 
     public void commitToServer() throws URISyntaxException, IOException {
-        StringBuilder urlBuilder = new StringBuilder(scheme + "://" + host + path + "?");
-        for (NameValuePair pair : nvps)
+        final StringBuilder urlBuilder = new StringBuilder(scheme + "://" + host + path + "?");
+        for (final NameValuePair pair : nvps)
             urlBuilder.append(pair.name + "=" + pair.value + "&");
-        URL url = new URL(urlBuilder.toString());
+        final URL url = new URL(urlBuilder.toString());
         
-        HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
         conn.setRequestMethod("GET");
         conn.getResponseCode();
     }

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/msg/ClientMessageContext.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/msg/ClientMessageContext.java
@@ -15,6 +15,21 @@
  */
 package com.netflix.msl.client.configuration.msg;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.crypto.interfaces.DHPrivateKey;
+import javax.crypto.interfaces.DHPublicKey;
+import javax.crypto.spec.DHParameterSpec;
+
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslKeyExchangeException;
 import com.netflix.msl.keyx.AsymmetricWrappedExchange;
@@ -31,20 +46,6 @@ import com.netflix.msl.userauth.MockEmailPasswordAuthenticationFactory;
 import com.netflix.msl.userauth.UserAuthenticationData;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
 import com.netflix.msl.util.MslContext;
-
-import javax.crypto.interfaces.DHPrivateKey;
-import javax.crypto.interfaces.DHPublicKey;
-import javax.crypto.spec.DHParameterSpec;
-import java.io.IOException;
-import java.math.BigInteger;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * User: skommidi
@@ -82,7 +83,7 @@ public class ClientMessageContext extends MockMessageContext {
      *                         if there is an error accessing Diffie-
      *                         Hellman parameters.
      */
-    public ClientMessageContext(MslContext ctx, String userId, UserAuthenticationScheme scheme, boolean isMessageEncrypted, boolean isIntegrityProtected) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, MslCryptoException, MslKeyExchangeException {
+    public ClientMessageContext(final MslContext ctx, final String userId, final UserAuthenticationScheme scheme, final boolean isMessageEncrypted, final boolean isIntegrityProtected) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, MslCryptoException, MslKeyExchangeException {
         super(ctx, userId, scheme);
         super.setEncrypted(isMessageEncrypted);
         super.setIntegrityProtected(isIntegrityProtected);
@@ -91,7 +92,7 @@ public class ClientMessageContext extends MockMessageContext {
         currentRetryCount = 0;
     }
 
-    public void setBuffer(byte[] dataToWrite) {
+    public void setBuffer(final byte[] dataToWrite) {
         buffer = dataToWrite;
     }
 
@@ -99,13 +100,12 @@ public class ClientMessageContext extends MockMessageContext {
      * @see com.netflix.msl.msg.MockMessageContext#write(com.netflix.msl.msg.MessageOutputStream)
      */
     @Override
-    public void write(MessageOutputStream output) throws IOException {
+    public void write(final MessageOutputStream output) throws IOException {
         output.write(buffer);
-        output.flush();
         output.close();
     }
 
-    public void setMaxRetryCount(int maxRetryCount) {
+    public void setMaxRetryCount(final int maxRetryCount) {
         this.maxRetryCount = maxRetryCount;
     }
 

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/EntityAuthTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/EntityAuthTests.java
@@ -41,10 +41,11 @@ import com.netflix.msl.userauth.UserAuthenticationScheme;
  * Date: 7/25/14
  */
 public class EntityAuthTests extends BaseTestClass {
-    private int numThreads = 0;
+    private final int numThreads = 0;
     private ServerConfiguration serverConfig = null;
     private static final int TIME_OUT = 60000; //60 seconds
     private static final String PATH = "/test";
+    private static final String USER_ID = "userId";
 
     @BeforeMethod
     public void setup() throws IOException, URISyntaxException {
@@ -79,6 +80,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -126,7 +128,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -156,6 +158,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.RSA)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -202,7 +205,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -235,11 +238,12 @@ public class EntityAuthTests extends BaseTestClass {
                 .setMaxEntityAuthRetryCount(2)
                 .resetCurrentEntityAuthRetryCount()
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenThe(message)
                 .shouldBe().validFirstEntityAuthRSAMsg()
@@ -268,6 +272,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.ECC)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -310,11 +315,12 @@ public class EntityAuthTests extends BaseTestClass {
                 .setMaxEntityAuthRetryCount(5)
                 .resetCurrentEntityAuthRetryCount()
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -344,6 +350,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.X509)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.DIFFIE_HELLMAN);
         clientConfig.commitConfiguration();
@@ -387,11 +394,12 @@ public class EntityAuthTests extends BaseTestClass {
                 .setMaxEntityAuthRetryCount(5)
                 .resetCurrentEntityAuthRetryCount()
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -422,6 +430,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -449,6 +458,7 @@ public class EntityAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .clearKeyRequestData();
         clientConfig.commitConfiguration();
@@ -456,7 +466,7 @@ public class EntityAuthTests extends BaseTestClass {
         serverConfig.isMessageEncrypted(true)
                 .commitToServer();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/MasterTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/MasterTokenTests.java
@@ -18,6 +18,7 @@ package com.netflix.msl.client.tests;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.security.InvalidAlgorithmParameterException;
@@ -55,6 +56,7 @@ public class MasterTokenTests extends BaseTestClass {
 
     private static final String PATH = "/test";
     private static final int TIME_OUT = 60000; // 60 Seconds
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
@@ -71,6 +73,7 @@ public class MasterTokenTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -93,7 +96,7 @@ public class MasterTokenTests extends BaseTestClass {
             final Connection connection = remoteEntity.openConnection();
 
             out = connection.getOutputStream();
-            in = new DelayedInputStream(connection);
+            in = connection.getInputStream();
         } catch (final IOException e) {
             if(out != null) out.close();
             if(in != null) in.close();
@@ -231,5 +234,5 @@ public class MasterTokenTests extends BaseTestClass {
     private final int numThreads = 0;
     private ServerConfiguration serverConfig;
     private OutputStream out;
-    private DelayedInputStream in;
+    private InputStream in;
 }

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/PushTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/PushTests.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.client.tests;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.junit.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.netflix.msl.MslConstants;
+import com.netflix.msl.MslConstants.ResponseCode;
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.client.common.BaseTestClass;
+import com.netflix.msl.client.configuration.ClientConfiguration;
+import com.netflix.msl.client.configuration.msg.ClientMessageContext;
+import com.netflix.msl.client.configuration.util.ClientMslContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
+import com.netflix.msl.io.Url;
+import com.netflix.msl.io.Url.Connection;
+import com.netflix.msl.msg.ConsoleFilterStreamFactory;
+import com.netflix.msl.msg.ErrorHeader;
+import com.netflix.msl.msg.MessageInputStream;
+import com.netflix.msl.msg.MessageOutputStream;
+import com.netflix.msl.msg.MslControl;
+
+/**
+ * <p>Tests of the {@link MslControl} push methods.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class PushTests extends BaseTestClass {
+    /** Local entity identity. */
+    private static final String ENTITY_IDENTITY = "push-test";
+    
+    /** Network timeout in milliseconds. */
+    private static final int TIMEOUT = 60000;
+    
+    public void init(final String path) throws URISyntaxException, IOException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+        clientConfig = new ClientConfiguration()
+            .setScheme("http")
+            .setHost(getRemoteEntityUrl())
+            .setPath(path)
+            .setNumThreads(0)
+            .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE);
+        clientConfig.commitConfiguration();
+        
+        super.setServerMslCryptoContext();
+    }
+
+    @BeforeClass
+    public void setup() throws IOException {
+        super.loadProperties();
+    }
+    
+    @Test
+    public void publicPush() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException, IOException, InterruptedException, ExecutionException {
+        // Initalize.
+        init("/public-push");
+        
+        // Prepare.
+        final MslControl ctrl = clientConfig.getMslControl();
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(false)
+            .setIsIntegrityProtected(false)
+            .clearKeyRequestData()
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Open connection.
+        final Connection conn = remoteEntity.openConnection();
+        final InputStream in = conn.getInputStream();
+        final OutputStream out = conn.getOutputStream();
+        
+        // Send message.
+        final byte[] output = new byte[16];
+        ctx.getRandom().nextBytes(output);
+        msgCtx.setBuffer(output);
+        final Future<MessageOutputStream> send = ctrl.send(ctx, msgCtx, in, out, TIMEOUT);
+        final MessageOutputStream mos = send.get();
+        Assert.assertNotNull(mos);
+        
+        // Receive message.
+        //
+        // We expect to receive the output data back.
+        final Future<MessageInputStream> receive = ctrl.receive(ctx, msgCtx, in, out, TIMEOUT);
+        final MessageInputStream mis = receive.get();
+        Assert.assertNotNull(mis);
+        Assert.assertNotNull(mis.getMessageHeader());
+        final ByteArrayOutputStream input = new ByteArrayOutputStream();
+        do {
+            final byte[] b = new byte[output.length];
+            final int count = mis.read(b);
+            if (count == -1) break;
+            input.write(b, 0, count);
+        } while (true);
+        
+        // Confirm data.
+        Assert.assertArrayEquals(output, input.toByteArray());
+    }
+    
+    @Test
+    public void secretPush() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException, IOException, InterruptedException, ExecutionException {
+        // Initalize.
+        init("/secret-push");
+        
+        // Prepare.
+        final MslControl ctrl = clientConfig.getMslControl();
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(false)
+            .setIsIntegrityProtected(false)
+            .clearKeyRequestData()
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Open connection.
+        final Connection conn = remoteEntity.openConnection();
+        final InputStream in = conn.getInputStream();
+        final OutputStream out = conn.getOutputStream();
+        
+        // Send message.
+        final byte[] output = new byte[16];
+        ctx.getRandom().nextBytes(output);
+        msgCtx.setBuffer(output);
+        final Future<MessageOutputStream> send = ctrl.send(ctx, msgCtx, in, out, TIMEOUT);
+        final MessageOutputStream mos = send.get();
+        Assert.assertNotNull(mos);
+        
+        // Receive message.
+        //
+        // We expect to receive an error indicating key exchange is required.
+        final Future<MessageInputStream> receive = ctrl.receive(ctx, msgCtx, in, out, TIMEOUT);
+        final MessageInputStream mis = receive.get();
+        Assert.assertNotNull(mis);
+        final ErrorHeader errorHeader = mis.getErrorHeader();
+        Assert.assertNotNull(errorHeader);
+        final ResponseCode responseCode = errorHeader.getErrorCode();
+        Assert.assertEquals(MslConstants.ResponseCode.KEYX_REQUIRED, responseCode);
+    }
+    
+    @Test
+    public void multiPush() throws MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException, IOException, InterruptedException, ExecutionException {
+        // Initalize.
+        init("/multi-push");
+        
+        // Prepare.
+        final MslControl ctrl = clientConfig.getMslControl();
+        ctrl.setFilterFactory(new ConsoleFilterStreamFactory());
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(false)
+            .setIsIntegrityProtected(false)
+            .clearKeyRequestData()
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Open connection.
+        final Connection conn = remoteEntity.openConnection();
+        final InputStream in = conn.getInputStream();
+        final OutputStream out = conn.getOutputStream();
+        
+        // Send message.
+        final byte[] output = new byte[16];
+        ctx.getRandom().nextBytes(output);
+        msgCtx.setBuffer(output);
+        final Future<MessageOutputStream> send = ctrl.send(ctx, msgCtx, in, out, TIMEOUT);
+        final MessageOutputStream mos = send.get();
+        Assert.assertNotNull(mos);
+        
+        // Receive message.
+        //
+        // We expect to receive the output data back three times.
+        for (int i = 0; i < 3; i++) {
+            final Future<MessageInputStream> receive = ctrl.receive(ctx, msgCtx, in, out, TIMEOUT);
+            final MessageInputStream mis = receive.get();
+            Assert.assertNotNull(mis);
+            Assert.assertNotNull(mis.getMessageHeader());
+            final ByteArrayOutputStream input = new ByteArrayOutputStream();
+            do {
+                final byte[] b = new byte[output.length];
+                final int count = mis.read(b);
+                if (count == -1) break;
+                input.write(b, 0, count);
+            } while (true);
+            
+            // Confirm data.
+            Assert.assertArrayEquals(output, input.toByteArray());
+        }
+    }
+}

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/SendTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/SendTests.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.msl.client.tests;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.netflix.msl.MslConstants;
+import com.netflix.msl.MslCryptoException;
+import com.netflix.msl.MslEncodingException;
+import com.netflix.msl.MslKeyExchangeException;
+import com.netflix.msl.client.common.BaseTestClass;
+import com.netflix.msl.client.configuration.ClientConfiguration;
+import com.netflix.msl.client.configuration.ServerConfiguration;
+import com.netflix.msl.client.configuration.msg.ClientMessageContext;
+import com.netflix.msl.client.configuration.util.ClientMslContext;
+import com.netflix.msl.entityauth.EntityAuthenticationScheme;
+import com.netflix.msl.entityauth.UnauthenticatedAuthenticationData;
+import com.netflix.msl.io.Url;
+import com.netflix.msl.keyx.KeyExchangeScheme;
+import com.netflix.msl.msg.MessageHeader;
+import com.netflix.msl.msg.MessageOutputStream;
+import com.netflix.msl.msg.MslControl;
+import com.netflix.msl.server.servlet.LogServlet;
+import com.netflix.msl.util.MslStore;
+
+/**
+ * <p>Tests of the {@link MslControl} send methods.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class SendTests extends BaseTestClass {
+    /** Local entity identity. */
+    private static final String ENTITY_IDENTITY = "send-test";
+    
+    /** Server path. */
+    private static final String PATH = "/log";
+    /** Network timeout in milliseconds. */
+    private static final int TIMEOUT = 60000;
+    
+    @BeforeClass
+    public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
+        super.loadProperties();
+        serverConfig = new ServerConfiguration()
+            .resetDefaultConfig()
+            .setHost(getRemoteEntityUrl())
+            .setPath(PATH);
+        serverConfig.commitToServer();
+        
+        clientConfig = new ClientConfiguration()
+            .setScheme("http")
+            .setHost(getRemoteEntityUrl())
+            .setPath(PATH)
+            .setNumThreads(0)
+            .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE);
+        clientConfig.commitConfiguration();
+        
+        super.setServerMslCryptoContext();
+    }
+    
+    @AfterMethod
+    public void reset() {
+        final MslStore store = clientConfig.getMslContext().getMslStore();
+        store.clearCryptoContexts();
+        store.clearUserIdTokens();
+        store.clearServiceTokens();
+    }
+    
+    /**
+     * <p>Query the server for the reported string.</p>
+     * 
+     * @return the string returned by a report query.
+     * @throws IOException if there is an error making the query.
+     */
+    public String report() throws IOException {
+        // Prepare the request.
+        final String uri = "http://" + getRemoteEntityUrl() + PATH + "?" + LogServlet.REPORT;
+        final URL url = new URL(uri);
+        final HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        conn.setRequestMethod("GET");
+        
+        // Read the response.
+        final Reader in = new InputStreamReader(conn.getInputStream());
+        final StringBuffer content = new StringBuffer();
+        final char[] buffer = new char[16384];
+        while (true) {
+            final int count = in.read(buffer);
+            if (count == -1) break;
+            content.append(buffer, 0, count);
+        }
+        return content.toString();
+    }
+    
+    @Test
+    public void send() throws IOException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException {
+        // Prepare.
+        final String message = "fire-and-forget";
+        final MslControl ctrl = clientConfig.getMslControl();
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(false)
+            .setIsIntegrityProtected(false)
+            .clearKeyRequestData()
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Send message.
+        msgCtx.setBuffer(message.getBytes(MslConstants.DEFAULT_CHARSET));
+        final Future<MessageOutputStream> future = ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT);
+        MessageOutputStream mos = null;
+        try {
+            mos = future.get();
+            Assert.assertNotNull(mos);
+            final MessageHeader messageHeader = mos.getMessageHeader();
+            Assert.assertNotNull(messageHeader);
+            Assert.assertNull(messageHeader.getMasterToken());
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            e.printStackTrace(System.err);
+            return;
+        } finally {
+            if (mos != null)
+                try { mos.close(); } catch (final IOException e) {}
+        }
+        
+        // Query receipt.
+        final String report = report();
+        Assert.assertEquals(report, message);
+    }
+    
+    @Test
+    public void handshakeSend() throws IOException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException, URISyntaxException {
+        // Prepare.
+        final String message = "handshake";
+        final MslControl ctrl = clientConfig.getMslControl();
+        final ClientMslContext ctx = clientConfig.getMslContext();
+        ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+        clientConfig
+            .setIsMessageEncrypted(true)
+            .setIsIntegrityProtected(true)
+            .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED)
+            .commitConfiguration();
+        final ClientMessageContext msgCtx = clientConfig.getMessageContext();
+        final Url remoteEntity = clientConfig.getRemoteEntity();
+        
+        // Send message.
+        msgCtx.setBuffer(message.getBytes(MslConstants.DEFAULT_CHARSET));
+        final Future<MessageOutputStream> future = ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT);
+        MessageOutputStream mos = null;
+        try {
+            mos = future.get();
+            Assert.assertNotNull(mos);
+            final MessageHeader messageHeader = mos.getMessageHeader();
+            Assert.assertNotNull(messageHeader);
+            Assert.assertNotNull(messageHeader.getMasterToken());
+        } catch (final ExecutionException | InterruptedException | CancellationException e) {
+            e.printStackTrace(System.err);
+            return;
+        } finally {
+            if (mos != null)
+                try { mos.close(); } catch (final IOException e) {}
+        }
+        
+        // Query receipt.
+        final String report = report();
+        Assert.assertEquals(report, message);
+    }
+
+    /** Server configuration. */
+    private ServerConfiguration serverConfig;
+}

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
@@ -18,6 +18,7 @@ package com.netflix.msl.client.tests;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.security.InvalidAlgorithmParameterException;
@@ -59,6 +60,7 @@ public class ServiceTokenTests extends BaseTestClass {
 
     private static final String PATH = "/test";
     private static final int TIME_OUT = 60000; // 60 Seconds
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
@@ -75,6 +77,7 @@ public class ServiceTokenTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -100,7 +103,7 @@ public class ServiceTokenTests extends BaseTestClass {
             final Connection connection = remoteEntity.openConnection();
 
             out = connection.getOutputStream();
-            in = new DelayedInputStream(connection);
+            in = connection.getInputStream();
         } catch (final IOException e) {
             if(out != null) out.close();
             if(in != null) in.close();
@@ -191,5 +194,5 @@ public class ServiceTokenTests extends BaseTestClass {
     private ServerConfiguration serverConfig;
     private final int numThreads = 0;
     private OutputStream out;
-    private DelayedInputStream in;
+    private InputStream in;
 }

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/UserAuthTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/UserAuthTests.java
@@ -15,6 +15,15 @@
  */
 package com.netflix.msl.client.tests;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ExecutionException;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
@@ -27,14 +36,6 @@ import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.keyx.KeyExchangeScheme;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.userauth.UserAuthenticationScheme;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * User: skommidi
@@ -42,9 +43,10 @@ import java.util.concurrent.ExecutionException;
  */
 public class UserAuthTests extends BaseTestClass {
     private static final int TIME_OUT = 60000; // 60 Seconds
-    private int numThreads = 0;
+    private final int numThreads = 0;
     private ServerConfiguration serverConfig;
     private static final String PATH = "/test";
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException {
@@ -64,11 +66,12 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.DIFFIE_HELLMAN);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenThe(message)
                 .shouldBe().validFirstEntityAuthNONEMsg()
@@ -84,6 +87,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.INVALID_EMAIL)
                 .setMaxUserAuthRetryCount(5)
@@ -91,7 +95,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -107,6 +111,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.INVALID_PASSWORD)
                 .setMaxUserAuthRetryCount(5)
@@ -114,7 +119,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -130,6 +135,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.EMPTY_EMAIL)
                 .setMaxUserAuthRetryCount(5)
@@ -137,7 +143,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -153,6 +159,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.EMPTY_PASSWORD)
                 .setMaxUserAuthRetryCount(5)
@@ -160,7 +167,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenTheErr(message)
                 .shouldBe().validateHdr()
@@ -176,6 +183,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.NONE)
                 .setIsPeerToPeer(false)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.DIFFIE_HELLMAN)
                 .setNullUserAuthData();
@@ -202,6 +210,7 @@ public class UserAuthTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.X509)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setInvalidUserAuthData(InvalidUserAuthScheme.INVALID_EMAIL)
                 .setKeyRequestData(KeyExchangeScheme.ASYMMETRIC_WRAPPED)
@@ -209,7 +218,7 @@ public class UserAuthTests extends BaseTestClass {
                 .resetCurrentUserAuthRetryCount();
         clientConfig.commitConfiguration();
 
-        MessageInputStream message = sendReceive(TIME_OUT);
+        final MessageInputStream message = sendReceive(TIME_OUT);
 
         thenThe(message)
                 .shouldBe().validFirstEntityAuthX509Msg()

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/UserIdTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/UserIdTokenTests.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.security.InvalidAlgorithmParameterException;
@@ -57,6 +58,7 @@ public class UserIdTokenTests extends BaseTestClass {
 
     private static final String PATH = "/test";
     private static final int TIME_OUT = 60000; // 60 Seconds
+    private static final String USER_ID = "userId";
 
     @BeforeClass
     public void setup() throws IOException, URISyntaxException, MslCryptoException, MslEncodingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, MslKeyExchangeException {
@@ -73,6 +75,7 @@ public class UserIdTokenTests extends BaseTestClass {
                 .setPath(PATH)
                 .setNumThreads(numThreads)
                 .setEntityAuthenticationScheme(EntityAuthenticationScheme.PSK)
+                .setUserId(USER_ID)
                 .setUserAuthenticationScheme(UserAuthenticationScheme.EMAIL_PASSWORD)
                 .setKeyRequestData(KeyExchangeScheme.SYMMETRIC_WRAPPED);
         clientConfig.commitConfiguration();
@@ -95,7 +98,7 @@ public class UserIdTokenTests extends BaseTestClass {
             final Connection connection = remoteEntity.openConnection();
 
             out = connection.getOutputStream();
-            in = new DelayedInputStream(connection);
+            in = connection.getInputStream();
         } catch (final IOException e) {
             if(out != null) out.close();
             if(in != null) in.close();
@@ -229,5 +232,5 @@ public class UserIdTokenTests extends BaseTestClass {
     private ServerConfiguration serverConfig;
     private final int numThreads = 0;
     private OutputStream out;
-    private DelayedInputStream in;
+    private InputStream in;
 }

--- a/integ-tests/src/test/javascript/PushTest.js
+++ b/integ-tests/src/test/javascript/PushTest.js
@@ -1,0 +1,437 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>Tests of the {@link MslControl} push methods.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+describe("PushTest", function() {
+    var MslConstants = require('msl-core/MslConstants.js');
+    var Url = require('msl-core/io/Url.js');
+    var Xhr = require('msl-core/io/Xhr.js');
+    var KeyExchangeScheme = require('msl-core/keyx/KeyExchangeScheme.js');
+    var MessageOutputStream = require('msl-core/msg/MessageOutputStream.js');
+    var MslControl = require('msl-core/msg/MslControl.js');
+    var UserAuthenticationScheme = require('msl-core/userauth/UserAuthenticationScheme.js');
+    var MslContext = require('msl-core/util/MslContext.js');
+    var MslStore = require('msl-core/util/MslStore.js');
+    var EntityAuthenticationScheme = require('msl-core/entityauth/EntityAuthenticationScheme.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var UnauthenticatedAuthenticationData = require('msl-core/entityauth/UnauthenticatedAuthenticationData.js');
+    var TextEncoding = require('msl-core/util/TextEncoding.js');
+    
+    var MockMslContext = require('msl-tests/util/MockMslContext.js');
+    var MslTestConstants = require('msl-tests/MslTestConstants.js');
+    var MockMessageContext = require('msl-tests/msg/MockMessageContext.js');
+    var NodeHttpLocation = require('msl-tests/io/NodeHttpLocation.js');
+    var MockRsaAuthenticationFactory = require('msl-tests/entityauth/MockRsaAuthenticationFactory.js');
+    
+    var http = require('http');
+    var url = require('url');
+
+    /**
+     * A message context that will write data without requiring encryption or
+     * integrity protection.
+     */
+    var WriteMessageContext = MockMessageContext.extend({
+        /**
+         * Create a new write message context.
+         * 
+         * @param {MockMslContext} ctx MSL context.
+         * @param {?string} userId user ID. May be {@code null}.
+         * @param {?UserAuthenticationScheme} scheme user authentication scheme. May be {@code null}.
+         * @param {Uint8Array} data the data to write.
+         * @param {result: function(WriteMessageContext), error: function(Error)}
+         *        callback the callback that will receive the new message context
+         *        or any thrown exceptions.
+         * @throws NoSuchAlgorithmException if a key generation algorithm is not
+         *         found.
+         * @throws InvalidAlgorithmParameterException if key generation parameters
+         *         are invalid.
+         * @throws CryptoException if there is an error creating a key.
+         */
+        init: function init(ctx, userId, scheme, data, callback) {
+            var self = this;
+
+            init.base.call(this, ctx, userId, scheme, {
+                result: function(msgCtx) {
+                    AsyncExecutor(callback, function() {
+                        // The properties.
+                        var props = {
+                            _data: { value: data, writable: false, enumerable: false, configurable: false },
+                        };
+                        Object.defineProperties(this, props);
+                        return this;
+                    }, self);
+                },
+                error: callback.error
+            });
+        },
+        
+        /** @inheritDoc */
+        write: function write(output, timeout, callback) {
+            AsyncExecutor(callback, function() {
+                output.write(this._data, 0, this._data.length, timeout, callback);
+            }, this);
+        },
+    });
+    
+    /**
+     * Create a new write message context.
+     * 
+     * @param {MockMslContext} ctx MSL context.
+     * @param {string} userId user ID.
+     * @param {UserAuthenticationScheme} scheme user authentication scheme.
+     * @param {Uint8Array} data the data to write.
+     * @param {result: function(WriteMessageContext), error: function(Error)}
+     *        callback the callback that will receive the new message context
+     *        or any thrown exceptions.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws CryptoException if there is an error creating a key.
+     */
+    WriteMessageContext.create = function WriteMessageContext$create(ctx, userId, scheme, data, callback) {
+        new WriteMessageContext(ctx, userId, scheme, data, callback);
+    };
+    
+    /** Local entity identity. */
+    var ENTITY_IDENTITY = "push-test";
+
+    /** Server host. */
+    var HOST = "localhost:8080";
+    /** Server base path. */
+    var BASE_PATH = "/msl-integ-tests";
+    /** Network timeout in milliseconds. */
+    var TIMEOUT = 2000;
+
+    /** MSL control. */
+    var ctrl = new MslControl();
+    /** MSL context. */
+    var ctx;
+    
+    var initialized = false;
+    beforeEach(function() {
+        if (initialized) return;
+        
+        runs(function() {
+            MockMslContext.create(EntityAuthenticationScheme.NONE, false, {
+                result: function(x) { ctx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ctx; }, "ctx", MslTestConstants.TIMEOUT_CTX);
+        
+        runs(function() {
+            ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+            initialized = true;
+        });
+    });
+    
+    afterEach(function() {
+        var store = ctx.getMslStore();
+        store.clearCryptoContexts();
+        store.clearUserIdTokens();
+        store.clearServiceTokens();
+    });
+    
+    it("public push", function() {
+        // Prepare.
+        var uri = "http://" + HOST + BASE_PATH + "/public-push";
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        var output = new Uint8Array(16);
+        ctx.getRandom().nextBytes(output);
+
+        // Open connection.
+        var conn = remoteEntity.openConnection();
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, output, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Do not require encryption or integrity protection.
+            msgCtx.setEncrypted(false);
+            msgCtx.setIntegrityProtected(false);
+
+            // Clear the key request data.
+            msgCtx.setKeyRequestData([]);
+            
+            ctrl.send(ctx, msgCtx, conn.input, conn.output, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Wait until ready.
+        var ready;
+        runs(function() {
+            mos.isReady({
+                result: function(x) { ready = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "ready", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Receive message.
+        var mis;
+        runs(function() {
+            ctrl.receive(ctx, msgCtx, conn.input, conn.output, TIMEOUT, {
+                result: function(x) { mis = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mis; }, "mis", TIMEOUT);
+        
+        // We expect to receive the output data back.
+        var input;
+        runs(function() {
+            expect(mis.getMessageHeader()).not.toBeNull();
+            mis.read(output.length, TIMEOUT, {
+                result: function(x) { input = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return input; }, "input", TIMEOUT);
+
+        runs(function() {
+            // Confirm data.
+            expect(input).toEqual(output); 
+        });
+    });
+    
+    it("secret push", function() {
+        // Prepare.
+        var uri = "http://" + HOST + BASE_PATH + "/secret-push";
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        var output = new Uint8Array(16);
+        ctx.getRandom().nextBytes(output);
+        
+        // Open connection.
+        var conn = remoteEntity.openConnection();
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, output, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Do not require encryption or integrity protection.
+            msgCtx.setEncrypted(false);
+            msgCtx.setIntegrityProtected(false);
+
+            // Clear the key request data.
+            msgCtx.setKeyRequestData([]);
+            
+            ctrl.send(ctx, msgCtx, conn.input, conn.output, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Wait until ready.
+        var ready;
+        runs(function() {
+            mos.isReady({
+                result: function(x) { ready = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "ready", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Receive message.
+        var mis;
+        runs(function() {
+            ctrl.receive(ctx, msgCtx, conn.input, conn.output, TIMEOUT, {
+                result: function(x) { mis = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mis; }, "mis", TIMEOUT);
+        
+        // We expect to receive an error indicating key exchange is required.
+        runs(function() {
+            var errorHeader = mis.getErrorHeader();
+            expect(errorHeader).not.toBeNull();
+            var responseCode = errorHeader.errorCode;
+            expect(responseCode).toEqual(MslConstants.ResponseCode.KEYX_REQUIRED);
+        });
+    });
+
+    it("multi push", function() {
+        // Prepare.
+        var uri = "http://" + HOST + BASE_PATH + "/multi-push";
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        var output = new Uint8Array(16);
+        ctx.getRandom().nextBytes(output);
+        
+        // Open connection.
+        var conn = remoteEntity.openConnection();
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, output, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Do not require encryption or integrity protection.
+            msgCtx.setEncrypted(false);
+            msgCtx.setIntegrityProtected(false);
+
+            // Clear the key request data.
+            msgCtx.setKeyRequestData([]);
+            
+            ctrl.send(ctx, msgCtx, conn.input, conn.output, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Wait until ready.
+        var ready;
+        runs(function() {
+            mos.isReady({
+                result: function(x) { ready = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "ready", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Receive message.
+        //
+        // We expect to receive the output data back three times.
+        var count = 3;
+        runs(function() {
+            function recv() {
+                // Exit if done.
+                if (count == 0)
+                    return;
+                
+                // Receive message.
+                ctrl.receive(ctx, msgCtx, conn.input, conn.output, TIMEOUT, {
+                    result: function(mis) {
+                        expect(mis.getMessageHeader()).not.toBeNull();
+                        mis.read(output.length, TIMEOUT, {
+                            result: function(input) {
+                                // Confirm data.
+                                expect(input).toEqual(output);
+                                --count;
+                                mis.close(TIMEOUT, {
+                                    result: function(success) {
+                                        recv();
+                                    },
+                                    timeout: function() { expect(function() { throw new MslIoException("Close timed out."); }).not.toThrow(); },
+                                    error: function(e) { expect(function() { throw e.requestCause; throw e; }).not.toThrow(); }
+                                });
+                            },
+                            timeout: function() { expect(function() { throw new MslIoException("Read timed out."); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e.requestCause; throw e; }).not.toThrow(); }
+                        });
+                    },
+                    timeout: function() { expect(function() { throw new MslIoException("Receive timed out."); }).not.toThrow(); },
+                    error: function(e) { expect(function() { throw e.requestCause; throw e; }).not.toThrow(); }
+                });
+            }
+            recv();
+        });
+        waitsFor(function() { return count == 0; }, "recv", 3 * TIMEOUT);
+    });
+});

--- a/integ-tests/src/test/javascript/SendTest.js
+++ b/integ-tests/src/test/javascript/SendTest.js
@@ -1,0 +1,365 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>Tests of the {@link MslControl} send methods.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+describe("SendTest", function() {
+    var MslConstants = require('msl-core/MslConstants.js');
+    var Url = require('msl-core/io/Url.js');
+    var Xhr = require('msl-core/io/Xhr.js');
+    var KeyExchangeScheme = require('msl-core/keyx/KeyExchangeScheme.js');
+    var MessageOutputStream = require('msl-core/msg/MessageOutputStream.js');
+    var MslControl = require('msl-core/msg/MslControl.js');
+    var UserAuthenticationScheme = require('msl-core/userauth/UserAuthenticationScheme.js');
+    var MslContext = require('msl-core/util/MslContext.js');
+    var MslStore = require('msl-core/util/MslStore.js');
+    var EntityAuthenticationScheme = require('msl-core/entityauth/EntityAuthenticationScheme.js');
+    var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
+    var AsymmetricWrappedExchange = require('msl-core/keyx/AsymmetricWrappedExchange.js');
+    var UnauthenticatedAuthenticationData = require('msl-core/entityauth/UnauthenticatedAuthenticationData.js');
+    var TextEncoding = require('msl-core/util/TextEncoding.js');
+    
+    var MockMslContext = require('msl-tests/util/MockMslContext.js');
+    var MslTestConstants = require('msl-tests/MslTestConstants.js');
+    var MockMessageContext = require('msl-tests/msg/MockMessageContext.js');
+    var NodeHttpLocation = require('msl-tests/io/NodeHttpLocation.js');
+    var MockRsaAuthenticationFactory = require('msl-tests/entityauth/MockRsaAuthenticationFactory.js');
+    
+    var http = require('http');
+    var url = require('url');
+    
+    /**
+     * A message context that will write data without requiring encryption or
+     * integrity protection.
+     */
+    var WriteMessageContext = MockMessageContext.extend({
+        /**
+         * Create a new write message context.
+         * 
+         * @param {MockMslContext} ctx MSL context.
+         * @param {?string} userId user ID. May be {@code null}.
+         * @param {?UserAuthenticationScheme} scheme user authentication scheme. May be {@code null}.
+         * @param {Uint8Array} data the data to write.
+         * @param {result: function(WriteMessageContext), error: function(Error)}
+         *        callback the callback that will receive the new message context
+         *        or any thrown exceptions.
+         * @throws NoSuchAlgorithmException if a key generation algorithm is not
+         *         found.
+         * @throws InvalidAlgorithmParameterException if key generation parameters
+         *         are invalid.
+         * @throws CryptoException if there is an error creating a key.
+         */
+        init: function init(ctx, userId, scheme, data, callback) {
+            var self = this;
+
+            init.base.call(this, ctx, userId, scheme, {
+                result: function(msgCtx) {
+                    AsyncExecutor(callback, function() {
+                        // The properties.
+                        var props = {
+                            _data: { value: data, writable: false, enumerable: false, configurable: false },
+                        };
+                        Object.defineProperties(this, props);
+                        return this;
+                    }, self);
+                },
+                error: callback.error
+            });
+        },
+        
+        /** @inheritDoc */
+        write: function write(output, timeout, callback) {
+            AsyncExecutor(callback, function() {
+                output.write(this._data, 0, this._data.length, timeout, callback);
+            }, this);
+        },
+    });
+    
+    /**
+     * Create a new write message context.
+     * 
+     * @param {MockMslContext} ctx MSL context.
+     * @param {string} userId user ID.
+     * @param {UserAuthenticationScheme} scheme user authentication scheme.
+     * @param {Uint8Array} data the data to write.
+     * @param {result: function(WriteMessageContext), error: function(Error)}
+     *        callback the callback that will receive the new message context
+     *        or any thrown exceptions.
+     * @throws NoSuchAlgorithmException if a key generation algorithm is not
+     *         found.
+     * @throws InvalidAlgorithmParameterException if key generation parameters
+     *         are invalid.
+     * @throws CryptoException if there is an error creating a key.
+     */
+    WriteMessageContext.create = function WriteMessageContext$create(ctx, userId, scheme, data, callback) {
+        new WriteMessageContext(ctx, userId, scheme, data, callback);
+    };
+    
+    /** Local entity identity. */
+    var ENTITY_IDENTITY = "send-test";
+
+    /** Server host. */
+    var HOST = "localhost:8080";
+    /** Server path. */
+    var PATH = "/msl-integ-tests/log";
+    /** Report query string. */
+    var REPORT = "report";
+    /** Network timeout in milliseconds. */
+    var TIMEOUT = 2000;
+
+    /** MSL control. */
+    var ctrl = new MslControl();
+    /** MSL context. */
+    var ctx;
+    
+    var initialized = false;
+    beforeEach(function() {
+        if (initialized) return;
+        
+        runs(function() {
+            MockMslContext.create(EntityAuthenticationScheme.NONE, false, {
+                result: function(x) { ctx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ctx; }, "ctx", MslTestConstants.TIMEOUT_CTX);
+        
+        runs(function() {
+            ctx.setEntityAuthenticationData(new UnauthenticatedAuthenticationData(ENTITY_IDENTITY));
+            initialized = true;
+        });
+    });
+    
+    afterEach(function() {
+        var store = ctx.getMslStore();
+        store.clearCryptoContexts();
+        store.clearUserIdTokens();
+        store.clearServiceTokens();
+    });
+
+    /**
+     * <p>Query the server for the reported string.</p>
+     * 
+     * @param {{result: function(string), timeout: function(), error: function(Error)}}
+     *        callback the callback that will receive the response body, be
+     *        notified of timeout, or any thrown errors.
+     * @return the string returned by a report query.
+     */
+    function report(callback) {
+        // Prepare the request.
+        var options = url.parse("http://" + HOST + PATH + "?" + REPORT);
+        options.timeout = TIMEOUT;
+
+        // Buffer and then deliver the accumulated data. Only
+        // allow the callback to be triggered once, in case
+        // events keep arriving after the data has been
+        // delivered or after an error has occurred.
+        var buffer = "";
+        var delivered = false;
+        var request = http.get(options, function(message) {
+            message.on('data', function(chunk) {
+                try {
+                    if (typeof chunk === 'string')
+                        buffer += chunk;
+                    else
+                        buffer += chunk.toString();
+                } catch (e) {
+                    if (!delivered)
+                        callback.error(e);
+                    delivered = true;
+                }
+            });
+            message.on('end', function() {
+                if (!delivered)
+                    callback.result(buffer);
+                delivered = true;
+            });
+        });
+        request.on('timeout', function() {
+            if (!delivered)
+                callback.timeout();
+            delivered = true;
+        });
+        request.on('error', function(e) {
+            if (!delivered)
+                callback.error(e);
+            delivered = true;
+        });
+    }
+    
+    it("send", function() {
+        // Prepare.
+        var message = "handshake";
+        var messageBytes = TextEncoding.getBytes(message);
+        var uri = "http://" + HOST + PATH;
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, messageBytes, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Do not require encryption or integrity protection.
+            msgCtx.setEncrypted(false);
+            msgCtx.setIntegrityProtected(false);
+
+            // Clear the key request data.
+            msgCtx.setKeyRequestData([]);
+            
+            ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Wait until ready.
+        var ready;
+        runs(function() {
+            mos.isReady({
+                result: function(x) { ready = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "ready", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Query receipt.
+        var result;
+        runs(function() {
+            report({
+                result: function(x) { result = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return result; }, "report", TIMEOUT);
+        
+        runs(function() {
+            expect(result).toEqual(message);
+        });
+    });
+    
+    it("send handshake", function() {
+        // Prepare.
+        var message = "handshake";
+        var messageBytes = TextEncoding.getBytes(message);
+        var uri = "http://" + HOST + PATH;
+        var location = new NodeHttpLocation(uri);
+        var remoteEntity = new Url(location, TIMEOUT);
+        
+        // Create message context.
+        var msgCtx;
+        runs(function() {
+            WriteMessageContext.create(ctx, null, null, messageBytes, {
+                result: function(x) { msgCtx = x; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return msgCtx; }, "msgCtx", MslTestConstants.TIMEOUT);
+        
+        // Send message.
+        var mos;
+        runs(function() {
+            // Require encryption and integrity protection.
+            msgCtx.setEncrypted(true);
+            msgCtx.setIntegrityProtected(true);
+            
+            // Set the key request data.
+            var publicKey = MockRsaAuthenticationFactory.RSA_PUBKEY;
+            var privateKey = MockRsaAuthenticationFactory.RSA_PRIVKEY;
+            var requestData = new AsymmetricWrappedExchange.RequestData("rsaKeypairId", AsymmetricWrappedExchange.Mechanism.JWE_RSA, publicKey, privateKey);
+            var keyxRequestData = [ requestData ];
+            msgCtx.setKeyRequestData(keyxRequestData);
+            
+            ctrl.send(ctx, msgCtx, remoteEntity, TIMEOUT, {
+                result: function(x) { mos = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return mos; }, "mos", TIMEOUT);
+        
+        // Wait until ready.
+        var ready;
+        runs(function() {
+            mos.isReady({
+                result: function(x) { ready = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "ready", TIMEOUT);
+        
+        // Close message output stream.
+        var closed;
+        runs(function() {
+            var messageHeader = mos.getMessageHeader();
+            expect(messageHeader).not.toBeNull();
+            expect(messageHeader.masterToken).not.toBeNull();
+            
+            mos.close(TIMEOUT, {
+                result: function(x) { closed = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return closed; }, "closed", TIMEOUT);
+        
+        // Query receipt.
+        var result;
+        runs(function() {
+            report({
+                result: function(x) { result = x; },
+                timeout: function() { expect(function() { throw new MslIoException("Request timed out."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return result; }, "report", TIMEOUT);
+        
+        runs(function() {
+            expect(result).toEqual(message);
+        });
+    });
+});

--- a/integ-tests/src/test/javascript/package.json
+++ b/integ-tests/src/test/javascript/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "msl-integ-tests-exec",
+  "version": "1.1220.0",
+  "description": "Message Security Layer Integration Tests Execution",
+  "keywords": [
+    "msl",
+    "message security layer",
+    "netflix"
+  ],
+  "homepage": "https://github.com/Netflix/msl",
+  "bugs": {
+    "url": "https://github.com/Netflix/msl/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com:Netflix/msl.git"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs -n1 jasmine-node --matchall --forceexit --captureExceptions ./node_modules/msl-tests/lib/jasmine/msl-helpers.js",
+    "lint": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs jshint --verbose"
+  },
+  "dependencies": {
+    "msl-core": "^1.1220.0",
+    "msl-tests": "^1.1220.0"
+  },
+  "devDependencies": {
+    "ec-key": "0.0.2",
+    "elliptic": "^6.4.0",
+    "jshint": "^2.9.5",
+    "jsrsasign": "^7.2.2",
+    "ursa": "^0.9.4"
+  }
+}

--- a/tests/.cproject
+++ b/tests/.cproject
@@ -30,7 +30,7 @@
 								</option>
 								<option id="macosx.cpp.link.option.paths.1082102412" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/lib"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/lib"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1103657322" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
@@ -51,7 +51,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1527158162" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -133,7 +133,7 @@
 								</option>
 								<option id="macosx.cpp.link.option.paths.1230734662" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/lib"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/lib"/>
 								</option>
 								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.715455431" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
@@ -154,7 +154,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.349980858" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -245,7 +245,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1845721471" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
@@ -337,7 +337,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/include"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2n/include"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1520566858" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>

--- a/tests/src/main/cpp/msg/MockMessageContext.cpp
+++ b/tests/src/main/cpp/msg/MockMessageContext.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ MockMessageContext::MockMessageContext(shared_ptr<MslContext> ctx, const string&
 {
 	if (UserAuthenticationScheme::EMAIL_PASSWORD == scheme) {
 		userAuthData_ = make_shared<EmailPasswordAuthenticationData>(MockEmailPasswordAuthenticationFactory::EMAIL, MockEmailPasswordAuthenticationFactory::PASSWORD);
-	} else {
+	} else if (UserAuthenticationScheme::INVALID != scheme) {
 		throw IllegalArgumentException("Unsupported authentication type: " + scheme.name());
 	}
 

--- a/tests/src/main/cpp/msg/MockMessageContext.h
+++ b/tests/src/main/cpp/msg/MockMessageContext.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,8 +60,9 @@ public:
      * The message will not be encrypted or non-replayable.
      *
      * @param ctx MSL context.
-     * @param userId user ID.
-     * @param scheme user authentication scheme.
+     * @param userId user ID. May be the empty string.
+     * @param scheme user authentication scheme. May be
+     *        {@code userauth::UserAuthenticationScheme::INVALID}.
      * @throws NoSuchAlgorithmException if a key generation algorithm is not
      *         found.
      * @throws InvalidAlgorithmParameterException if key generation parameters

--- a/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
+++ b/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
@@ -92,8 +92,8 @@ public class MockMessageContext implements MessageContext {
      * The message will not be encrypted or non-replayable.
      * 
      * @param ctx MSL context.
-     * @param userId user ID.
-     * @param scheme user authentication scheme.
+     * @param userId user ID. May be {@code null}.
+     * @param scheme user authentication scheme. May be {@code null}.
      * @throws NoSuchAlgorithmException if a key generation algorithm is not
      *         found.
      * @throws InvalidAlgorithmParameterException if key generation parameters
@@ -113,7 +113,7 @@ public class MockMessageContext implements MessageContext {
         
         if (UserAuthenticationScheme.EMAIL_PASSWORD.equals(scheme)) {
             userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL, MockEmailPasswordAuthenticationFactory.PASSWORD);
-        } else {
+        } else if (scheme != null) {
             throw new IllegalArgumentException("Unsupported authentication type: " + scheme.name());
         }
         

--- a/tests/src/main/javascript/io/NodeHttpLocation.js
+++ b/tests/src/main/javascript/io/NodeHttpLocation.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>An HTTP location that is implemented using Node HTTP.</p>
+ * 
+ * @author Wesley Miaw <wmiaw@netlix.com>
+ */
+(function(require, module) {
+    "use strict";
+    
+    var Url = require('msl-core/io/Url.js');
+    var MslIoException = require('msl-core/MslIoException.js');
+    var InterruptibleExecutor = require('msl-core/util/InterruptibleExecutor.js');
+    
+    var http = require('http');
+    var url = require('url');
+    
+    /**
+     * Interface for getting an HTTP response given a request.
+     */
+    var NodeHttpLocation = module.exports = Url.IHttpLocation.extend({
+        /**
+         * <p>Create a new Node HTTP location pointing at the specified
+         * endpoint.</p>
+         * 
+         * @param {string} endpoint the URL to send the request to.
+         */
+        init: function(endpoint) {
+            // Set properties.
+            var props = {
+                _endpoint: { value: endpoint, writable: false, enumerable: false, configurable: false },
+            };
+            Object.defineProperties(this, props);
+        },
+        
+        /**
+         * Given a request, gets the response.
+         *
+         * @param {{body: string}} request
+         * @param {number} timeout request response timeout in milliseconds or -1 for no timeout.
+         * @param {{result: function({=body: string, =content: Uint8Array}), timeout: function(), error: function(Error)}}
+         *        callback the callback that will receive the response data as
+         *        a string or bytes, be notified of timeout or any thrown
+         *        exceptions.
+         * @returns {{abort:Function})
+         */
+        /** @inheritDoc */
+        getResponse: function(request, timeout, callback) {
+            var self = this;
+            
+            // Declare the http.ClientRequest reference here to provide the
+            // abort function.
+            var req;
+        
+            InterruptibleExecutor(callback, function() {
+                // Convert the endpoint to HTTP request options.
+                var options = url.parse(this._endpoint);
+                options.method = 'POST';
+                options.timeout = timeout;
+                
+                // Issue the request asynchronously.
+                //
+                // Only allow the callback to be triggered once, in case events
+                // keep arriving after the data has been delivered or after an
+                // error has occurred.
+                var delivered = false;
+                req = http.request(options);
+                req.on('response', function(message) {
+                    InterruptibleExecutor(callback, function() {
+                        // Check for an error.
+                        if (message.statusCode < 200 || message.statusCode >= 300)
+                            throw new MslIoException("HTTP " + message.statusCode + ": " + message.statusMessage);
+                        
+                        // Buffer and then deliver the accumulated data. 
+                        var buffers = [];
+                        message.on('data', function(chunk) {
+                            try {
+                                if (typeof chunk === 'string') {
+                                    var buffer = Buffer.from(chunk);
+                                    buffers.push(buffer);
+                                } else {
+                                    buffers.push(chunk);
+                                }
+                            } catch (e) {
+                                if (!delivered)
+                                    callback.error(e);
+                                delivered = true;
+                            }
+                        });
+                        message.on('end', function() {
+                            try {
+                                if (!delivered) {
+                                    var data = Buffer.concat(buffers);
+                                    var content = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+                                    callback.result({ content: content });
+                                }
+                                delivered = true;
+                            } catch (e) {
+                                if (!delivered)
+                                    callback.error(e);
+                                delivered = true;
+                            }
+                        });
+                    }, self);
+                });
+                req.on('timeout', function() {
+                    if (!delivered)
+                        callback.timeout();
+                    delivered = true;
+                });
+                req.on('error', function(e) {
+                    if (!delivered)
+                        callback.error(e);
+                    delivered = true;
+                });
+                var postdata = Buffer.from(request.body.buffer);
+                req.end(postdata);
+            }, self);
+
+            // Return the abort function.
+            return { abort: function() { req.abort(); } };
+        },
+    });
+})(require, (typeof module !== 'undefined') ? module : mkmodule('NodeHttpLocation'));

--- a/tests/src/main/javascript/msg/MockMessageContext.js
+++ b/tests/src/main/javascript/msg/MockMessageContext.js
@@ -82,8 +82,8 @@
 	     * The message will not be encrypted or non-replayable.
 	     * 
 	     * @param {MockMslContext} ctx MSL context.
-	     * @param {string} userId user ID.
-	     * @param {UserAuthenticationScheme} scheme user authentication scheme.
+	     * @param {?string} userId user ID. May be {@code null}.
+	     * @param {?UserAuthenticationScheme} scheme user authentication scheme. May be {@code null}.
 	     * @param {result: function(MockMessageContext), error: function(Error)}
 	     *        callback the callback that will receive the new message context
 	     *        or any thrown exceptions.
@@ -121,10 +121,10 @@
 	        
 	        function createContext(tokenEncryptionKeyA, tokenHmacKeyA, tokenEncryptionKeyB, tokenHmacKeyB) {
 	            AsyncExecutor(callback, function() {
-	                var userAuthData;
+	                var userAuthData = null;
 	                if (UserAuthenticationScheme.EMAIL_PASSWORD == scheme) {
 	                    userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL, MockEmailPasswordAuthenticationFactory.PASSWORD);
-	                } else {
+	                } else if (scheme) {
 	                    throw new MslInternalException("Unsupported authentication type: " + scheme.name);
 	                }
 
@@ -332,7 +332,7 @@
      * The message will not be encrypted or non-replayable.
      * 
      * @param {MockMslContext} ctx MSL context.
-     * @param {string} userId user ID.
+     * @param {?string} userId user ID. May be {@code null}.
      * @param {UserAuthenticationScheme} scheme user authentication scheme.
      * @param {result: function(MockMessageContext), error: function(Error)}
      *        callback the callback that will receive the new message context

--- a/tests/src/main/javascript/tokens/MockTokenFactory.js
+++ b/tests/src/main/javascript/tokens/MockTokenFactory.js
@@ -148,6 +148,15 @@
                 MasterToken.create(ctx, renewalWindow, expiration, sequenceNumber, serialNumber, issuerData, identity, encryptionKey, hmacKey, callback);
             }, this);
         },
+        
+        /** @inheritDoc */
+        isMasterTokenRenewable: function(ctx, masterToken, callback) {
+            AsyncExecutor(callback, function() {
+                if (!masterToken.isDecrypted())
+                    return MslError.MASTERTOKEN_UNTRUSTED;
+                return null;
+            }, this);
+        },
 
         /** @inheritDoc */
         renewMasterToken: function(ctx, masterToken, encryptionKey, hmacKey, issuerData, callback) {

--- a/tests/src/main/javascript/userauth/MockUserIdTokenAuthenticationFactory.js
+++ b/tests/src/main/javascript/userauth/MockUserIdTokenAuthenticationFactory.js
@@ -27,6 +27,7 @@
     var MslInternalException = require('msl-core/MslInternalException.js');
     var UserIdTokenAuthenticationData = require('msl-core/userauth/UserIdTokenAuthenticationData.js');
     var MslUserAuthException = require('msl-core/MslUserAuthException.js');
+    var MslException = require('msl-core/MslException.js');
     var MslError = require('msl-core/MslError.js');
     var AsyncExecutor = require('msl-core/util/AsyncExecutor.js');
     

--- a/tests/src/test/cpp/io/BufferedInputStreamTest.cpp
+++ b/tests/src/test/cpp/io/BufferedInputStreamTest.cpp
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <io/BufferedInputStream.h>
+#include <crypto/Random.h>
+#include <io/ByteArrayInputStream.h>
+#include <IOException.h>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+using namespace std;
+using namespace netflix::msl::crypto;
+
+namespace netflix {
+namespace msl {
+typedef std::vector<uint8_t> ByteArray;
+namespace io {
+
+namespace {
+
+/**
+ * A byte array input stream that counts the number of bytes read.
+ */
+class CountingByteArrayInputStream : public ByteArrayInputStream
+{
+public:
+    virtual ~CountingByteArrayInputStream() {}
+
+    /**
+     * Create a new byte array input stream from the provided data.
+     *
+     * @param data the data.
+     */
+    CountingByteArrayInputStream(std::shared_ptr<ByteArray> data)
+        : ByteArrayInputStream(data)
+    {}
+
+    /**
+     * Create a new byte array input stream from the provided string.
+     *
+     * @param s the string.
+     */
+    CountingByteArrayInputStream(const std::string& s)
+        : ByteArrayInputStream(s)
+    {}
+
+    /** @inheritDoc */
+    virtual int read(ByteArray& out, int timeout = -1)
+    {
+        int count = ByteArrayInputStream::read(out, 0, out.size(), timeout);
+        if (count != -1)
+            readcount_ += count;
+        return count;
+    }
+
+    /** @inheritDoc */
+    virtual int read(ByteArray& out, size_t offset, size_t len, int timeout = -1)
+    {
+        int count = ByteArrayInputStream::read(out, offset, len, timeout);
+        if (count != -1)
+            readcount_ += count;
+        return count;
+    }
+
+    /**
+     * @return the number of bytes that have been read, including bytes that
+     *         may have been read multiple times due to mark() and reset().
+     */
+    virtual size_t readCount() { return readcount_; }
+
+    /**
+     * @return the number of additional bytes that can be read before reaching
+     *         end of stream.
+     */
+    virtual size_t available() { return static_cast<size_t>(data_->size()) - currentPosition_; }
+
+protected:
+    /** Number of bytes read. */
+    size_t readcount_ = 0;
+};
+} // namespace anonymous
+
+class BufferedInputStreamTest : public ::testing::Test
+{
+public:
+    virtual ~BufferedInputStreamTest() {}
+
+    BufferedInputStreamTest()
+    {
+        data = make_shared<ByteArray>(123456);
+        Random r;
+        r.nextBytes(*data);
+        cbais = make_shared<CountingByteArrayInputStream>(data);
+    }
+
+protected:
+    shared_ptr<ByteArray> data;
+    shared_ptr<CountingByteArrayInputStream> cbais;
+};
+
+TEST_F(BufferedInputStreamTest, ReadDefault)
+{
+    const size_t readSize = BufferedInputStream::DEFAULT_READ_SIZE;
+    BufferedInputStream bis(cbais);
+
+    // Nothing should be read yet.
+    EXPECT_EQ(static_cast<size_t>(0), cbais->readCount());
+    EXPECT_EQ(data->size(), cbais->available());
+
+    // Reading one byte should result in a larger number of bytes equal to the
+    // default read size being read.
+    ByteArray one(1);
+    int oneCount = bis.read(one);
+    EXPECT_EQ(one.size(), static_cast<size_t>(oneCount));
+    EXPECT_TRUE(equal(data->begin(), data->begin() + oneCount, one.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Reading more bytes up to the default read size should not result in
+    // additional reads against the backing source.
+    ByteArray remaining(readSize - one.size());
+    int remainingCount = bis.read(remaining);
+    EXPECT_EQ(remaining.size(), static_cast<size_t>(remainingCount));
+    EXPECT_TRUE(equal(data->begin() + oneCount, data->begin() + remainingCount, remaining.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Reading more than the default read size should read at least that much
+    // from the backing source.
+    ByteArray large(readSize + 1);
+    int largeCount = bis.read(large);
+    EXPECT_EQ(large.size(), static_cast<size_t>(largeCount));
+    EXPECT_TRUE(equal(data->begin() + oneCount + remainingCount, data->begin() + oneCount + remainingCount + largeCount, large.begin()));
+    EXPECT_LE(large.size(), cbais->readCount());
+    EXPECT_EQ(data->size() - cbais->readCount(), cbais->available());
+}
+
+TEST_F(BufferedInputStreamTest, ReadSmall)
+{
+    const size_t readSize = 32;
+    BufferedInputStream bis(cbais, readSize);
+
+    // Nothing should be read yet.
+    EXPECT_EQ(static_cast<size_t>(0), cbais->readCount());
+    EXPECT_EQ(data->size(), cbais->available());
+
+    // Reading one byte should result in a larger number of bytes equal to the
+    // default read size being read.
+    ByteArray one(1);
+    int oneCount = bis.read(one);
+    EXPECT_EQ(one.size(), static_cast<size_t>(oneCount));
+    EXPECT_TRUE(equal(data->begin(), data->begin() + oneCount, one.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Reading more bytes up to the default read size should not result in
+    // additional reads against the backing source.
+    ByteArray remaining(readSize - one.size());
+    int remainingCount = bis.read(remaining);
+    EXPECT_EQ(remaining.size(), static_cast<size_t>(remainingCount));
+    EXPECT_TRUE(equal(data->begin() + oneCount, data->begin() + remainingCount, remaining.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Reading more than the default read size should read at least that much
+    // from the backing source.
+    ByteArray large(readSize + 1);
+    int largeCount = bis.read(large);
+    EXPECT_EQ(large.size(), static_cast<size_t>(largeCount));
+    EXPECT_TRUE(equal(data->begin() + oneCount + remainingCount, data->begin() + oneCount + remainingCount + largeCount, large.begin()));
+    EXPECT_LE(large.size(), cbais->readCount());
+    EXPECT_EQ(data->size() - cbais->readCount(), cbais->available());
+}
+
+TEST_F(BufferedInputStreamTest, MarkReset)
+{
+    const size_t readSize = 32;
+    BufferedInputStream bis(cbais, readSize);
+
+    // Mark at zero and read one byte.
+    bis.mark(2 * readSize);
+    ByteArray one(1);
+    int oneCount = bis.read(one);
+    EXPECT_EQ(one.size(), static_cast<size_t>(oneCount));
+    EXPECT_TRUE(equal(data->begin(), data->begin() + oneCount, one.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Reset and read a chunk worth of bytes. No bytes should have been read
+    // off the backing source.
+    bis.reset();
+    ByteArray chunk(readSize);
+    int chunkCount = bis.read(chunk);
+    EXPECT_EQ(chunk.size(), static_cast<size_t>(chunkCount));
+    EXPECT_TRUE(equal(data->begin(), data->begin() + chunkCount, chunk.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Read another byte. Another chunk's worth of bytes should have been read
+    // off the backing source.
+    chunkCount = bis.read(chunk);
+    EXPECT_EQ(chunk.size(), static_cast<size_t>(chunkCount));
+    EXPECT_TRUE(equal(data->begin() + chunkCount, data->begin() + 2 * chunkCount, chunk.begin()));
+    EXPECT_EQ(2 * readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - 2 * readSize, cbais->available());
+}
+
+TEST_F(BufferedInputStreamTest, InvalidateMark)
+{
+    const size_t readSize = 32;
+    BufferedInputStream bis(cbais, readSize);
+
+    // Mark with a read limit half the chunk size.
+    bis.mark(readSize / 2);
+
+    // Read a chunk. This should invalidate the mark.
+    ByteArray chunk(readSize);
+    int chunkCount = bis.read(chunk);
+    EXPECT_EQ(chunk.size(), static_cast<size_t>(chunkCount));
+    EXPECT_TRUE(equal(data->begin(), data->begin() + chunkCount, chunk.begin()));
+    EXPECT_EQ(readSize, cbais->readCount());
+    EXPECT_EQ(data->size() - readSize, cbais->available());
+
+    // Reset should throw an exception.
+    EXPECT_THROW(bis.reset(), IOException);
+}
+
+}}} // namespace netflix::msl::io

--- a/tests/src/test/cpp/io/DefaultMslEncoderFactorySuite.cpp
+++ b/tests/src/test/cpp/io/DefaultMslEncoderFactorySuite.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,11 +221,13 @@ TEST_F(DefaultMslEncoderFactoryTest, CreateTokenizer)
 
     // explicit format
     shared_ptr<MslTokenizer> mt = mef->createTokenizer(is);
+    mt->close();
 
     // deduced format
     shared_ptr<InputStream> bad = make_shared<ByteArrayInputStream>("afkhadgfk");
     EXPECT_THROW(mef->createTokenizer(bad), MslEncoderException);
     mt = mef->createTokenizer(is);
+    mt->close();
 }
 
 } /* namespace io */

--- a/tests/src/test/cpp/msg/MessageOutputStreamTest.cpp
+++ b/tests/src/test/cpp/msg/MessageOutputStreamTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,6 +203,9 @@ TEST_F(MessageOutputStreamTest, messageHeader)
 	vector<shared_ptr<PayloadChunk>> payloads = mos->getPayloads();
 	EXPECT_EQ(static_cast<size_t>(1), payloads.size());
 	EXPECT_EQ(*payload, *payloads[0]);
+
+	// Close tokenizer.
+	tokenizer->close();
 }
 
 TEST_F(MessageOutputStreamTest, errorHeader)
@@ -230,6 +233,9 @@ TEST_F(MessageOutputStreamTest, errorHeader)
 	// Verify cached payloads.
 	vector<shared_ptr<PayloadChunk>> payloads = mos->getPayloads();
 	EXPECT_EQ(static_cast<size_t>(0), payloads.size());
+
+    // Close tokenizer.
+    tokenizer->close();
 }
 
 TEST_F(MessageOutputStreamTest, writeOffsets)
@@ -279,6 +285,9 @@ TEST_F(MessageOutputStreamTest, writeOffsets)
 	vector<shared_ptr<PayloadChunk>> payloads = mos->getPayloads();
 	EXPECT_EQ(static_cast<size_t>(1), payloads.size());
 	EXPECT_EQ(*payload, *payloads[0]);
+
+    // Close tokenizer.
+    tokenizer->close();
 }
 
 TEST_F(MessageOutputStreamTest, writeBytes)
@@ -325,6 +334,9 @@ TEST_F(MessageOutputStreamTest, writeBytes)
 	vector<shared_ptr<PayloadChunk>> payloads = mos->getPayloads();
 	EXPECT_EQ(static_cast<size_t>(1), payloads.size());
 	EXPECT_EQ(*payload, *payloads[0]);
+
+    // Close tokenizer.
+    tokenizer->close();
 }
 
 TEST_F(MessageOutputStreamTest, compressed)
@@ -366,6 +378,7 @@ TEST_F(MessageOutputStreamTest, compressed)
 	vector<shared_ptr<MslObject>> payloadMos;
 	while (tokenizer->more(TIMEOUT))
 		payloadMos.push_back(tokenizer->nextObject(TIMEOUT));
+	tokenizer->close();
 
 	// Verify the number and contents of the payloads.
 	shared_ptr<MessageHeader> messageHeader = dynamic_pointer_cast<MessageHeader>(Header::parseHeader(ctx, headerMo, cryptoContexts));
@@ -422,6 +435,7 @@ TEST_F(MessageOutputStreamTest, flush)
 	vector<shared_ptr<MslObject>> payloadMos;
 	while (tokenizer->more(TIMEOUT))
 		payloadMos.push_back(tokenizer->nextObject(TIMEOUT));
+	tokenizer->close();
 
 	// Verify the number and contents of the payloads.
 	shared_ptr<MessageHeader> messageHeader = dynamic_pointer_cast<MessageHeader>(Header::parseHeader(ctx, headerMo, cryptoContexts));
@@ -564,6 +578,9 @@ TEST_F(MessageOutputStreamTest, multiClose)
 	vector<shared_ptr<PayloadChunk>> payloads = mos->getPayloads();
 	EXPECT_EQ(static_cast<size_t>(1), payloads.size());
 	EXPECT_EQ(*payload, *payloads[0]);
+
+    // Close tokenizer.
+    tokenizer->close();
 }
 
 TEST_F(MessageOutputStreamTest, stressWrite)
@@ -593,6 +610,7 @@ TEST_F(MessageOutputStreamTest, stressWrite)
 	vector<shared_ptr<MslObject>> payloadMos;
 	while (tokenizer->more(TIMEOUT))
 		payloadMos.push_back(tokenizer->nextObject(TIMEOUT));
+	tokenizer->close();
 
 	shared_ptr<Header> header = Header::parseHeader(ctx, headerMo, cryptoContexts);
 	EXPECT_TRUE(instanceof<MessageHeader>(header));

--- a/tests/src/test/java/com/netflix/msl/io/DefaultMslEncoderFactorySuite.java
+++ b/tests/src/test/java/com/netflix/msl/io/DefaultMslEncoderFactorySuite.java
@@ -532,6 +532,9 @@ public class DefaultMslEncoderFactorySuite {
                 final byte[] data = payload.getData();
                 assertArrayEquals(expectedPayload, data);
             }
+            
+            // Close tokenizer.
+            tokenizer.close();
         }
     }
     

--- a/tests/src/test/java/com/netflix/msl/msg/MessageOutputStreamTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageOutputStreamTest.java
@@ -177,6 +177,9 @@ public class MessageOutputStreamTest {
         final List<PayloadChunk> payloads = mos.getPayloads();
         assertEquals(1, payloads.size());
         assertEquals(payload, payloads.get(0));
+        
+        // Close the tokenizer.
+        tokenizer.close();
     }
     
     @Test
@@ -204,6 +207,9 @@ public class MessageOutputStreamTest {
         // Verify cached payloads.
         final List<PayloadChunk> payloads = mos.getPayloads();
         assertEquals(0, payloads.size());
+        
+        // Close the tokenizer.
+        tokenizer.close();
     }
     
     @Test
@@ -253,6 +259,9 @@ public class MessageOutputStreamTest {
         final List<PayloadChunk> payloads = mos.getPayloads();
         assertEquals(1, payloads.size());
         assertEquals(payload, payloads.get(0));
+        
+        // Close the tokenizer.
+        tokenizer.close();
     }
     
     @Test
@@ -299,6 +308,9 @@ public class MessageOutputStreamTest {
         final List<PayloadChunk> payloads = mos.getPayloads();
         assertEquals(1, payloads.size());
         assertEquals(payload, payloads.get(0));
+        
+        // Close the tokenizer.
+        tokenizer.close();
     }
     
     @Test
@@ -344,6 +356,9 @@ public class MessageOutputStreamTest {
         final List<PayloadChunk> payloads = mos.getPayloads();
         assertEquals(1, payloads.size());
         assertEquals(payload, payloads.get(0));
+        
+        // Close the tokenizer.
+        tokenizer.close();
     }
     
     @Test
@@ -385,6 +400,7 @@ public class MessageOutputStreamTest {
         final List<MslObject> payloadMos = new ArrayList<MslObject>();
         while (tokenizer.more(TIMEOUT))
             payloadMos.add(tokenizer.nextObject(TIMEOUT));
+        tokenizer.close();
         
         // Verify the number and contents of the payloads.
         final MessageHeader messageHeader = (MessageHeader)Header.parseHeader(ctx, headerMo, cryptoContexts);
@@ -440,6 +456,7 @@ public class MessageOutputStreamTest {
         final List<MslObject> payloadMos = new ArrayList<MslObject>();
         while (tokenizer.more(TIMEOUT))
             payloadMos.add(tokenizer.nextObject(TIMEOUT));
+        tokenizer.close();
         
         // Verify the number and contents of the payloads.
         final MessageHeader messageHeader = (MessageHeader)Header.parseHeader(ctx, headerMo, cryptoContexts);
@@ -578,6 +595,9 @@ public class MessageOutputStreamTest {
         final List<PayloadChunk> payloads = mos.getPayloads();
         assertEquals(1, payloads.size());
         assertEquals(payload, payloads.get(0));
+        
+        // Close the tokenizer.
+        tokenizer.close();
     }
     
     @Test
@@ -607,6 +627,7 @@ public class MessageOutputStreamTest {
         final List<MslObject> payloadMos = new ArrayList<MslObject>();
         while (tokenizer.more(TIMEOUT))
             payloadMos.add(tokenizer.nextObject(TIMEOUT));
+        tokenizer.close();
         
         final Header header = Header.parseHeader(ctx, headerMo, cryptoContexts);
         assertTrue(header instanceof MessageHeader);

--- a/tests/src/test/javascript/io/DefaultMslEncoderFactorySuite.js
+++ b/tests/src/test/javascript/io/DefaultMslEncoderFactorySuite.js
@@ -55,19 +55,19 @@ describe("DefaultMslEncoderFactory", function() {
     var initialized = false;
     beforeEach(function() {
         if (!initialized) {
-        	runs(function() {
-	            MockMslContext.create(EntityAuthenticationScheme.PSK, false, {
-	            	result: function(x) { ctx = x; },
-	            	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-	            });
-        	});
-        	waitsFor(function() { return ctx; }, "ctx", MslTestConstants.TIMEOUT_CTX);
-        	
-        	runs(function() {
-        		encoder = new DefaultMslEncoderFactory();
-        		random = ctx.getRandom();
-        		initialized = true;
-        	});
+            runs(function() {
+                MockMslContext.create(EntityAuthenticationScheme.PSK, false, {
+                    result: function(x) { ctx = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
+            });
+            waitsFor(function() { return ctx; }, "ctx", MslTestConstants.TIMEOUT_CTX);
+            
+            runs(function() {
+                encoder = new DefaultMslEncoderFactory();
+                random = ctx.getRandom();
+                initialized = true;
+            });
         }
     });
 
@@ -88,7 +88,7 @@ describe("DefaultMslEncoderFactory", function() {
             case 4:
                 return "MslArray";
             case 5:
-            	return "MslObject";
+                return "MslObject";
             case 6:
                 return "long";
             default:
@@ -401,96 +401,96 @@ describe("DefaultMslEncoderFactory", function() {
         var jsonMessageData, unsupportedMessageData;
         
         var initialized = false;
-    	beforeEach(function() {
-    		if (!initialized) {
-    	    	// JSON encoder format.
-    	        var jsonCaps = new MessageCapabilities(null, null, [ MslEncoderFormat.JSON ]);
+        beforeEach(function() {
+            if (!initialized) {
+                // JSON encoder format.
+                var jsonCaps = new MessageCapabilities(null, null, [ MslEncoderFormat.JSON ]);
 
-    	        // Create MSL message.
-    	        var destination = new ByteArrayOutputStream();
-    	        var peerData = new MessageHeader.HeaderPeerData(null, null, null);
-	    		var entityAuthData;
-	    		runs(function() {
-	        		ctx.getEntityAuthenticationData(null, {
-	        			result: function(x) { entityAuthData = x; },
-		            	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-	        		});
-	        	});
-	        	waitsFor(function() { return entityAuthData; }, "entityAuthData", MslTestConstants.TIMEOUT);
-	        	
-	        	var jsonMessageHeader;
-	        	runs(function() {
-	        		// Create JSON version.
-	                var jsonHeaderData = new MessageHeader.HeaderData(null, 1, null, false, false, jsonCaps, null, null, null, null, null);
-	                MessageHeader.create(ctx, entityAuthData, null, jsonHeaderData, peerData, {
-	                	result: function(x) { jsonMessageHeader = x; },
-	                	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-	                });
-	        	});
-	        	waitsFor(function() { return jsonMessageHeader; }, "jsonMessageHeader", MslTestConstants.TIMEOUT);
-	        	
-	        	var jsonMos;
-	        	runs(function() {
-		        	var jsonCryptoContext = jsonMessageHeader.cryptoContext;
-		            MessageOutputStream.create(ctx, destination, jsonMessageHeader, jsonCryptoContext, null, -1, {
-		            	result: function(x) { jsonMos = x; },
-		                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-		            	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-		            });
-	        	});
-	        	waitsFor(function() { return jsonMos; }, "jsonMos", MslTestConstants.TIMEOUT);
-	        	
-	        	runs(function() {
-	        		function writePayload(index) {
-	        			if (index >= PAYLOADS.length) {
-	        				closeMos();
-	        				return;
-	        			}
-	        			
-	        			var payload = PAYLOADS[index];
-	        			jsonMos.write(payload, 0, payload.length, -1, {
-	        				result: function(count) {
-	        					jsonMos.flush(-1, {
-	        						result: function(flushed) {
-	        							writePayload(index + 1);
-	        						},
-	    			                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-	    			                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-	        					});
-	        				},
-	        				timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-	        				error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-	        			});
-	        		}
-	        		writePayload(0);
-	        		
-	        		function closeMos() {
-	        			jsonMos.close(-1, {
-	        				result: function(closed) {
-	        	                // JSON.
-	        	                jsonMessageData = destination.toByteArray();
-	        	                
-	        	                // Unsupported.
-	        	                unsupportedMessageData = Arrays.copyOf(jsonMessageData, 0, jsonMessageData.length);
-	        	                unsupportedMessageData[0] = '1';
-	        	                
-	        	                initialized = true;
-	        				},
-	        				timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-	        				error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-	        			});
-	        		}
-	        	});
-	        	waitsFor(function() { return initialized; }, "initialized", MslTestConstants.TIMEOUT);
-    		}
-    	});
-    	
-    	parameterize("Parameterized", function data() {
-    		return [
-    		    [ MslEncoderFormat.JSON, null ],
-    		    [ null, new MslEncoderException() ],
-    		];
-    	},
+                // Create MSL message.
+                var destination = new ByteArrayOutputStream();
+                var peerData = new MessageHeader.HeaderPeerData(null, null, null);
+                var entityAuthData;
+                runs(function() {
+                    ctx.getEntityAuthenticationData(null, {
+                        result: function(x) { entityAuthData = x; },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                    });
+                });
+                waitsFor(function() { return entityAuthData; }, "entityAuthData", MslTestConstants.TIMEOUT);
+                
+                var jsonMessageHeader;
+                runs(function() {
+                    // Create JSON version.
+                    var jsonHeaderData = new MessageHeader.HeaderData(null, 1, null, false, false, jsonCaps, null, null, null, null, null);
+                    MessageHeader.create(ctx, entityAuthData, null, jsonHeaderData, peerData, {
+                        result: function(x) { jsonMessageHeader = x; },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                    });
+                });
+                waitsFor(function() { return jsonMessageHeader; }, "jsonMessageHeader", MslTestConstants.TIMEOUT);
+                
+                var jsonMos;
+                runs(function() {
+                    var jsonCryptoContext = jsonMessageHeader.cryptoContext;
+                    MessageOutputStream.create(ctx, destination, jsonMessageHeader, jsonCryptoContext, null, -1, {
+                        result: function(x) { jsonMos = x; },
+                        timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                    });
+                });
+                waitsFor(function() { return jsonMos; }, "jsonMos", MslTestConstants.TIMEOUT);
+                
+                runs(function() {
+                    function writePayload(index) {
+                        if (index >= PAYLOADS.length) {
+                            closeMos();
+                            return;
+                        }
+                        
+                        var payload = PAYLOADS[index];
+                        jsonMos.write(payload, 0, payload.length, -1, {
+                            result: function(count) {
+                                jsonMos.flush(-1, {
+                                    result: function(flushed) {
+                                        writePayload(index + 1);
+                                    },
+                                    timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                                });
+                            },
+                            timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                        });
+                    }
+                    writePayload(0);
+                    
+                    function closeMos() {
+                        jsonMos.close(-1, {
+                            result: function(closed) {
+                                // JSON.
+                                jsonMessageData = destination.toByteArray();
+                                
+                                // Unsupported.
+                                unsupportedMessageData = Arrays.copyOf(jsonMessageData, 0, jsonMessageData.length);
+                                unsupportedMessageData[0] = '1';
+                                
+                                initialized = true;
+                            },
+                            timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                        });
+                    }
+                });
+                waitsFor(function() { return initialized; }, "initialized", MslTestConstants.TIMEOUT);
+            }
+        });
+        
+        parameterize("Parameterized", function data() {
+            return [
+                [ MslEncoderFormat.JSON, null ],
+                [ null, new MslEncoderException() ],
+            ];
+        },
         /**
          * Create a new MSL encoder factory test instance with the specified
          * encoding format and provided message data.
@@ -498,165 +498,176 @@ describe("DefaultMslEncoderFactory", function() {
          * @param {?MslEncoderFormat} format MSL encoding format.
          * @param {?Error} exceptionClass expected exception class.
          */
-    	function(format, expectedException) {
-    		/**
-    		 * Encoded message.
-    		 * @type {Uint8Array}
-    		 */
-    		var messageData;
-    		beforeEach(function() {
-    			if (format == MslEncoderFormat.JSON)
-    				messageData = jsonMessageData;
-    			else if (format == null)
-    				messageData = unsupportedMessageData;
-    			else
-    				throw new Error("Unidentified message format.");
-    		});
-    		
-	        it("detect tokenizer", function() {
-	            var tokenizer, exception;
-	            runs(function() {
-		            // Create the tokenizer.
-		            var source = new ByteArrayInputStream(messageData);
-		            encoder.createTokenizer(source, null, -1, {
-		            	result: function(x) { tokenizer = x; },
-		                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-		            	error: function(e) { exception = e; },
-		            });
-	            });
-	            waitsFor(function() { return tokenizer || exception; }, "tokenizer or exception", MslTestConstants.TIMEOUT);
-	
-	            runs(function() {
-	            	if (expectedException) {
-	            		expect(function() { throw exception; }).toThrow(expectedException);
-	            		return;
-	            	} else if (exception) {
-	            	    expect(function() { throw exception; }).not.toThrow();
-	            	    return;
-	            	}
-	
-	            	var objects;
-	            	runs(function() {
-	            		expect(tokenizer).not.toBeNull();
-		            
-			            // Pull data off the tokenizer.
-			            var tokens = [];
-			            function f() {
-			            	tokenizer.more(-1, {
-			            		result: function(success) {
-			            			if (!success) {
-			            				objects = tokens;
-			            				return;
-			            			}
-			            			tokenizer.nextObject(-1, {
-			            				result: function(object) {
-			            					expect(object).not.toBeNull();
-			            					tokens.push(object);
-			            					f();
-			            				},
-			            				timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-			    	            		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			            			});
-			            		},
-				                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-			            		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			            	});
-			            }
-			            f();
-		            });
-		            waitsFor(function() { return objects; }, "objects", MslTestConstants.TIMEOUT);
-			        
-		            var nextObject;
-			        runs(function() {
-			            // +1 for the header, +1 for the EOM payload.
-			            expect(objects.length).toEqual(PAYLOADS.length + 2);
-			            tokenizer.nextObject(-1, {
-			            	result: function(object) { nextObject = object; },
-			                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
-			            	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			            });
-			        });
-			        waitsFor(function() { return nextObject !== undefined; }, "nextObject", MslTestConstants.TIMEOUT);
-			        
-			        var header;
-			        runs(function() {
-			            expect(nextObject).toBeNull();
-			            
-			            // Pull message header.
-			            var headerO = objects[0];
-			            var cryptoContexts = [];
-			            Header.parseHeader(ctx, headerO, cryptoContexts, {
-			            	result: function(x) { header = x; },
-			            	error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			            });
-			        });
-			        waitsFor(function() { return header; }, "header", MslTestConstants.TIMEOUT);
-			        
-			        var verified = false;
-			        runs(function() {
-			            expect(header instanceof MessageHeader).toBeTruthy();
-			            var messageHeader = header;
-			            
-			            // Verify payloads.
-			            var payloadCryptoContext = messageHeader.cryptoContext;
-			            function f(i) {
-			            	if (i >= PAYLOADS.length) {
-			            		verified = true;
-			            		return;
-			            	}
-			            	var expectedPayload = PAYLOADS[i];
-			            	var payloadMo = objects[i + 1];
-			            	PayloadChunk.parse(ctx, payloadMo, payloadCryptoContext, {
-			            		result: function(payload) {
-			            			var data = payload.data;
-			    	                expect(data).toEqual(expectedPayload);
-			    	                f(i+1);
-			            		},
-			            		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			            	});
-			            }
-			            f(0);
-			        });
-			        waitsFor(function() { return verified; }, "verified", MslTestConstants.TIMEOUT);
-	            });
-	        });
-    	});
+        function(format, expectedException) {
+            /**
+             * Encoded message.
+             * @type {Uint8Array}
+             */
+            var messageData;
+            beforeEach(function() {
+                if (format == MslEncoderFormat.JSON)
+                    messageData = jsonMessageData;
+                else if (format == null)
+                    messageData = unsupportedMessageData;
+                else
+                    throw new Error("Unidentified message format.");
+            });
+            
+            it("detect tokenizer", function() {
+                var tokenizer, exception;
+                runs(function() {
+                    // Create the tokenizer.
+                    var source = new ByteArrayInputStream(messageData);
+                    encoder.createTokenizer(source, null, -1, {
+                        result: function(x) { tokenizer = x; },
+                        timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                        error: function(e) { exception = e; },
+                    });
+                });
+                waitsFor(function() { return tokenizer || exception; }, "tokenizer or exception", MslTestConstants.TIMEOUT);
+    
+                runs(function() {
+                    if (expectedException) {
+                        expect(function() { throw exception; }).toThrow(expectedException);
+                        return;
+                    } else if (exception) {
+                        expect(function() { throw exception; }).not.toThrow();
+                        return;
+                    }
+    
+                    var objects;
+                    runs(function() {
+                        expect(tokenizer).not.toBeNull();
+                    
+                        // Pull data off the tokenizer.
+                        var tokens = [];
+                        function f() {
+                            tokenizer.more(-1, {
+                                result: function(success) {
+                                    if (!success) {
+                                        objects = tokens;
+                                        return;
+                                    }
+                                    tokenizer.nextObject(-1, {
+                                        result: function(object) {
+                                            expect(object).not.toBeNull();
+                                            tokens.push(object);
+                                            f();
+                                        },
+                                        timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                                    });
+                                },
+                                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                            });
+                        }
+                        f();
+                    });
+                    waitsFor(function() { return objects; }, "objects", MslTestConstants.TIMEOUT);
+                    
+                    var nextObject;
+                    runs(function() {
+                        // +1 for the header, +1 for the EOM payload.
+                        expect(objects.length).toEqual(PAYLOADS.length + 2);
+                        tokenizer.nextObject(-1, {
+                            result: function(object) { nextObject = object; },
+                            timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                        });
+                    });
+                    waitsFor(function() { return nextObject !== undefined; }, "nextObject", MslTestConstants.TIMEOUT);
+                    
+                    var header;
+                    runs(function() {
+                        expect(nextObject).toBeNull();
+                        
+                        // Pull message header.
+                        var headerO = objects[0];
+                        var cryptoContexts = [];
+                        Header.parseHeader(ctx, headerO, cryptoContexts, {
+                            result: function(x) { header = x; },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                        });
+                    });
+                    waitsFor(function() { return header; }, "header", MslTestConstants.TIMEOUT);
+                    
+                    var verified = false;
+                    runs(function() {
+                        expect(header instanceof MessageHeader).toBeTruthy();
+                        var messageHeader = header;
+                        
+                        // Verify payloads.
+                        var payloadCryptoContext = messageHeader.cryptoContext;
+                        function f(i) {
+                            if (i >= PAYLOADS.length) {
+                                verified = true;
+                                return;
+                            }
+                            var expectedPayload = PAYLOADS[i];
+                            var payloadMo = objects[i + 1];
+                            PayloadChunk.parse(ctx, payloadMo, payloadCryptoContext, {
+                                result: function(payload) {
+                                    var data = payload.data;
+                                    expect(data).toEqual(expectedPayload);
+                                    f(i+1);
+                                },
+                                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                            });
+                        }
+                        f(0);
+                    });
+                    waitsFor(function() { return verified; }, "verified", MslTestConstants.TIMEOUT);
+                    
+                    var closed = false;
+                    runs(function() {
+                        // Close tokenizer.
+                        tokenizer.close(-1, {
+                            result: function(x) { closed = x; },
+                            timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                            error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                        });
+                    });
+                    waitsFor(function() { return closed; }, "closed", MslTestConstants.TIMEOUT);
+                });
+            });
+        });
     });
     
     /** Container unit tests. */
     describe("Container", function() {
-    	/**
-    	 * Return the 32-bit integer value of a number.
-    	 * 
-    	 * @param {number} n the number.
-    	 * @returns the integer value of the number.
-    	 */
-    	function intValue(n) {
-    		// The << 0 operation converts to a signed 32-bit integer.
-    		return n << 0;
-    	}
-    	
-    	/**
-    	 * Return the long value of a number.
-    	 * 
-    	 * @param {number} n the number.
-    	 * @returns the long value of the number.
-    	 */
-    	function longValue(n) {
-    		// The parseInt function converts to the integer value.
-    		return parseInt(n);
-    	}
-    	
-    	/**
-    	 * Return the floating point value of a number.
-    	 * 
-    	 * @param {number} n the number.
-    	 * @returns the floating point value of the number.
-    	 */
-    	function doubleValue(n) {
-    		return n;
-    	}
-    	
+        /**
+         * Return the 32-bit integer value of a number.
+         * 
+         * @param {number} n the number.
+         * @returns the integer value of the number.
+         */
+        function intValue(n) {
+            // The << 0 operation converts to a signed 32-bit integer.
+            return n << 0;
+        }
+        
+        /**
+         * Return the long value of a number.
+         * 
+         * @param {number} n the number.
+         * @returns the long value of the number.
+         */
+        function longValue(n) {
+            // The parseInt function converts to the integer value.
+            return parseInt(n);
+        }
+        
+        /**
+         * Return the floating point value of a number.
+         * 
+         * @param {number} n the number.
+         * @returns the floating point value of the number.
+         */
+        function doubleValue(n) {
+            return n;
+        }
+        
         /**
          * Compare two numbers. The expected value is the original value. The
          * candidate value is the value that was the original was converted
@@ -955,17 +966,17 @@ describe("DefaultMslEncoderFactory", function() {
     
     /** Accessor unit tests. */
     parameterize("Accessor", function() {
-    	return [
-    	   [ null ],
-    	   [ "boolean" ],
-    	   [ "Uint8Array" ],
-    	   [ "double" ],
-    	   [ "integer" ],
-    	   [ "MslArray" ],
-    	   [ "MslObject" ],
-    	   [ "long" ],
-    	   [ "string" ],
-    	];
+        return [
+           [ null ],
+           [ "boolean" ],
+           [ "Uint8Array" ],
+           [ "double" ],
+           [ "integer" ],
+           [ "MslArray" ],
+           [ "MslObject" ],
+           [ "long" ],
+           [ "string" ],
+        ];
     },
     /**
      * @param {?string} accessor type.
@@ -973,8 +984,8 @@ describe("DefaultMslEncoderFactory", function() {
     function(type) {
         it("object get with null key", function() {
             var f = function() {
-	            var mo = encoder.createObject();
-	            getTypedField(null, type, mo);
+                var mo = encoder.createObject();
+                getTypedField(null, type, mo);
             };
             expect(f).toThrow(new TypeError());
         });
@@ -989,25 +1000,25 @@ describe("DefaultMslEncoderFactory", function() {
         
         it("object opt with null key", function() {
             var f = function() {
-            	var mo = encoder.createObject();
-            	optTypedField(null, type, mo);
+                var mo = encoder.createObject();
+                optTypedField(null, type, mo);
             };
             expect(f).toThrow(new TypeError());
         });
         
         it("object opt default with null key", function() {
             var f = function() {
-            	var mo = encoder.createObject();
-            	optDefaultTypedField(null, type, mo);
+                var mo = encoder.createObject();
+                optDefaultTypedField(null, type, mo);
             };
             expect(f).toThrow(new TypeError());
         });
         
         it("object put with key null", function() {
             var f = function() {
-	            var mo = encoder.createObject();
-	            var value = createTypedValue(type);
-	            putTypedField(null, type, value, mo);
+                var mo = encoder.createObject();
+                var value = createTypedValue(type);
+                putTypedField(null, type, value, mo);
             };
             expect(f).toThrow(new TypeError());
         });
@@ -1026,67 +1037,67 @@ describe("DefaultMslEncoderFactory", function() {
         
         it("array get with negative index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            getTypedElement(-1, type, ma);
+                var ma = encoder.createArray();
+                getTypedElement(-1, type, ma);
             };
             expect(f).toThrow(new RangeError());
         });
         
         it("array get null element", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            putTypedElement(0, type, null, ma);
-	            expect(ma.size()).toEqual(1);
-	            getTypedElement(0, type, ma);
+                var ma = encoder.createArray();
+                putTypedElement(0, type, null, ma);
+                expect(ma.size()).toEqual(1);
+                getTypedElement(0, type, ma);
             };
             expect(f).toThrow(new MslEncoderException());
         });
         
         it("array opt with negative index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            optTypedElement(-1, type, ma);
+                var ma = encoder.createArray();
+                optTypedElement(-1, type, ma);
             };
             expect(f).toThrow(new RangeError());
         });
         
         it("array opt default with negative index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            optDefaultTypedElement(-1, type, ma);
+                var ma = encoder.createArray();
+                optDefaultTypedElement(-1, type, ma);
             };
             expect(f).toThrow(new RangeError());
         });
 
         it("array get with too big index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            getTypedElement(ma.size(), type, ma);
+                var ma = encoder.createArray();
+                getTypedElement(ma.size(), type, ma);
             };
             expect(f).toThrow(new RangeError());
         });
         
         it("array opt with too big index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            optTypedElement(ma.size(), type, ma);
+                var ma = encoder.createArray();
+                optTypedElement(ma.size(), type, ma);
             };
             expect(f).toThrow(new RangeError());
         });
         
         it("array opt default with too big index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            optDefaultTypedElement(ma.size(), type, ma);
+                var ma = encoder.createArray();
+                optDefaultTypedElement(ma.size(), type, ma);
             };
             expect(f).toThrow(new RangeError());
         });
         
         it("array put with negative index", function() {
             var f = function() {
-	            var ma = encoder.createArray();
-	            var value = createTypedValue(type);
-	            putTypedElement(-2, type, value, ma);
+                var ma = encoder.createArray();
+                var value = createTypedValue(type);
+                putTypedElement(-2, type, value, ma);
             };
             expect(f).toThrow(new RangeError());
         });
@@ -1094,12 +1105,12 @@ describe("DefaultMslEncoderFactory", function() {
     
     /** Encoding unit tests. */
     parameterize("Encoding", function() {
-    	return [
-    	    [ MslEncoderFormat.JSON ],
-    	];
+        return [
+            [ MslEncoderFormat.JSON ],
+        ];
     },
     function(format) {
-    	it("encode and parse object", function() {
+        it("encode and parse object", function() {
             // Generate some values.
             var map = {};
             for (var i = 0; i < MAX_NUM_ELEMENTS; ++i) {
@@ -1116,19 +1127,19 @@ describe("DefaultMslEncoderFactory", function() {
             var encode;
             runs(function() {
                 // Encode.
-            	encoder.encodeObject(mo, format, {
-            		result: function(x) { encode = x; },
-            		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-            	});
+                encoder.encodeObject(mo, format, {
+                    result: function(x) { encode = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
             });
             waitsFor(function() { return encode; }, "encode", MslTestConstants.TIMEOUT);
             
             runs(function() {
-	            expect(encode).not.toBeNull();
-	            
-	            // Parse.
-	            var parsedMo = encoder.parseObject(encode);
-	            expect(MslEncoderUtils.equalObjects(mo, parsedMo)).toBeTruthy();
+                expect(encode).not.toBeNull();
+                
+                // Parse.
+                var parsedMo = encoder.parseObject(encode);
+                expect(MslEncoderUtils.equalObjects(mo, parsedMo)).toBeTruthy();
             });
         });
 
@@ -1149,25 +1160,25 @@ describe("DefaultMslEncoderFactory", function() {
             var encode;
             runs(function() {
                 // Encode.
-            	encoder.encodeObject(mo, format, {
-            		result: function(x) { encode = x; },
-            		error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-            	});
+                encoder.encodeObject(mo, format, {
+                    result: function(x) { encode = x; },
+                    error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+                });
             });
             waitsFor(function() { return encode; }, "encode", MslTestConstants.TIMEOUT);
             
             runs(function() {
-	            expect(encode).not.toBeNull();
-	
-	            // Corrupt the encode.
-	            encode[0] = 0;
-	            encode[encode.length - 1] = 'x';
-	            
-	            // Parse.
-	            var f = function() {
-	            	encoder.parseObject(encode);
-	            };
-	            expect(f).toThrow(new MslEncoderException());
+                expect(encode).not.toBeNull();
+    
+                // Corrupt the encode.
+                encode[0] = 0;
+                encode[encode.length - 1] = 'x';
+                
+                // Parse.
+                var f = function() {
+                    encoder.parseObject(encode);
+                };
+                expect(f).toThrow(new MslEncoderException());
             });
         });
     });

--- a/tests/src/test/javascript/keyx/DiffieHellmanExchangeSuite.js
+++ b/tests/src/test/javascript/keyx/DiffieHellmanExchangeSuite.js
@@ -461,7 +461,7 @@ xdescribe("DiffieHellmanExchangeSuite", function() {
         			error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         		});
         	});
-        	waitsFor(function() { masterToken; }, "master token not received", MslTestConstants.TIMEOUT);
+        	waitsFor(function() { return masterToken; }, "master token not received", MslTestConstants.TIMEOUT);
         	
         	runs(function() {
         		expect(masterToken).toEqual(MASTER_TOKEN);

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -7869,7 +7869,7 @@ describe("MessageHeader", function() {
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
 		});
-		waitsFor(function() { peerServiceTokensA && peerServiceTokensB; }, "service tokens not received", MslTestConstants.TIMEOUT);
+		waitsFor(function() { return peerServiceTokensA && peerServiceTokensB; }, "service tokens not received", MslTestConstants.TIMEOUT);
 
         var builder;
         runs(function() {

--- a/tests/src/test/javascript/msg/MessageInputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageInputStreamTest.js
@@ -1224,6 +1224,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var buffer;
         runs(function() {
             mis.read(MAX_READ_LEN, TIMEOUT, {
@@ -1299,6 +1309,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var buffer;
         runs(function() {
@@ -1604,6 +1624,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var closed;
         runs(function() {
             mis.close(TIMEOUT, {
@@ -1657,6 +1687,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var closed;
         runs(function() {
             mis.close(TIMEOUT, {
@@ -1709,6 +1749,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var closed;
         runs(function() {
@@ -1905,6 +1955,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var closed;
         runs(function() {
@@ -2824,6 +2884,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var buffer;
         runs(function() {
             mis.read(MAX_READ_LEN, TIMEOUT, {
@@ -2909,6 +2979,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var buffer;
         runs(function() {
@@ -2999,6 +3079,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         // Read everything. Each bad payload should throw an exception.
         var buffer = new ByteArrayOutputStream();
@@ -3110,6 +3200,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         // Read everything. Each bad payload should throw an exception.
         var buffer = new ByteArrayOutputStream();
         var caughtExceptions = 0;
@@ -3206,6 +3306,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var firstdata;
         runs(function() {
             mis.read(-1, TIMEOUT, {
@@ -3282,6 +3392,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var appdata, buffer;
         var firstRead = 0;
@@ -3493,6 +3613,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var appdata, buffer;
         var firstRead = 0;
         var beginningOffset, beginningLength;
@@ -3645,6 +3775,16 @@ describe("MessageInputStream", function() {
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
 
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
+
         var appdata, buffer;
         var oneRead = 0;
         runs(function() {
@@ -3790,6 +3930,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var appdata, buffer;
         var beginningRead = 0;
@@ -3987,6 +4137,16 @@ describe("MessageInputStream", function() {
             });
         });
         waitsFor(function() { return mis; }, "mis", MslTestConstants.TIMEOUT);
+
+        var ready = false;
+        runs(function() {
+            mis.isReady({
+                result: function(r) { ready = r; },
+                timeout: function() { expect(function() { throw new Error("Timed out waiting for mis ready."); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return ready; }, "mis ready", MslTestConstants.TIMEOUT);
 
         var buffer;
         runs(function() {

--- a/tests/src/test/javascript/msg/MessageOutputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageOutputStreamTest.js
@@ -260,6 +260,7 @@ describe("MessageOutputStream", function() {
         });
         waitsFor(function() { return more3 !== undefined; }, "more3", MslTestConstants.TIMEOUT);
 
+        var tokenizerClosed = false;
         runs(function() {
             expect(more3).toBeFalsy();
 
@@ -267,7 +268,15 @@ describe("MessageOutputStream", function() {
             var payloads = mos.getPayloads();
             expect(payloads.length).toEqual(1);
             expect(payloads[0]).toEqual(payload);
+
+            // Close tokenizer.
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
         });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
     });
 
     it("error header stream", function() {
@@ -357,13 +366,22 @@ describe("MessageOutputStream", function() {
         });
         waitsFor(function() { return more2 !== undefined; }, "more2", MslTestConstants.TIMEOUT);
 
+        var tokenizerClosed = false;
         runs(function() {
             expect(more2).toBeFalsy();
 
             // Verify cached payloads.
             var payloads = mos.getPayloads();
             expect(payloads.length).toEqual(0);
+
+            // Close tokenizer.
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
         });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
     });
 
     it("write with offsets", function() {
@@ -511,6 +529,7 @@ describe("MessageOutputStream", function() {
         });
         waitsFor(function() { return more3 !== undefined; }, "more3", MslTestConstants.TIMEOUT);
 
+        var tokenizerClosed = false;
         runs(function() {
             expect(more3).toBeFalsy();
 
@@ -518,7 +537,15 @@ describe("MessageOutputStream", function() {
             var payloads = mos.getPayloads();
             expect(payloads.length).toEqual(1);
             expect(payloads[0]).toEqual(payload);
+
+            // Close tokenizer.
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
         });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
     });
 
     it("write", function() {
@@ -662,6 +689,7 @@ describe("MessageOutputStream", function() {
         });
         waitsFor(function() { return more3 !== undefined; }, "more3", MslTestConstants.TIMEOUT);
 
+        var tokenizerClosed = false;
         runs(function() {
             expect(more3).toBeFalsy();
 
@@ -669,7 +697,15 @@ describe("MessageOutputStream", function() {
             var payloads = mos.getPayloads();
             expect(payloads.length).toEqual(1);
             expect(payloads[0]).toEqual(payload);
+
+            // Close tokenizer.
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
         });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
     });
 
     it("write with compression", function() {
@@ -822,6 +858,16 @@ describe("MessageOutputStream", function() {
             loop();
         });
         waitsFor(function() { return noMore; }, "no more", MslTestConstants.TIMEOUT);
+        
+        var tokenizerClosed = false;
+        runs(function() {
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
+        });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
 
         var messageHeader;
         runs(function() {
@@ -1010,6 +1056,16 @@ describe("MessageOutputStream", function() {
             loop();
         });
         waitsFor(function() { return noMore; }, "no more", MslTestConstants.TIMEOUT);
+        
+        var tokenizerClosed = false;
+        runs(function() {
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
+        });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
 
         var messageHeader;
         runs(function() {
@@ -1461,6 +1517,7 @@ describe("MessageOutputStream", function() {
         });
         waitsFor(function() { return more3 !== undefined; }, "more3", MslTestConstants.TIMEOUT);
 
+        var tokenizerClosed = false;
         runs(function() {
             expect(more3).toBeFalsy();
 
@@ -1468,7 +1525,15 @@ describe("MessageOutputStream", function() {
             var payloads = mos.getPayloads();
             expect(payloads.length).toEqual(1);
             expect(payloads[0]).toEqual(payload);
+
+            // Close tokenizer.
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
         });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
     });
 
     it("stress write", function() {
@@ -1613,6 +1678,16 @@ describe("MessageOutputStream", function() {
             loop();
         });
         waitsFor(function() { return noMore; }, "no more", MslTestConstants.TIMEOUT);
+        
+        var tokenizerClosed = false;
+        runs(function() {
+            tokenizer.close(-1, {
+                result: function(x) { tokenizerClosed = x; },
+                timeout: function() { expect(function() { throw new Error("timeout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
+            });
+        });
+        waitsFor(function() { return tokenizerClosed; }, "tokenizer closed", MslTestConstants.TIMEOUT);
 
         var header;
         runs(function() {

--- a/tests/src/test/javascript/package.json
+++ b/tests/src/test/javascript/package.json
@@ -24,7 +24,6 @@
     "msl-tests": "^1.1220.0"
   },
   "devDependencies": {
-    "clarinet": "^0.11.0",
     "ec-key": "0.0.2",
     "elliptic": "^6.4.0",
     "jshint": "^2.9.5",

--- a/tests/src/test/javascript/tokens/ServiceTokenTest.js
+++ b/tests/src/test/javascript/tokens/ServiceTokenTest.js
@@ -103,10 +103,10 @@ function(encoding, compressionAlgo) {
                                 return cryptoContext;
                             });
                         },
-                        error: function(e) { callback.error(e); }
+                        error: callback.error,
                     });
                 },
-                error: function(e) { callback.error(e); }
+                error: callback.error,
             });
         });
     }


### PR DESCRIPTION
`MslControl.send()` can be used to issue a fire-and-forget MSL request.
- only for use by trusted network clients and peer-to-peer entities
- not recommended as it will not inform the caller of MSL errors; establishing a MSL channel for bi-directional communication is more reliable
- will perform a handshake if necessary to deliver the application data

`MslControl.push()` can be used to issue a fire-and-forget MSL request.
- for use by trusted network servers to push messages to a trusted network client
- the client should have sent a message using `MslControl.send()`
- clients must still make use of normal request/response operations in order to ensure master tokens and user ID tokens are renewed

In order to facilitate efficient I/O on an input stream that will be used for multiple MSL messages, the `InputStream` returned by a `Url` connection must support the mark, reset, and skip functionality. It would be too expensive to read one character at a time while parsing the MSL message, so data is read in 64KiB chunks which may read past the end of one MSL message into a second.

(Last portion is pending.)