### PR TITLE
Remove sender & recipient fields; verify remote entity identity if specified.

### DIFF
--- a/core/src/main/java/com/netflix/msl/MslError.java
+++ b/core/src/main/java/com/netflix/msl/MslError.java
@@ -239,6 +239,7 @@ public class MslError {
     public static final MslError MESSAGE_REPLAYED_UNRECOVERABLE = new MslError(6040, ResponseCode.ENTITY_REAUTH, "Non-replayable message replayed with a sequence number that is too far out of sync to recover.");
     public static final MslError UNEXPECTED_LOCAL_MESSAGE_SENDER = new MslError(6041, ResponseCode.FAIL, "Message sender is equal to the local entity.");
     public static final MslError UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA = new MslError(6042, ResponseCode.FAIL, "User authentication data included in unencrypted message header.");
+    public static final MslError MESSAGE_SENDER_MISMATCH = new MslError(6043, ResponseCode.FAIL, "Message sender entity identity does not match expected identity.");
 
     // 7 Key Exchange
     public static final MslError UNIDENTIFIED_KEYX_SCHEME = new MslError(7000, ResponseCode.FAIL, "Unable to identify key exchange scheme.");

--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -411,7 +411,6 @@ public class MessageBuilder {
      * specified (i.e. unknown) then a random message ID will be generated.</p>
      * 
      * @param ctx MSL context.
-     * @param recipient error response recipient. May be null.
      * @param requestMessageId message ID of request. May be null.
      * @param error the MSL error.
      * @param userMessage localized user-consumable error message. May be null.

--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -182,17 +182,16 @@ public class MessageBuilder {
      * @param masterToken master token. May be null unless a user ID token is
      *        provided.
      * @param userIdToken user ID token. May be null.
-     * @param recipient message recipient. May be null.
      * @param messageId the message ID to use. Must be within range.
      * @return the message builder.
      * @throws MslException if a user ID token is not bound to its
      *         corresponding master token.
      */
-    public static MessageBuilder createRequest(final MslContext ctx, final MasterToken masterToken, final UserIdToken userIdToken, final String recipient, final long messageId) throws MslException {
+    public static MessageBuilder createRequest(final MslContext ctx, final MasterToken masterToken, final UserIdToken userIdToken, final long messageId) throws MslException {
         if (messageId < 0 || messageId > MslConstants.MAX_LONG_VALUE)
             throw new MslInternalException("Message ID " + messageId + " is outside the valid range.");
         final MessageCapabilities capabilities = ctx.getMessageCapabilities();
-        return new MessageBuilder(ctx, recipient, messageId, capabilities, masterToken, userIdToken, null, null, null, null, null);
+        return new MessageBuilder(ctx, messageId, capabilities, masterToken, userIdToken, null, null, null, null, null);
     }
     
     /**
@@ -202,15 +201,14 @@ public class MessageBuilder {
      * @param masterToken master token. May be null unless a user ID token is
      *        provided.
      * @param userIdToken user ID token. May be null.
-     * @param recipient message recipient. May be null.
      * @return the message builder.
      * @throws MslException if a user ID token is not bound to its
      *         corresponding master token.
      */
-    public static MessageBuilder createRequest(final MslContext ctx, final MasterToken masterToken, final UserIdToken userIdToken, final String recipient) throws MslException {
+    public static MessageBuilder createRequest(final MslContext ctx, final MasterToken masterToken, final UserIdToken userIdToken) throws MslException {
         final long messageId = MslUtils.getRandomLong(ctx);
         final MessageCapabilities capabilities = ctx.getMessageCapabilities();
-        return new MessageBuilder(ctx, recipient, messageId, capabilities, masterToken, userIdToken, null, null, null, null, null);
+        return new MessageBuilder(ctx, messageId, capabilities, masterToken, userIdToken, null, null, null, null, null);
     }
     
     /**
@@ -237,9 +235,6 @@ public class MessageBuilder {
         final EntityAuthenticationData entityAuthData = requestHeader.getEntityAuthenticationData();
         UserIdToken userIdToken = requestHeader.getUserIdToken();
         final UserAuthenticationData userAuthData = requestHeader.getUserAuthenticationData();
-        
-        // The response recipient is the requesting entity.
-        final String recipient = (masterToken != null) ? masterToken.getIdentity() : entityAuthData.getIdentity();
         
         // The response message ID must be equal to the request message ID + 1.
         final long requestMessageId = requestHeader.getMessageId();
@@ -343,10 +338,10 @@ public class MessageBuilder {
                 final MasterToken peerMasterToken = (keyResponseData != null) ? keyResponseData.getMasterToken() : requestHeader.getPeerMasterToken();
                 final UserIdToken peerUserIdToken = requestHeader.getPeerUserIdToken();
                 final Set<ServiceToken> peerServiceTokens = requestHeader.getPeerServiceTokens();
-                return new MessageBuilder(ctx, recipient, messageId, capabilities, peerMasterToken, peerUserIdToken, peerServiceTokens, masterToken, userIdToken, serviceTokens, keyExchangeData);
+                return new MessageBuilder(ctx, messageId, capabilities, peerMasterToken, peerUserIdToken, peerServiceTokens, masterToken, userIdToken, serviceTokens, keyExchangeData);
             } else {
                 final MasterToken localMasterToken = (keyResponseData != null) ? keyResponseData.getMasterToken() : masterToken;
-                return new MessageBuilder(ctx, recipient, messageId, capabilities, localMasterToken, userIdToken, serviceTokens, null, null, null, keyExchangeData);
+                return new MessageBuilder(ctx, messageId, capabilities, localMasterToken, userIdToken, serviceTokens, null, null, null, keyExchangeData);
             }
         } catch (final MslException e) {
             e.setMasterToken(masterToken);
@@ -377,9 +372,6 @@ public class MessageBuilder {
         final UserIdToken userIdToken = requestHeader.getUserIdToken();
         final UserAuthenticationData userAuthData = requestHeader.getUserAuthenticationData();
         
-        // The response recipient is the requesting entity.
-        final String recipient = (masterToken != null) ? masterToken.getIdentity() : entityAuthData.getIdentity();
-        
         // The response message ID must be equal to the request message ID + 1.
         final long requestMessageId = requestHeader.getMessageId();
         final long messageId = incrementMessageId(requestMessageId);
@@ -398,10 +390,10 @@ public class MessageBuilder {
                 final MasterToken peerMasterToken = (keyResponseData != null) ? keyResponseData.getMasterToken() : requestHeader.getPeerMasterToken();
                 final UserIdToken peerUserIdToken = requestHeader.getPeerUserIdToken();
                 final Set<ServiceToken> peerServiceTokens = requestHeader.getPeerServiceTokens();
-                return new MessageBuilder(ctx, recipient, messageId, capabilities, peerMasterToken, peerUserIdToken, peerServiceTokens, masterToken, userIdToken, serviceTokens, null);
+                return new MessageBuilder(ctx, messageId, capabilities, peerMasterToken, peerUserIdToken, peerServiceTokens, masterToken, userIdToken, serviceTokens, null);
             } else {
                 final MasterToken localMasterToken = (keyResponseData != null) ? keyResponseData.getMasterToken() : masterToken;
-                return new MessageBuilder(ctx, recipient, messageId, capabilities, localMasterToken, userIdToken, serviceTokens, null, null, null, null);
+                return new MessageBuilder(ctx, messageId, capabilities, localMasterToken, userIdToken, serviceTokens, null, null, null, null);
             }
         } catch (final MslException e) {
             e.setMasterToken(masterToken);
@@ -431,7 +423,7 @@ public class MessageBuilder {
      * @throws MslMessageException if no entity authentication data was
      *         returned by the MSL context.
      */
-    public static ErrorHeader createErrorResponse(final MslContext ctx, final String recipient, final Long requestMessageId, final MslError error, final String userMessage) throws MslCryptoException, MslEntityAuthException, MslMessageException {
+    public static ErrorHeader createErrorResponse(final MslContext ctx, final Long requestMessageId, final MslError error, final String userMessage) throws MslCryptoException, MslEntityAuthException, MslMessageException {
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         // If we have the request message ID then the error response message ID
         // must be equal to the request message ID + 1.
@@ -446,7 +438,7 @@ public class MessageBuilder {
         final ResponseCode errorCode = error.getResponseCode();
         final int internalCode = error.getInternalCode();
         final String errorMsg = error.getMessage();
-        return new ErrorHeader(ctx, entityAuthData, recipient, messageId, errorCode, internalCode, errorMsg, userMessage);
+        return new ErrorHeader(ctx, entityAuthData, messageId, errorCode, internalCode, errorMsg, userMessage);
     }
     
     /**
@@ -454,7 +446,6 @@ public class MessageBuilder {
      * data if a master token was issued or renewed.
      * 
      * @param ctx MSL context.
-     * @param recipient message recipient. May be null.
      * @param messageId message ID.
      * @param capabilities message capabilities.
      * @param masterToken master token. May be null unless a user ID token is
@@ -470,7 +461,7 @@ public class MessageBuilder {
      * @throws MslException if a user ID token is not bound to its master
      *         token.
      */
-    private MessageBuilder(final MslContext ctx, final String recipient, final long messageId, final MessageCapabilities capabilities, final MasterToken masterToken, final UserIdToken userIdToken, final Set<ServiceToken> serviceTokens, final MasterToken peerMasterToken, final UserIdToken peerUserIdToken, final Set<ServiceToken> peerServiceTokens, final KeyExchangeData keyExchangeData) throws MslException {
+    private MessageBuilder(final MslContext ctx, final long messageId, final MessageCapabilities capabilities, final MasterToken masterToken, final UserIdToken userIdToken, final Set<ServiceToken> serviceTokens, final MasterToken peerMasterToken, final UserIdToken peerUserIdToken, final Set<ServiceToken> peerServiceTokens, final KeyExchangeData keyExchangeData) throws MslException {
         // Primary and peer token combinations will be verified when the
         // message header is constructed. So delay those checks in favor of
         // avoiding duplicate code.
@@ -479,7 +470,6 @@ public class MessageBuilder {
         
         // Set the primary fields.
         this.ctx = ctx;
-        this.recipient = recipient;
         this.messageId = messageId;
         this.capabilities = capabilities;
         this.masterToken = masterToken;
@@ -625,7 +615,7 @@ public class MessageBuilder {
         } else {
             nonReplayableId = null;
         }
-        final HeaderData headerData = new HeaderData(recipient, messageId, nonReplayableId, renewable, handshake, capabilities, keyRequestData, response, userAuthData, userIdToken, tokens);
+        final HeaderData headerData = new HeaderData(messageId, nonReplayableId, renewable, handshake, capabilities, keyRequestData, response, userAuthData, userIdToken, tokens);
         final Set<ServiceToken> peerTokens = new HashSet<ServiceToken>(peerServiceTokens.values());
         final HeaderPeerData peerData = new HeaderPeerData(peerMasterToken, peerUserIdToken, peerTokens);
         
@@ -1140,8 +1130,6 @@ public class MessageBuilder {
     
     /** Message header master token. */
     private MasterToken masterToken;
-    /** Message recipient. */
-    private final String recipient;
     /** Header data message ID. */
     private long messageId;
     /** Key exchange data. */

--- a/core/src/main/java/com/netflix/msl/msg/MessageContext.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,16 +98,15 @@ public interface MessageContext {
     public Map<String,ICryptoContext> getCryptoContexts();
     
     /**
-     * <p>Called to identify the entity identity the message application data
-     * is intended for. If the identity is not known this method must return
-     * {@code null}.</p> 
+     * <p>Called to identify the expected remote entity identity. If the remote
+     * entity identity is not known this method must return {@code null}.</p> 
      * 
      * <p>Trusted network servers may always return {@code null}.</p>
      * 
-     * @return the entity identity of the application data recipient or
-     *         {@code null} if the identity is not known.
+     * @return the remote entity identity or {@code null} if the identity is
+     *         not known.
      */
-    public String getRecipient();
+    public String getRemoteEntityIdentity();
     
     /**
      * <p>Called to determine if the message application data must be

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -525,11 +525,11 @@ public class MslControl {
         }
         
         /* (non-Javadoc)
-         * @see com.netflix.msl.msg.MessageContext#getRecipient()
+         * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
          */
         @Override
-        public String getRecipient() {
-            return appCtx.getRecipient();
+        public String getRemoteEntityIdentity() {
+            return appCtx.getRemoteEntityIdentity();
         }
 
         /* (non-Javadoc)
@@ -1780,7 +1780,7 @@ public class MslControl {
             
             // Reject if a recipient was specified and it is not equal to the
             // message entity identity.
-            final String expectedIdentity = msgCtx.getRecipient();
+            final String expectedIdentity = msgCtx.getRemoteEntityIdentity();
             if (expectedIdentity != null && sender != null && !expectedIdentity.equals(sender))
                 throw new MslMessageException(MslError.MESSAGE_SENDER_MISMATCH, "expected " + expectedIdentity + "; received " + sender);
 

--- a/core/src/main/java/com/netflix/msl/msg/MslControl.java
+++ b/core/src/main/java/com/netflix/msl/msg/MslControl.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -98,75 +98,75 @@ import com.netflix.msl.util.NullMslStore;
  * sending and receiving messages with an optional thread pool. An application
  * should only use one instance of {@code MslControl} for all MSL
  * communication. This class is thread-safe.</p>
- * 
+ *
  * <p>This class provides methods for sending and receiving messages for all
  * types of entities in both trusted network and peer-to-peer network types.
  * Refer to the documentation for each method to determine which methods should
  * be used based on the entity's role and network type.</p>
- * 
+ *
  * <h3>Error Handling</h3>
- * 
+ *
  * <dl>
  *  <dt>{@link ResponseCode#FAIL}</dt>
  *  <dd>The caller is notified of the failure.</dd>
- *  
+ *
  *  <dt>{@link ResponseCode#TRANSIENT_FAILURE}</dt>
  *  <dd>The caller is notified of the failure. MSL will not automatically
  *      retry.</dd>
- *      
+ *
  *  <dt>{@link ResponseCode#ENTITY_REAUTH}</dt>
  *  <dd>MSL will attempt to resend the message using the entity authentication
  *      data. The previous master token and master token-bound service tokens
  *      will be discarded if successful.</dd>
- *  
+ *
  *  <dt>{@link ResponseCode#USER_REAUTH}</dt>
  *  <dd>MSL will attempt to resend the message using the user authentication
  *      data if made available by the message context. Otherwise request fails.
  *      The previous user ID token-bound service tokens will be discarded if
  *      successful.</dd>
- *      
+ *
  *  <dt>{@link ResponseCode#KEYX_REQUIRED}</dt>
  *  <dd>MSL will attempt to perform key exchange to establish session keys and
  *      then resend the message.</dd>
- *  
+ *
  *  <dt>{@link ResponseCode#ENTITYDATA_REAUTH}</dt>
  *  <dd>MSL will attempt to resend the message using new entity authentication
  *      data. The previous master token and master token-bound service tokens
  *      will be discarded if successful.</dd>
- *  
+ *
  *  <dt>{@link ResponseCode#USERDATA_REAUTH}</dt>
  *  <dd>MSL will attempt to resend the message using new user authentication
  *      data if made available by the message context. Otherwise request fails.
  *      The previous user ID token-bound service tokens will be discarded if
  *      successful.</dd>
- *      
+ *
  *  <dt>{@link ResponseCode#EXPIRED}</dt>
  *  <dd>MSL will attempt to resend the message with the renewable flag set or
  *      after receiving a new master token.</dd>
- *  
+ *
  *  <dt>{@link ResponseCode#REPLAYED}</dt>
  *  <dd>MSL will attempt to resend the message after renewing the master token
  *      or receiving a new master token.</dd>
- *  
+ *
  *  <dt>{@link ResponseCode#SSOTOKEN_REJECTED}</dt>
  *  <dd>Identical to {@link ResponseCode#USERDATA_REAUTH}.</dd>
  * </dl>
- * 
+ *
  * <h3>Anti-Replay</h3>
- * 
+ *
  * <p>Requests marked as non-replayable will include a non-replayable ID.</p>
- * 
+ *
  * <p>Responses must always reply with the message ID of the request
  * incremented by 1. When the request message ID equals 2<sup>63</sup>-1 the
  * response message ID must be 0. If the response message ID does not equal the
  * expected value it is rejected and the caller is notified.</p>
- * 
+ *
  * <h3>Renewal Synchronization</h3>
- * 
+ *
  * <p>For a given MSL context there will be at most one renewable request with
  * a master token and key request data in process. This prevents excessive
  * master token renewal and potential renewal race conditions.</p>
- * 
+ *
  * <p>Requests will be marked renewable if any of the following is true:
  * <ul>
  * <li>The master token renewal window has been entered.</li>
@@ -174,16 +174,16 @@ import com.netflix.msl.util.NullMslStore;
  * <li>The application requests or requires establishment of session keys.</li>
  * </ul>
  * </p>
- * 
+ *
  * <h3>MSL Handshake</h3>
- * 
+ *
  * <p>Whenever requested or possible application data is encrypted and
  * integrity-protected while in transit. If the MSL context entity
  * authentication scheme does not support encryption or integrity protection
  * when requested an initial handshake will be performed to establish session
  * keys. This handshake occurs silently without the application's
  * knowledge.</p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class MslControl {
@@ -196,7 +196,7 @@ public class MslControl {
         /** The user identity is no longer accepted by the application. */
         USER_REJECTED,
     }
-    
+
     /**
      * A {@link MessageInputStream} and {@link MessageOutputStream} pair
      * representing a single MSL communication channel established between
@@ -205,7 +205,7 @@ public class MslControl {
     public static class MslChannel {
         /**
          * Create a new MSL channel with the provided input and output streams.
-         * 
+         *
          * @param input message input stream to read from the remote entity.
          * @param output message output stream to write to the remote entity.
          */
@@ -213,20 +213,20 @@ public class MslControl {
             this.input = input;
             this.output = output;
         }
-        
+
         /** Message input stream to read from the remote entity. */
         public final MessageInputStream input;
         /** Message output stream to write to the remote entity. */
         public final MessageOutputStream output;
     }
-    
+
     /**
      * A map key based off a MSL context and master token pair.
      */
     private static class MslContextMasterTokenKey {
         /**
          * Create a new MSL context and master token map key.
-         * 
+         *
          * @param ctx MSL context.
          * @param masterToken master token.
          */
@@ -253,13 +253,13 @@ public class MslControl {
             final MslContextMasterTokenKey that = (MslContextMasterTokenKey)obj;
             return this.ctx.equals(that.ctx) && this.masterToken.equals(that.masterToken);
         }
-        
+
         /** MSL context. */
         private final MslContext ctx;
         /** Master token. */
         private final MasterToken masterToken;
     }
-    
+
     /**
      * This class executes all tasks synchronously on the calling thread.
      */
@@ -317,11 +317,11 @@ public class MslControl {
             shutdown = true;
             return Collections.emptyList();
         }
-        
+
         /** Shutdown? */
         private boolean shutdown = false;
     }
-    
+
     /**
      * A dummy MSL context only used for our dummy
      * {@link MslControl#NULL_MASTER_TOKEN}.
@@ -349,7 +349,7 @@ public class MslControl {
                 throw new MslInternalException("DummyMslEncoderFactory.encodeObject() not supported.");
             }
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getTime()
          */
@@ -357,7 +357,7 @@ public class MslControl {
         public long getTime() {
             return System.currentTimeMillis();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getRandom()
          */
@@ -381,7 +381,7 @@ public class MslControl {
         public MessageCapabilities getMessageCapabilities() {
             return null;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getEntityAuthenticationData(com.netflix.msl.util.MslContext.ReauthCode)
          */
@@ -397,7 +397,7 @@ public class MslControl {
         public ICryptoContext getMslCryptoContext() throws MslCryptoException {
             return new NullCryptoContext();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getEntityAuthenticationScheme(java.lang.String)
          */
@@ -413,7 +413,7 @@ public class MslControl {
         public EntityAuthenticationFactory getEntityAuthenticationFactory(final EntityAuthenticationScheme scheme) {
             return null;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getUserAuthenticationScheme(java.lang.String)
          */
@@ -429,7 +429,7 @@ public class MslControl {
         public UserAuthenticationFactory getUserAuthenticationFactory(final UserAuthenticationScheme scheme) {
             return null;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getTokenFactory()
          */
@@ -437,7 +437,7 @@ public class MslControl {
         public TokenFactory getTokenFactory() {
             throw new MslInternalException("Dummy token factory should never actually get used.");
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getKeyExchangeScheme(java.lang.String)
          */
@@ -469,7 +469,7 @@ public class MslControl {
         public MslStore getMslStore() {
             return new NullMslStore();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.util.MslContext#getMslEncoderFactory()
          */
@@ -478,7 +478,7 @@ public class MslControl {
             return new DummyMslEncoderFactory();
         }
     }
-    
+
     /**
      * A dummy error message registry that always returns null for the user
      * message.
@@ -491,7 +491,7 @@ public class MslControl {
         public String getUserMessage(final MslError err, final List<String> languages) {
             return null;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.ErrorMessageRegistry#getUserMessage(java.lang.Throwable, java.util.List)
          */
@@ -509,13 +509,13 @@ public class MslControl {
         /**
          * Creates a message context that passes through calls to the backing
          * message context.
-         * 
+         *
          * @param appCtx the application's message context.
          */
         protected FilterMessageContext(final MessageContext appCtx) {
             this.appCtx = appCtx;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#getCryptoContexts()
          */
@@ -523,7 +523,7 @@ public class MslControl {
         public Map<String, ICryptoContext> getCryptoContexts() {
             return appCtx.getCryptoContexts();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
          */
@@ -539,7 +539,7 @@ public class MslControl {
         public boolean isEncrypted() {
             return appCtx.isEncrypted();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#isIntegrityProtected()
          */
@@ -547,7 +547,7 @@ public class MslControl {
         public boolean isIntegrityProtected() {
             return appCtx.isIntegrityProtected();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#isNonReplayable()
          */
@@ -555,7 +555,7 @@ public class MslControl {
         public boolean isNonReplayable() {
             return appCtx.isNonReplayable();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#isRequestingTokens()
          */
@@ -563,7 +563,7 @@ public class MslControl {
         public boolean isRequestingTokens() {
             return appCtx.isRequestingTokens();
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#getUserId()
          */
@@ -611,7 +611,7 @@ public class MslControl {
         public void write(final MessageOutputStream output) throws IOException {
             appCtx.write(output);
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#getDebugContext()
          */
@@ -633,7 +633,7 @@ public class MslControl {
          * or handshake. If the payloads are null the application's message
          * context will be asked to write its data. Otherwise the provided
          * payloads will be used for the message's application data.
-         * 
+         *
          * @param payloads original request payload chunks. May be null.
          * @param appCtx the application's message context.
          */
@@ -653,7 +653,7 @@ public class MslControl {
                 appCtx.write(output);
                 return;
             }
-            
+
             // Rewrite the payloads one-by-one.
             for (final PayloadChunk chunk : payloads) {
                 output.setCompressionAlgorithm(chunk.getCompressionAlgo());
@@ -664,11 +664,11 @@ public class MslControl {
                     output.flush();
             }
         }
-        
+
         /** The application data to resend. */
         private final List<PayloadChunk> payloads;
     }
-    
+
     /**
      * This message context is used to send messages that will not expect a
      * response.
@@ -678,7 +678,7 @@ public class MslControl {
          * Creates a message context used to send messages that do not expect a
          * response by ensuring that the message context conforms to those
          * expectations.
-         * 
+         *
          * @param appCtx the application's message context.
          */
         public SendMessageContext(final MessageContext appCtx) {
@@ -693,7 +693,7 @@ public class MslControl {
             return false;
         }
     }
-    
+
     /**
      * This message context is used to send a handshake response.
      */
@@ -701,7 +701,7 @@ public class MslControl {
         /**
          * Creates a message context used for automatically generated handshake
          * responses.
-         * 
+         *
          * @param appCtx the application's message context.
          */
         public KeyxResponseMessageContext(final MessageContext appCtx) {
@@ -717,7 +717,7 @@ public class MslControl {
             // exchange could never succeed in some cases.
             return false;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MslControl.FilterMessageContext#isIntegrityProtected()
          */
@@ -727,7 +727,7 @@ public class MslControl {
             // otherwise key exchange could never succeed in some cases.
             return false;
         }
-        
+
         /* (non-Javadoc)
          * @see com.netflix.msl.msg.MessageContext#isNonReplayable()
          */
@@ -744,12 +744,12 @@ public class MslControl {
             // No application data.
         }
     }
-    
+
     /**
      * <p>Returns true if the current thread has been interrupted as indicated
      * by the {@code Thread#isInterrupted()} method or the type of caught
      * throwable.</p>
-     * 
+     *
      * <p>The following {@code Throwable} types are considered interruptions that the application
      * initiated or should otherwise be aware of:
      * <ul>
@@ -758,7 +758,7 @@ public class MslControl {
      * <li>{@link FileLockInterruptionException}</li>
      * <li>{@link ClosedByInterruptException}</li>
      * </ul></p>
-     * 
+     *
      * @param t caught throwable. May be null.
      * @return true if this thread was interrupted or the exception indicates
      *         an operation was interrupted.
@@ -780,50 +780,23 @@ public class MslControl {
         }
         return false;
     }
-    
-    /**
-     * Returns the provided message sender's entity identity from the master
-     * token or entity authentication data, if it can be determined.
-     * 
-     * @param mis the message input stream.
-     * @return the message sender's entity identity or null if unknown.
-     * @throws MslCryptoException if there is a crypto error accessing the
-     *         entity identity.
-     */
-    private static String getIdentity(final MessageInputStream mis) throws MslCryptoException {
-        // Try message header's first, as that is the most common case.
-        final MessageHeader messageHeader = mis.getMessageHeader();
-        if (messageHeader != null) {
-            final MasterToken masterToken = messageHeader.getMasterToken();
-            if (masterToken != null)
-                return masterToken.getIdentity();
-            final EntityAuthenticationData entityAuthData = messageHeader.getEntityAuthenticationData();
-            return entityAuthData.getIdentity();
-        }
-        
-        // Try error headers.
-        final ErrorHeader errorHeader = mis.getErrorHeader();
-        final EntityAuthenticationData entityAuthData = errorHeader.getEntityAuthenticationData();
-        return entityAuthData.getIdentity();
-    }
 
-    
     /**
      * Create a new instance of MSL control with the specified number of
      * threads. A thread count of zero will cause all operations to execute on
      * the calling thread.
-     * 
+     *
      * @param numThreads number of worker threads to create.
      */
     public MslControl(final int numThreads) {
         this(numThreads, null, null);
     }
-    
+
     /**
      * Create a new instance of MSL control with the specified number of
      * threads and user error message registry. A thread count of zero will
      * cause all operations to execute on the calling thread.
-     * 
+     *
      * @param numThreads number of worker threads to create.
      * @param streamFactory message stream factory. May be {@code null}.
      * @param messageRegistry error message registry. May be {@code null}.
@@ -831,19 +804,19 @@ public class MslControl {
     public MslControl(final int numThreads, final MessageStreamFactory streamFactory, final ErrorMessageRegistry messageRegistry) {
         if (numThreads < 0)
             throw new IllegalArgumentException("Number of threads must be non-negative.");
-        
+
         // Set the stream factory.
         this.streamFactory = (streamFactory != null) ? streamFactory : new MessageStreamFactory();
-        
+
         // Set the message registry.
         this.messageRegistry = (messageRegistry != null) ? messageRegistry : new DummyMessageRegistry();
-        
+
         // Create the thread pool if requested.
         if (numThreads > 0)
             executor = Executors.newFixedThreadPool(numThreads);
         else
             executor = new SynchronousExecutor();
-        
+
         // Create the dummy master token used as a special value when releasing
         // the renewal lock without a new master token.
         try {
@@ -859,19 +832,19 @@ public class MslControl {
             throw new MslInternalException("Unexpected exception when constructing dummy master token.", e);
         }
     }
-    
+
     /**
      * Assigns a filter stream factory that will be used to filter any incoming
      * or outgoing messages. The filters will be placed between the MSL message
      * and MSL control, meaning they will see the actual MSL message data as it
      * is being read from or written to the remote entity.
-     * 
+     *
      * @param factory filter stream factory. May be null.
      */
     public void setFilterFactory(final FilterStreamFactory factory) {
         filterFactory = factory;
     }
-    
+
     /**
      * Gracefully shutdown the MSL control instance. No additional messages may
      * be processed. Any messages pending or in process will be completed.
@@ -879,7 +852,7 @@ public class MslControl {
     public void shutdown() {
         executor.shutdown();
     }
-    
+
     /* (non-Javadoc)
      * @see java.lang.Object#finalize()
      */
@@ -888,15 +861,15 @@ public class MslControl {
         executor.shutdownNow();
         super.finalize();
     }
-    
+
     /**
      * <p>Returns the newest master token from the MSL store and acquires the
      * master token's read lock.</p>
-     * 
+     *
      * <p>When the caller no longer requires the master token or its crypto
      * context to exist (i.e. it does not expect to receive a response that
      * uses the same master token) then it must release the lock.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @return the newest master token or null if there is none.
      * @throws InterruptedException if the thread is interrupted while trying
@@ -935,11 +908,11 @@ public class MslControl {
             finalLock.writeLock().unlock();
         } while (true);
     }
-    
+
     /**
      * Deletes the provided master token from the MSL store. Doing so requires
      * acquiring the master token's write lock.
-     * 
+     *
      * @param ctx MSL context.
      * @param masterToken master token to delete. May be null.
      * @throws InterruptedException if the thread is interrupted while trying
@@ -981,11 +954,11 @@ public class MslControl {
             writeLock.unlock();
         }
     }
-    
+
     /**
      * Release the read lock of the provided master token. If no master token
      * is provided then this method is a no-op.
-     * 
+     *
      * @param ctx MSL context.
      * @param masterToken the master token. May be null.
      * @see #getNewestMasterToken(MslContext)
@@ -994,18 +967,18 @@ public class MslControl {
         if (masterToken != null) {
             final MslContextMasterTokenKey key = new MslContextMasterTokenKey(ctx, masterToken);
             final ReadWriteLock lock = masterTokenLocks.get(key);
-            
+
             // The lock may be null if the master token was deleted.
             if (lock != null)
                 lock.readLock().unlock();
         }
     }
-    
+
     /**
      * Update the MSL store crypto contexts with the crypto contexts of the
      * message being sent. Only crypto contexts for master tokens used by the
      * local entity for message authentication are saved.
-     * 
+     *
      * @param ctx MSL context.
      * @param messageHeader outgoing message header.
      * @param keyExchangeData outgoing message key exchange data.
@@ -1021,17 +994,17 @@ public class MslControl {
             final ICryptoContext keyxCryptoContext = keyExchangeData.cryptoContext;
             final MasterToken keyxMasterToken = keyResponseData.getMasterToken();
             store.setCryptoContext(keyxMasterToken, keyxCryptoContext);
-            
+
             // Delete the old master token. Even if we receive future messages
             // with this master token we can reconstruct the crypto context.
             deleteMasterToken(ctx, messageHeader.getMasterToken());
         }
     }
-    
+
     /**
      * Update the MSL store crypto contexts with the crypto contexts provided
      * by received message.
-     * 
+     *
      * @param ctx MSL context.
      * @param request previous message the response was received for.
      * @param response received message input stream.
@@ -1043,25 +1016,25 @@ public class MslControl {
         final MessageHeader messageHeader = response.getMessageHeader();
         if (messageHeader == null)
             return;
-        
+
         // Save the crypto context of the message's key response data.
         final MslStore store = ctx.getMslStore();
         final KeyResponseData keyResponseData = messageHeader.getKeyResponseData();
         if (keyResponseData != null) {
             final MasterToken keyxMasterToken = keyResponseData.getMasterToken();
             store.setCryptoContext(keyxMasterToken, response.getKeyExchangeCryptoContext());
-            
+
             // Delete the old master token. We won't use it anymore to build
             // messages.
             deleteMasterToken(ctx, request.getMasterToken());
         }
     }
-    
+
     /**
      * Update the MSL store by removing any service tokens marked for deletion
      * and adding/replacing any other service tokens contained in the message
      * header.
-     * 
+     *
      * @param ctx MSL context.
      * @param masterToken master for the service tokens.
      * @param userIdToken user ID token for the service tokens.
@@ -1087,19 +1060,19 @@ public class MslControl {
         }
         store.addServiceTokens(storeTokens);
     }
-    
+
     /**
      * <p>Create a new message builder that will craft a new message.</p>
-     * 
+     *
      * <p>If a master token is available it will be used to build the new
      * message and its read lock will be acquired. The caller must release the
      * read lock after it has either received a response to the built request
      * or after sending the message if no response is expected.</p>
-     * 
+     *
      * <p>If a master token is available and a user ID is provided by the
      * message context the user ID token for that user ID will be used to build
-     * the message if the user ID token is bound to the master token.</p> 
-     * 
+     * the message if the user ID token is bound to the master token.</p>
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @return the message builder.
@@ -1108,7 +1081,7 @@ public class MslControl {
      */
     private MessageBuilder buildRequest(final MslContext ctx, final MessageContext msgCtx) throws InterruptedException {
         final MslStore store = ctx.getMslStore();
-        
+
         // Grab the newest master token.
         final MasterToken masterToken = getNewestMasterToken(ctx);
         final UserIdToken userIdToken;
@@ -1122,7 +1095,7 @@ public class MslControl {
         } else {
             userIdToken = null;
         }
-        
+
         try {
             final MessageBuilder builder = MessageBuilder.createRequest(ctx, masterToken, userIdToken);
             builder.setNonReplayable(msgCtx.isNonReplayable());
@@ -1137,23 +1110,23 @@ public class MslControl {
             throw re;
         }
     }
-    
+
     /**
      * <p>Create a new message builder that will craft a new message in
      * response to another message. The constructed message may be used as a
      * request.</p>
-     * 
+     *
      * <p>In peer-to-peer mode if the response does not have a primary master
      * token and a master token is available then it will be used to build the
      * new message and its read lock will be acquired. The caller must release
      * the read lock after it has either received a response to the built
      * request or after sending the message if no response is expected.</p>
-     * 
+     *
      * <p>In peer-to-peer mode if a master token is being used to build the new
      * message and a user ID is provided by the message context, the user ID
      * token for that user ID will be used to build the message if the user ID
      * token is bound to the master token.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param request message header to respond to.
@@ -1176,7 +1149,7 @@ public class MslControl {
         // Create the response.
         final MessageBuilder builder = MessageBuilder.createResponse(ctx, request);
         builder.setNonReplayable(msgCtx.isNonReplayable());
-        
+
         // Trusted network clients should use the newest master token. Trusted
         // network servers must not use a newer master token. This method is
         // only called by trusted network clients after a handshake response is
@@ -1185,7 +1158,7 @@ public class MslControl {
         // return immediately.
         if (!ctx.isPeerToPeer() && request.getKeyResponseData() == null)
             return builder;
-        
+
         // In peer-to-peer mode the primary master token may no longer be known
         // if it was renewed between calls to receive() and respond()
         // (otherwise we would have held a lock). In this case, we need to
@@ -1214,13 +1187,13 @@ public class MslControl {
         builder.setAuthTokens(masterToken, userIdToken);
         return builder;
     }
-    
+
     /**
      * <p>Create a new message builder that will craft a new message based on
      * another message. The constructed message will have a randomly assigned
      * message ID, thus detaching it from the message being responded to, and
      * may be used as a request.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param request message header to respond to.
@@ -1237,7 +1210,7 @@ public class MslControl {
         builder.setMessageId(MslUtils.getRandomLong(ctx));
         return builder;
     }
-    
+
     /**
      * The result of building an error response.
      */
@@ -1245,7 +1218,7 @@ public class MslControl {
         /**
          * Create a new result with the provided request builder and message
          * context.
-         * 
+         *
          * @param builder
          * @param msgCtx
          */
@@ -1253,17 +1226,17 @@ public class MslControl {
             this.builder = builder;
             this.msgCtx = msgCtx;
         }
-        
+
         /** The new request to send. */
         public final MessageBuilder builder;
         /** The new message context to use. */
         public final MessageContext msgCtx;
     }
-    
+
     /**
      * Creates a message builder and message context appropriate for re-sending
      * the original message in response to the received error.
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param sent result of original sent message.
@@ -1295,7 +1268,7 @@ public class MslControl {
                 } catch (final IllegalArgumentException e) {
                     throw new MslInternalException("Unsupported response code mapping onto entity re-authentication codes.", e);
                 }
-                
+
                 // Resend the request without a master token or user ID token.
                 // Make sure the use the error header message ID + 1.
                 final long messageId = MessageBuilder.incrementMessageId(errorHeader.getMessageId());
@@ -1321,7 +1294,7 @@ public class MslControl {
                 } catch (final IllegalArgumentException e) {
                     throw new MslInternalException("Unsupported response code mapping onto user re-authentication codes.", e);
                 }
-                
+
                 // Otherwise we have now triggered the need for new user
                 // authentication data. Fall through.
             }
@@ -1380,7 +1353,7 @@ public class MslControl {
                 } else {
                     userIdToken = null;
                 }
-                
+
                 // Resend the request.
                 final long messageId = MessageBuilder.incrementMessageId(errorHeader.getMessageId());
                 final MessageContext resendMsgCtx = new ResendMessageContext(payloads, msgCtx);
@@ -1423,7 +1396,7 @@ public class MslControl {
                 } else {
                     userIdToken = null;
                 }
-                
+
                 // Resend the request.
                 final long messageId = MessageBuilder.incrementMessageId(errorHeader.getMessageId());
                 final MessageContext resendMsgCtx = new ResendMessageContext(payloads, msgCtx);
@@ -1433,7 +1406,7 @@ public class MslControl {
                     final UserIdToken peerUserIdToken = requestHeader.getPeerUserIdToken();
                     requestBuilder.setPeerAuthTokens(peerMasterToken, peerUserIdToken);
                 }
-                
+
                 // Mark the message as replayable or not as dictated by the
                 // message context.
                 requestBuilder.setNonReplayable(resendMsgCtx.isNonReplayable());
@@ -1444,12 +1417,12 @@ public class MslControl {
                 return null;
         }
     }
-    
+
     /**
      * Called after successfully handling an error message to delete the old
      * invalid crypto contexts and bound service tokens associated with the
      * invalid master token or user ID token.
-     * 
+     *
      * @param ctx MSL context.
      * @param requestHeader initial request that generated the error.
      * @param errorHeader error response received and successfully handled.
@@ -1494,7 +1467,7 @@ public class MslControl {
                 break;
         }
     }
-    
+
     /**
      * The result of sending a message.
      */
@@ -1503,7 +1476,7 @@ public class MslControl {
          * Create a new result with the provided message output stream
          * containing the cached application data (which was not sent if the
          * message was a handshake).
-         * 
+         *
          * @param request request message output stream.
          * @param handshake true if a handshake message was sent and the
          *        application data was not sent.
@@ -1518,21 +1491,21 @@ public class MslControl {
         /** True if the message was a handshake (application data was not sent). */
         public final boolean handshake;
     }
-    
+
     /**
      * <p>Send a message. The message context will be used to build the message.
      * If the message will be sent then the stored master token crypto contexts
      * and service tokens will be updated just prior to sending.</p>
-     * 
+     *
      * <p>If the application data must be encrypted but the message does not
      * support payload encryption then a handshake message will be sent. This
      * will be indicated by the returned result.</p>
-     * 
+     *
      * <p>N.B. The message builder must be set renewable and non-replayable
      * before calling this method. If the application data must be delayed then
      * this specific message will be sent replayable regardless of the builder
      * non-replayable value.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param out remote entity output stream.
@@ -1562,7 +1535,7 @@ public class MslControl {
         final MasterToken masterToken = builder.getMasterToken();
         UserIdToken userIdToken = builder.getUserIdToken();
         final UserIdToken peerUserIdToken = builder.getPeerUserIdToken();
-        
+
         // Ask the message context for user authentication data.
         boolean userAuthDataDelayed = false;
         final String userId = msgCtx.getUserId();
@@ -1584,12 +1557,12 @@ public class MslControl {
                 else
                     userAuthDataDelayed = true;
             }
-            
+
             // If user authentication data is required but was not provided
             // then this message may be associated with a user but not have any
             // user authentication data. For example upon user creation.
         }
-        
+
         // If there is no user ID token for the remote user then check if a
         // user ID token should be created and attached.
         if (!ctx.isPeerToPeer() && userIdToken == null ||
@@ -1598,7 +1571,7 @@ public class MslControl {
             final MslUser user = msgCtx.getUser();
             if (user != null) {
                 builder.setUser(user);
-            
+
                 // The user ID token may have changed and we need the latest one to
                 // store the service tokens below.
                 userIdToken = builder.getUserIdToken();
@@ -1617,10 +1590,10 @@ public class MslControl {
             (!msgCtx.isIntegrityProtected() || builder.willIntegrityProtectPayloads()) &&
             (!msgCtx.isNonReplayable() || (builder.isNonReplayable() && masterToken != null));
         final boolean handshake = !writeData;
-        
+
         // Set the message handshake flag.
         builder.setHandshake(handshake);
-        
+
         // If this message is renewable...
         final Set<KeyRequestData> keyRequests = new HashSet<KeyRequestData>();
         if (builder.isRenewable()) {
@@ -1640,22 +1613,22 @@ public class MslControl {
         final MessageServiceTokenBuilder serviceTokenBuilder = new MessageServiceTokenBuilder(ctx, msgCtx, builder);
         msgCtx.updateServiceTokens(serviceTokenBuilder, handshake);
         final MessageHeader requestHeader = builder.getHeader();
-        
+
         // Deliver the header that will be sent to the debug context.
         final MessageDebugContext debugCtx = msgCtx.getDebugContext();
         if (debugCtx != null) debugCtx.sentHeader(requestHeader);
-        
+
         // Update the stored crypto contexts just before sending the
         // message so we can receive new messages immediately after it is
         // sent.
         final KeyExchangeData keyExchangeData = builder.getKeyExchangeData();
         updateCryptoContexts(ctx, requestHeader, keyExchangeData);
-        
+
         // Update the stored service tokens.
         final MasterToken tokenVerificationMasterToken = (keyExchangeData != null) ? keyExchangeData.keyResponseData.getMasterToken() : masterToken;
         final Set<ServiceToken> serviceTokens = requestHeader.getServiceTokens();
         storeServiceTokens(ctx, tokenVerificationMasterToken, userIdToken, serviceTokens);
-        
+
         // We will either use the header crypto context or the key exchange
         // data crypto context in trusted network mode to process the message
         // payloads.
@@ -1664,28 +1637,28 @@ public class MslControl {
             payloadCryptoContext = keyExchangeData.cryptoContext;
         else
             payloadCryptoContext = requestHeader.getCryptoContext();
-        
+
         // Send the request.
         final OutputStream os = (filterFactory != null) ? filterFactory.getOutputStream(out) : out;
         final MessageOutputStream request = streamFactory.createOutputStream(ctx, os, requestHeader, payloadCryptoContext);
         request.closeDestination(closeDestination);
-        
+
         // If it is okay to write the data then ask the application to write it
         // and return the real output stream. Otherwise it will be asked to do
         // so after the handshake is completed.
         if (!handshake)
             msgCtx.write(request);
-        
+
         // Return the result.
         return new SendResult(request, handshake);
     }
-    
+
     /**
      * <p>Receive a message.</p>
-     * 
+     *
      * <p>If a message is received the stored master tokens, crypto contexts,
      * user ID tokens, and service tokens will be updated.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param in remote entity input stream.
@@ -1733,7 +1706,7 @@ public class MslControl {
         final ErrorHeader errorHeader = response.getErrorHeader();
         final MessageDebugContext debugCtx = msgCtx.getDebugContext();
         if (debugCtx != null) debugCtx.receivedHeader((responseHeader != null) ? responseHeader : errorHeader);
-        
+
         // Pull the response master token or entity authentication data and
         // user ID token or user authentication data to attach them to any
         // thrown exceptions.
@@ -1771,18 +1744,26 @@ public class MslControl {
                         throw new MslMessageException(MslError.UNEXPECTED_RESPONSE_MESSAGE_ID, "expected " + expectedMessageId + "; received " + responseMessageId);
                 }
             }
-            
-            // Reject if the sender is equal to this entity.
-            final String localIdentity = ctx.getEntityAuthenticationData(null).getIdentity();
-            final String sender = getIdentity(response);
-            if (localIdentity != null && sender != null && localIdentity.equals(sender))
-                throw new MslMessageException(MslError.UNEXPECTED_MESSAGE_SENDER, sender);
-            
-            // Reject if a recipient was specified and it is not equal to the
-            // message entity identity.
+
+            // Verify expected identity if specified.
             final String expectedIdentity = msgCtx.getRemoteEntityIdentity();
-            if (expectedIdentity != null && sender != null && !expectedIdentity.equals(sender))
-                throw new MslMessageException(MslError.MESSAGE_SENDER_MISMATCH, "expected " + expectedIdentity + "; received " + sender);
+            if (expectedIdentity != null) {
+                // Reject if the remote entity identity is not equal to the
+                // message entity authentication data identity.
+                if (entityAuthData != null) {
+                    final String entityAuthIdentity = entityAuthData.getIdentity();
+                    if (entityAuthIdentity != null && !expectedIdentity.equals(entityAuthIdentity))
+                        throw new MslMessageException(MslError.MESSAGE_SENDER_MISMATCH, "expected " + expectedIdentity + "; received " + entityAuthIdentity);
+                }
+
+                // Reject if in peer-to-peer mode and the message sender does
+                // not match.
+                if (ctx.isPeerToPeer()) {
+                    final String sender = response.getIdentity();
+                    if (sender != null && !expectedIdentity.equals(sender))
+                        throw new MslMessageException(MslError.MESSAGE_SENDER_MISMATCH, "expected " + expectedIdentity + "; received " + sender);
+                }
+            }
 
             // Process the response.
             if (responseHeader != null) {
@@ -1816,7 +1797,7 @@ public class MslControl {
                 // Update the stored service tokens.
                 storeServiceTokens(ctx, tokenVerificationMasterToken, localUserIdToken, serviceTokens);
             }
-            
+
             // Update the synchronized clock if we are a trusted network client
             // (there is a request) or peer-to-peer entity.
             final Date timestamp = (responseHeader != null) ? responseHeader.getTimestamp() : errorHeader.getTimestamp();
@@ -1829,11 +1810,11 @@ public class MslControl {
             e.setUserAuthenticationData(userAuthData);
             throw e;
         }
-        
+
         // Return the result.
         return response;
     }
-    
+
     /**
      * Indicates response expectations for a specific request.
      */
@@ -1852,7 +1833,7 @@ public class MslControl {
     private static class SendReceiveResult extends SendResult {
         /**
          * Create a new result with the provided response and send result.
-         * 
+         *
          * @param response response message input stream. May be {@code null}.
          * @param sent sent message result.
          */
@@ -1860,11 +1841,11 @@ public class MslControl {
             super(sent.request, sent.handshake);
             this.response = response;
         }
-        
+
         /** The response message input stream. */
         public final MessageInputStream response;
     }
-    
+
     /**
      * <p>Send the provided request and optionally receive a response from the
      * remote entity. The method will attempt to receive a response if one of
@@ -1875,10 +1856,10 @@ public class MslControl {
      * <li>key request data appears in the request</li>
      * <li>a renewable message with user authentication data was sent</li>
      * </ul></p>
-     * 
+     *
      * <p>This method is only used from trusted network clients and peer-to-
      * peer entities.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param in remote entity input stream.
@@ -1886,7 +1867,7 @@ public class MslControl {
      * @param builder request message builder.
      * @param receive indicates if a response should always be expected, should
      *        only be expected if the master token or user ID token will be
-     *        renewed, or should never be expected. 
+     *        renewed, or should never be expected.
      * @param closeStreams true if the remote entity input and output streams
      *        must be closed when the constructed message input and output
      *        streams are closed.
@@ -1933,7 +1914,7 @@ public class MslControl {
         } catch (final InterruptedException e) {
             // Release the master token lock.
             releaseMasterToken(ctx, builder.getMasterToken());
-            
+
             // This should only be if we were cancelled so return null.
             return null;
         } catch (final TimeoutException | RuntimeException e) {
@@ -1949,7 +1930,7 @@ public class MslControl {
             // Send the request.
             builder.setRenewable(renewing);
             sent = send(ctx, msgCtx, out, builder, closeStreams);
-            
+
             // Receive the response if expected, if we sent a handshake request,
             // or if we expect a response when renewing tokens and either key
             // request data was included or a master token and user
@@ -1963,7 +1944,7 @@ public class MslControl {
             {
                 response = receive(ctx, msgCtx, in, requestHeader);
                 response.closeSource(closeStreams);
-                
+
                 // If we received an error response then cleanup.
                 final ErrorHeader errorHeader = response.getErrorHeader();
                 if (errorHeader != null)
@@ -1973,11 +1954,11 @@ public class MslControl {
             // Release the renewal lock.
             if (renewing)
                 releaseRenewalLock(ctx, renewalQueue, response);
-            
+
             // Release the master token lock.
             releaseMasterToken(ctx, builder.getMasterToken());
         }
-        
+
         // Return the response.
         return new SendReceiveResult(response, sent);
     }
@@ -1985,14 +1966,14 @@ public class MslControl {
     /**
      * <p>Attempt to acquire the renewal lock if the message will need it using
      * the given blocking queue.</p>
-     * 
+     *
      * <p>If anti-replay is required then this method will block until the
      * renewal lock is acquired.</p>
-     * 
+     *
      * <p>If the message has already been marked renewable then this method
      * will block until the renewal lock is acquired or a renewing thread
      * delivers a new master token to this builder.</p>
-     * 
+     *
      * <p>If encryption is required but the builder will not be able to encrypt
      * the message payloads, or if integrity protection is required but the
      * builder will not be able to integrity protect the message payloads, or
@@ -2001,26 +1982,26 @@ public class MslControl {
      * be able to encrypt and integrity protect the message header, then this
      * method will block until the renewal lock is acquired or a renewing
      * thread delivers a master token to this builder.</p>
-     * 
+     *
      * <p>If the message is requesting tokens in response but there is no
      * master token, or there is no user ID token but the message is associated
      * with a user, then this method will block until the renewal lock is
      * acquired or a renewing thread delivers a master token to this builder
      * and a user ID token is also available if the message is associated with
      * a user.</p>
-     * 
+     *
      * <p>If there is no master token, or either the master token or the user
      * ID token is renewable, or there is no user ID token but the message is
      * associated with a user and the builder will be able to encrypt the
      * message header then this method will attempt to acquire the renewal
      * lock. If unable to do so, it returns null.</p>
-     * 
+     *
      * <p>If this method returns true, then the renewal lock must be released by
      * calling {@code releaseRenewalLock()}.</p>
-     * 
+     *
      * <p>This method is only used from trusted network clients and peer-to-
      * peer entities.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param queue caller's blocking queue.
@@ -2040,7 +2021,7 @@ public class MslControl {
         MasterToken masterToken = builder.getMasterToken();
         UserIdToken userIdToken = builder.getUserIdToken();
         final String userId = msgCtx.getUserId();
-        
+
         // If the application data needs to be encrypted and the builder will
         // not encrypt payloads, or the application data needs to be integrity
         // protected and the builder will not integrity protect payloads, or if
@@ -2070,16 +2051,16 @@ public class MslControl {
                 // replayable. Try to acquire the renewal lock on this MSL
                 // context so we can send a handshake message.
                 final BlockingQueue<MasterToken> ctxRenewingQueue = renewingContexts.putIfAbsent(ctx, queue);
-                
+
                 // If there is no one else already renewing then our queue has
                 // acquired the renewal lock.
                 if (ctxRenewingQueue == null)
                     return true;
-                
+
                 // Otherwise we need to wait for a master token from the
                 // renewing request.
                 final MasterToken newMasterToken = ctxRenewingQueue.poll(timeout, TimeUnit.MILLISECONDS);
-                
+
                 // If timed out throw an exception.
                 if (newMasterToken == null)
                     throw new TimeoutException("acquireRenewalLock timed out.");
@@ -2087,12 +2068,12 @@ public class MslControl {
                 // Put the same master token back on the renewing queue so
                 // anyone else waiting can also proceed.
                 ctxRenewingQueue.add(newMasterToken);
-                
+
                 // If the renewing request did not acquire a master token then
                 // try again to acquire renewal ownership.
                 if (newMasterToken == NULL_MASTER_TOKEN)
                     continue;
-                
+
                 // If the new master token is not equal to the previous master
                 // token then release the previous master token and get the
                 // newest master token.
@@ -2103,14 +2084,14 @@ public class MslControl {
                 if (masterToken == null || !masterToken.equals(newMasterToken)) {
                     releaseMasterToken(ctx, masterToken);
                     masterToken = getNewestMasterToken(ctx);
-                    
+
                     // If there is no newest master token (it could have been
                     // deleted despite just being delivered to us) then try
                     // again to acquire renewal ownership.
                     if (masterToken == null)
                         continue;
                 }
-                
+
                 // The renewing request may have acquired a new user ID token.
                 // Attach it to this message if the message is associated with
                 // a user and we do not already have a user ID token.
@@ -2125,22 +2106,22 @@ public class MslControl {
                     final UserIdToken storedUserIdToken = ctx.getMslStore().getUserIdToken(userId);
                     userIdToken = (storedUserIdToken != null && storedUserIdToken.isBoundTo(masterToken)) ? storedUserIdToken : null;
                 }
-                
+
                 // Update the message's master token and user ID token.
                 builder.setAuthTokens(masterToken, userIdToken);
-                
+
                 // If the new master token is still expired then try again to
                 // acquire renewal ownership.
                 final Date updateTime = ctx.getRemoteTime();
                 if (masterToken.isExpired(updateTime))
                     continue;
-                
+
                 // If this message is already marked renewable and the received
                 // master token is the same as the previous master token then
                 // we must still attempt to acquire the renewal lock.
                 if (builder.isRenewable() && masterToken.equals(previousMasterToken))
                     continue;
-                
+
                 // If this message is requesting tokens and is associated with
                 // a user but there is no user ID token then we must still
                 // attempt to acquire the renewal lock.
@@ -2152,7 +2133,7 @@ public class MslControl {
                 break;
             } while (true);
         }
-        
+
         // If we do not have a master token or the master token should be
         // renewed, or we do not have a user ID token but the message is
         // associated with a user, or if the user ID token should be renewed,
@@ -2164,32 +2145,32 @@ public class MslControl {
         {
             // Try to acquire the renewal lock on this MSL context.
             final BlockingQueue<MasterToken> ctxRenewingQueue = renewingContexts.putIfAbsent(ctx, queue);
-            
+
             // If there is no one else already renewing then our queue has
             // acquired the renewal lock.
             if (ctxRenewingQueue == null)
                 return true;
-            
+
             // Otherwise proceed without acquiring the lock.
             return false;
         }
-        
+
         // Otherwise we do not need to acquire the renewal lock.
         return false;
     }
-    
+
     /**
      * <p>Release the renewal lock.</p>
-     * 
+     *
      * <p>Delivers any received master token to the blocking queue. This may be
      * a null value if an error message was received or if the received message
      * does not contain a master token for the local entity.</p>
-     * 
+     *
      * <p>If no message was received a null master token will be delivered.</p>
-     * 
+     *
      * <p>This method is only used from trusted network clients and peer-to-
      * peer entities.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param queue caller's blocking queue.
      * @param message received message. May be null if no message was received.
@@ -2198,7 +2179,7 @@ public class MslControl {
         // Sanity check.
         if (renewingContexts.get(ctx) != queue)
             throw new IllegalStateException("Attempt to release renewal lock that is not owned by this queue.");
-        
+
         // If no message was received then deliver a null master token, release
         // the lock, and return immediately.
         if (message == null) {
@@ -2206,7 +2187,7 @@ public class MslControl {
             renewingContexts.remove(ctx);
             return;
         }
-        
+
         // If we received an error message then deliver a null master token,
         // release the lock, and return immediately.
         final MessageHeader messageHeader = message.getMessageHeader();
@@ -2215,7 +2196,7 @@ public class MslControl {
             renewingContexts.remove(ctx);
             return;
         }
-        
+
         // If we performed key exchange then the renewed master token should be
         // delivered.
         final KeyResponseData keyResponseData = messageHeader.getKeyResponseData();
@@ -2242,14 +2223,14 @@ public class MslControl {
             else
                 queue.add(NULL_MASTER_TOKEN);
         }
-        
+
         // Release the lock.
         renewingContexts.remove(ctx);
     }
-    
+
     /**
      * Send an error response over the provided output stream.
-     * 
+     *
      * @param ctx MSL context.
      * @param debugCtx message debug context.
      * @param requestHeader message the error is being sent in response to. May
@@ -2272,7 +2253,7 @@ public class MslControl {
         // Create error header.
         final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(ctx, messageId, error, userMessage);
         if (debugCtx != null) debugCtx.sentHeader(errorHeader);
-        
+
         // Determine encoder format.
         final MslEncoderFactory encoder = ctx.getMslEncoderFactory();
         final MessageCapabilities capabilities = (requestHeader != null)
@@ -2280,17 +2261,17 @@ public class MslControl {
             : ctx.getMessageCapabilities();
         final Set<MslEncoderFormat> formats = (capabilities != null) ? capabilities.getEncoderFormats() : null;
         final MslEncoderFormat format = encoder.getPreferredFormat(formats);
-        
+
         // Send error response.
         final MessageOutputStream response = streamFactory.createOutputStream(ctx, out, errorHeader, format);
         response.close();
     }
-    
+
     /**
      * <p>This service receives a request from a remote entity, and either
      * returns the received message or automatically generates a reply (and
      * returns null).</p>
-     * 
+     *
      * <p>This class will only be used by trusted-network servers and peer-to-
      * peer servers.</p>
      */
@@ -2305,10 +2286,10 @@ public class MslControl {
         private final OutputStream out;
         /** Read timeout in milliseconds. */
         private final int timeout;
-        
+
         /**
          * Create a new message receive service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param in remote entity input stream.
@@ -2322,7 +2303,7 @@ public class MslControl {
             this.out = out;
             this.timeout = timeout;
         }
-        
+
         /**
          * @return the received message or {@code null} if cancelled.
          * @throws MslException if there was an error with the received message
@@ -2338,7 +2319,7 @@ public class MslControl {
         @Override
         public MessageInputStream call() throws MslException, MslErrorResponseException, IOException, TimeoutException {
             final MessageDebugContext debugCtx = msgCtx.getDebugContext();
-            
+
             // Read the incoming message.
             final MessageInputStream request;
             try {
@@ -2349,7 +2330,7 @@ public class MslControl {
             } catch (final MslException e) {
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
-                
+
                 // Try to send an error response.
                 try {
                     final MslError error = e.getError();
@@ -2358,35 +2339,35 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error receiving the message header.", rt, e);
                 }
                 throw e;
             } catch (final IOException e) {
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
-                
+
                 // Maybe we can send an error response.
                 try {
                     sendError(ctx, debugCtx, null, null, MslError.MSL_COMMS_FAILURE, null, out);
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error receiving the message header.", rt, e);
                 }
                 throw e;
             } catch (final Throwable t) {
                 // If we were cancelled then return null.
                 if (cancelled(t)) return null;
-                
+
                 // Try to send an error response.
                 try {
                     sendError(ctx, debugCtx, null, null, MslError.INTERNAL_EXCEPTION, null, out);
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error receiving the message header.", rt, t);
                 }
                 throw new MslInternalException("Error receiving the message header.", t);
@@ -2396,7 +2377,7 @@ public class MslControl {
             final MessageHeader requestHeader = request.getMessageHeader();
             if (requestHeader == null)
                 return request;
-            
+
             // If the message is not a handshake message deliver it to the
             // caller.
             try {
@@ -2405,7 +2386,7 @@ public class MslControl {
             } catch (final MslException e) {
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
-                
+
                 // Try to send an error response.
                 try {
                     final MslError error = e.getError();
@@ -2414,14 +2395,14 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error peeking into the message payloads.", rt, e);
                 }
                 throw e;
             } catch (final Throwable t) {
                 // If we were cancelled then return null.
                 if (cancelled(t)) return null;
-                
+
                 // Try to send an error response.
                 try {
                     final Long requestMessageId = requestHeader.getMessageId();
@@ -2429,12 +2410,12 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error peeking into the message payloads.", rt, t);
                 }
                 throw new MslInternalException("Error peeking into the message payloads.", t);
             }
-            
+
             // This is a handshake request so automatically return a response.
             final MessageBuilder responseBuilder;
             try {
@@ -2447,7 +2428,7 @@ public class MslControl {
             } catch (final MslException e) {
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
-                
+
                 // Try to send an error response.
                 try {
                     final MslError error = e.getError();
@@ -2458,14 +2439,14 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error creating an automatic handshake response.", rt, e);
                 }
                 throw e;
             } catch (final Throwable t) {
                 // If we were cancelled then return null.
                 if (cancelled(t)) return null;
-                
+
                 // Try to send an error response.
                 try {
                     final Long requestMessageId = requestHeader.getMessageId();
@@ -2473,14 +2454,14 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error creating an automatic handshake response.", rt, t);
                 }
                 throw new MslInternalException("Error creating an automatic handshake response.", t);
             } finally {
                 try { request.close(); } catch (final IOException e) {}
             }
-            
+
             // If we are in trusted services mode then no additional data is
             // expected. Send the handshake response and return null. The next
             // message from the remote entity can be retrieved by another call
@@ -2497,7 +2478,7 @@ public class MslControl {
                 } catch (final MslException e) {
                     // If we were cancelled then return null.
                     if (cancelled(e)) return null;
-                    
+
                     // Try to send an error response.
                     try {
                         final Long requestMessageId = requestHeader.getMessageId();
@@ -2509,14 +2490,14 @@ public class MslControl {
                     } catch (final Throwable rt) {
                         // If we were cancelled then return null.
                         if (cancelled(rt)) return null;
-                        
+
                         throw new MslErrorResponseException("Error sending an automatic handshake response.", rt, e);
                     }
                     throw e;
                 } catch (final IOException e) {
                     // If we were cancelled then return null.
                     if (cancelled(e)) return null;
-                    
+
                     // Maybe we can send an error response.
                     try {
                         final Long requestMessageId = requestHeader.getMessageId();
@@ -2524,14 +2505,14 @@ public class MslControl {
                     } catch (final Throwable rt) {
                         // If we were cancelled then return null.
                         if (cancelled(rt)) return null;
-                        
+
                         throw new MslErrorResponseException("Error sending an automatic handshake response.", rt, e);
                     }
                     throw e;
                 } catch (final Throwable t) {
                     // If we were cancelled then return null.
                     if (cancelled(t)) return null;
-                    
+
                     // Try to send an error response.
                     try {
                         final Long requestMessageId = requestHeader.getMessageId();
@@ -2539,7 +2520,7 @@ public class MslControl {
                     } catch (final Throwable rt) {
                         // If we were cancelled then return null.
                         if (cancelled(rt)) return null;
-                        
+
                         throw new MslErrorResponseException("Error sending an automatic handshake response.", rt, t);
                     }
                     throw new MslInternalException("Error sending an automatic handshake response.", t);
@@ -2549,7 +2530,7 @@ public class MslControl {
                         releaseMasterToken(ctx, responseBuilder.getMasterToken());
                 }
             }
-            
+
             // Since we are in peer-to-peer mode our response may contain key
             // request data. Therefore we may receive another request after the
             // remote entity's key exchange completes containing peer
@@ -2561,7 +2542,7 @@ public class MslControl {
             // We have received one message.
             final RequestService service = new RequestService(ctx, keyxMsgCtx, in, out, responseBuilder, timeout, 1);
             final MslChannel channel = service.call();
-            
+
             // The MSL channel message output stream can be discarded since it
             // only contained a handshake response.
             if (channel != null)
@@ -2569,10 +2550,10 @@ public class MslControl {
             return null;
         }
     }
-    
+
     /**
      * <p>This service sends a response to the remote entity.</p>
-     * 
+     *
      * <p>This class will only be used trusted network servers and peer-to-peer
      * servers.</p>
      */
@@ -2589,10 +2570,10 @@ public class MslControl {
         protected final OutputStream out;
         /** Read timeout in milliseconds. */
         protected final int timeout;
-        
+
         /**
          * Create a new message respond service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param in remote entity input stream.
@@ -2610,10 +2591,10 @@ public class MslControl {
             this.request = request;
             this.timeout = timeout;
         }
-        
+
         /**
          * Send the response as a trusted network server.
-         * 
+         *
          * @param builder response message builder.
          * @param msgCount number of messages that have already been sent or
          *        received.
@@ -2634,11 +2615,11 @@ public class MslControl {
             try {
                 final MessageDebugContext debugCtx = msgCtx.getDebugContext();
                 final MessageHeader requestHeader = request.getMessageHeader();
-                
+
                 // Do nothing if we cannot send one more message.
                 if (msgCount + 1 > MslConstants.MAX_MESSAGES)
                     return null;
-                
+
                 // If the response must be encrypted or integrity protected but
                 // cannot then send an error requesting it. The client must re-
                 // initiate the transaction.
@@ -2658,11 +2639,11 @@ public class MslControl {
                     } catch (final Throwable rt) {
                         // If we were cancelled then return null.
                         if (cancelled(rt)) return null;
-                        
+
                         throw new MslErrorResponseException("Response requires encryption or integrity protection but cannot be protected: " + securityRequired, rt, null);
                     }
                 }
-                
+
                 // If the response wishes to attach a user ID token but there is no
                 // master token then send an error requesting the master token. The
                 // client must re-initiate the transaction.
@@ -2675,11 +2656,11 @@ public class MslControl {
                     } catch (final Throwable rt) {
                         // If we were cancelled then return null.
                         if (cancelled(rt)) return null;
-                        
+
                         throw new MslErrorResponseException("Response wishes to attach a user ID token but there is no master token.", rt, null);
                     }
                 }
-                
+
                 // Otherwise simply send the response.
                 builder.setRenewable(false);
                 final SendResult result = send(ctx, msgCtx, out, builder, false);
@@ -2689,10 +2670,10 @@ public class MslControl {
                 releaseMasterToken(ctx, builder.getMasterToken());
             }
         }
-        
+
         /**
          * Send the response as a peer-to-peer entity.
-         * 
+         *
          * @param msgCtx message context.
          * @param builder response message builder.
          * @param msgCount number of messages sent or received so far.
@@ -2714,7 +2695,7 @@ public class MslControl {
         protected MslChannel peerToPeerExecute(final MessageContext msgCtx, final MessageBuilder builder, int msgCount) throws MslException, IOException, InterruptedException, MslErrorResponseException, TimeoutException {
             final MessageDebugContext debugCtx = msgCtx.getDebugContext();
             final MessageHeader requestHeader = request.getMessageHeader();
-            
+
             // Do nothing if we cannot send and receive two more messages.
             //
             // Make sure to release the master token lock.
@@ -2722,7 +2703,7 @@ public class MslControl {
                 releaseMasterToken(ctx, builder.getMasterToken());
                 return null;
             }
-            
+
             // If the response wishes to attach a user ID token but there is no
             // master token then send an error requesting the master token. The
             // client must re-initiate the transaction.
@@ -2737,11 +2718,11 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Response wishes to attach a user ID token but there is no master token.", rt, null);
                 }
             }
-            
+
             // Send the response. A reply is not expected, but may be received.
             // This adds two to our message count.
             //
@@ -2749,12 +2730,12 @@ public class MslControl {
             final SendReceiveResult result = sendReceive(ctx, msgCtx, in, out, builder, Receive.RENEWING, false, timeout);
             final MessageInputStream response = result.response;
             msgCount += 2;
-            
+
             // If we did not receive a response then we're done. Return the
             // original message input stream and the new message output stream.
             if (response == null)
                 return new MslChannel(request, result.request);
-            
+
             // If the response is an error see if we can handle the error and
             // retry.
             final MessageHeader responseHeader = response.getMessageHeader();
@@ -2767,7 +2748,7 @@ public class MslControl {
                     if (cancelled(t)) return null;
                     // Otherwise we don't care about an exception on close.
                 }
-                
+
                 // Build the error response. This will acquire the master token
                 // lock.
                 final ErrorHeader errorHeader = response.getErrorHeader();
@@ -2776,7 +2757,7 @@ public class MslControl {
                 // If there is no error response then return the error.
                 if (errMsg == null)
                     return null;
-                
+
                 // Send the error response. Recursively execute this because it
                 // may take multiple messages to succeed with sending the
                 // response.
@@ -2787,7 +2768,7 @@ public class MslControl {
                 final MessageContext resendMsgCtx = errMsg.msgCtx;
                 return peerToPeerExecute(resendMsgCtx, requestBuilder, msgCount);
             }
-            
+
             // If we performed a handshake then re-send the message over the
             // same connection so this time the application can send its data.
             if (result.handshake) {
@@ -2799,7 +2780,7 @@ public class MslControl {
                     if (cancelled(t)) return null;
                     // Otherwise we don't care about an exception on close.
                 }
-                
+
                 // This will acquire the local entity's master token read lock.
                 // The master token lock will be released by the recursive call
                 // to peerToPeerExecute().
@@ -2807,13 +2788,13 @@ public class MslControl {
                 final MessageBuilder requestBuilder = buildResponse(ctx, resendMsgCtx, responseHeader);
                 return peerToPeerExecute(resendMsgCtx, requestBuilder, msgCount);
             }
-            
+
             // Otherwise we did send our application data (which may have been
             // zero-length) so we do not need to re-send our message. Return
             // the new message input stream and the new message output stream.
             return new MslChannel(result.response, result.request);
         }
-        
+
         /**
          * @return a {@link MslChannel} on success or {@code null} if cancelled,
          *         interrupted, if an error response was received (peer-to-peer
@@ -2829,7 +2810,7 @@ public class MslControl {
         @Override
         public MslChannel call() throws MslException, MslErrorResponseException, IOException {
             final MessageDebugContext debugCtx = msgCtx.getDebugContext();
-            
+
             final MessageHeader requestHeader = request.getMessageHeader();
             final MessageBuilder builder;
             try {
@@ -2842,7 +2823,7 @@ public class MslControl {
             } catch (final MslException e) {
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
-                
+
                 try {
                     final MslError error = e.getError();
                     final MessageCapabilities caps = requestHeader.getMessageCapabilities();
@@ -2856,7 +2837,7 @@ public class MslControl {
             } catch (final Throwable t) {
                 // If we were cancelled then return null.
                 if (cancelled(t)) return null;
-                
+
                 try {
                     sendError(ctx, debugCtx, requestHeader, null, MslError.INTERNAL_EXCEPTION, null, out);
                 } catch (final Throwable rt) {
@@ -2864,7 +2845,7 @@ public class MslControl {
                 }
                 throw new MslInternalException("Error building the response.", t);
             }
-            
+
             // At most three messages would have been involved in the original
             // receive.
             try {
@@ -2874,11 +2855,11 @@ public class MslControl {
                     channel = trustedNetworkExecute(builder, 3);
                 else
                     channel = peerToPeerExecute(msgCtx, builder, 3);
-                
+
                 // Clear any cached payloads.
                 if (channel != null)
                     channel.output.stopCaching();
-                
+
                 // Return the established channel.
                 return channel;
             } catch (final InterruptedException e) {
@@ -2895,7 +2876,7 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error sending the response.", rt, e);
                 }
                 throw e;
@@ -2936,10 +2917,10 @@ public class MslControl {
             }
         }
     }
-    
+
     /**
      * <p>This service sends an error response to the remote entity.</p>
-     * 
+     *
      * <p>This class will only be used trusted network servers and peer-to-peer
      * entities.</p>
      */
@@ -2954,10 +2935,10 @@ public class MslControl {
         private final MessageInputStream request;
         /** Remote entity output stream. */
         private final OutputStream out;
-        
+
         /**
          * Create a new error service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param err the application error.
@@ -2984,7 +2965,7 @@ public class MslControl {
         public Boolean call() throws MslException {
             final MessageDebugContext debugCtx = msgCtx.getDebugContext();
             final MessageHeader header = request.getMessageHeader();
-            
+
             try {
                 // Identify the correct MSL error.
                 final MslError error;
@@ -3002,36 +2983,36 @@ public class MslControl {
                     default:
                         throw new MslInternalException("Unhandled application error " + appError + ".");
                 }
-                
+
                 // Build and send the error response.
                 final MessageCapabilities caps = header.getMessageCapabilities();
                 final List<String> languages = (caps != null) ? caps.getLanguages() : null;
                 final String userMessage = messageRegistry.getUserMessage(error, languages);
                 sendError(ctx, debugCtx, header, header.getMessageId(), error, userMessage, out);
-                
+
                 // Success.
                 return Boolean.TRUE;
             } catch (final MslException e) {
                 // If we were cancelled then return false.
                 if (cancelled(e)) return false;
-                
+
                 // We failed to return an error response. Deliver the exception
                 // to the application.
                 throw e;
             } catch (final Throwable t) {
                 // If we were cancelled then return false.
                 if (cancelled(t)) return false;
-                
+
                 // An unexpected exception occurred.
                 throw new MslInternalException("Error building the error response.", t);
             }
         }
     }
-    
+
     /**
      * <p>This service sends a request to the remote entity and returns the
      * response.</p>
-     * 
+     *
      * <p>This class will only be used by trusted network clients, peer-to-peer
      * clients, and peer-to-peer servers.</p>
      */
@@ -3056,13 +3037,13 @@ public class MslControl {
         private final int timeout;
         /** Number of messages sent or received so far. */
         private final int msgCount;
-        
+
         /** True if the maximum message count is hit. */
         private boolean maxMessagesHit = false;
-        
+
         /**
          * Create a new message request service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param remoteEntity remote entity URL.
@@ -3082,10 +3063,10 @@ public class MslControl {
             this.timeout = timeout;
             this.msgCount = 0;
         }
-        
+
         /**
          * Create a new message request service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param in remote entity input stream.
@@ -3106,10 +3087,10 @@ public class MslControl {
             this.timeout = timeout;
             this.msgCount = 0;
         }
-        
+
         /**
          * Create a new message request service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param remoteEntity remote entity URL.
@@ -3132,10 +3113,10 @@ public class MslControl {
             this.timeout = timeout;
             this.msgCount = msgCount;
         }
-        
+
         /**
          * Create a new message request service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param in remote entity input stream.
@@ -3157,14 +3138,14 @@ public class MslControl {
             this.timeout = timeout;
             this.msgCount = msgCount;
         }
-        
+
         /**
          * <p>Send the provided request and receive a response from the remote
          * entity. Any necessary handshake messages will be sent.</p>
-         * 
+         *
          * <p>If an error was received and cannot be handled the returned MSL
          * channel will have {@code null} for its message output stream.</p>
-         * 
+         *
          * @param msgCtx message context.
          * @param builder request message builder.
          * @param timeout renewal lock acquisition timeout in milliseconds.
@@ -3189,7 +3170,7 @@ public class MslControl {
                 maxMessagesHit = true;
                 return null;
             }
-            
+
             // Send the request and receive the response. This adds two to our
             // message count.
             //
@@ -3198,7 +3179,7 @@ public class MslControl {
             final MessageOutputStream request = result.request;
             final MessageInputStream response = result.response;
             msgCount += 2;
-            
+
             // If we did not receive a response then we're done. Return the
             // new message output stream.
             if (response == null)
@@ -3224,7 +3205,7 @@ public class MslControl {
                     if (cancelled(e)) return null;
                     // Otherwise we don't care about an I/O exception on close.
                 }
-                
+
                 // Build the error response. This will acquire the master token
                 // lock.
                 final ErrorHeader errorHeader = response.getErrorHeader();
@@ -3254,24 +3235,24 @@ public class MslControl {
                     // call to execute().
                     newChannel = execute(resendMsgCtx, requestBuilder, timeout, msgCount);
                 }
-                
+
                 // If the maximum message count was hit or if there is no new
                 // response then return the original error response.
                 if (maxMessagesHit || (newChannel != null && newChannel.input == null))
                     return new MslChannel(response, null);
-                
+
                 // Return the new channel, which may contain an error or be
                 // null if cancelled or interrupted.
                 return newChannel;
             }
-            
+
             // If we are in trusted network mode...
             if (!ctx.isPeerToPeer()) {
                 // If we did not perform a handshake then we're done. Deliver
                 // the response.
                 if (!result.handshake)
                     return new MslChannel(response, request);
-                
+
                 // We did perform a handshake. Re-send the message over a new
                 // connection to allow the application to send its data.
                 //
@@ -3299,7 +3280,7 @@ public class MslControl {
                 final RequestService service = new RequestService(ctx, resendMsgCtx, remoteEntity, requestBuilder, expectResponse, timeout, msgCount);
                 return service.call();
             }
-            
+
             // We are in peer-to-peer mode...
             //
             // If we did perform a handshake. Re-send the message over the same
@@ -3322,7 +3303,7 @@ public class MslControl {
                     if (cancelled(e)) return null;
                     // Otherwise we don't care about an I/O exception on close.
                 }
-                
+
                 // Now resend.
                 //
                 // The master token lock acquired from buildResponse() will be
@@ -3331,7 +3312,7 @@ public class MslControl {
                 final MessageBuilder requestBuilder = buildResponse(ctx, msgCtx, responseHeader);
                 return execute(resendMsgCtx, requestBuilder, timeout, msgCount);
             }
-            
+
             // Otherwise we did send our application data (which may have been
             // zero-length) so we do not need to re-send our message.
             //
@@ -3346,7 +3327,7 @@ public class MslControl {
                 // Build the response. This will acquire the master token lock.
                 final MessageContext keyxMsgCtx = new KeyxResponseMessageContext(msgCtx);
                 final MessageBuilder keyxBuilder = buildResponse(ctx, keyxMsgCtx, responseHeader);
-                
+
                 try {
                     // If the response is not a handshake message then we do not
                     // expect a reply.
@@ -3359,7 +3340,7 @@ public class MslControl {
                             if (cancelled(e)) return null;
                             // Otherwise we don't care about an I/O exception on close.
                         }
-                        
+
                         // The remote entity is expecting a response. We need
                         // to send it even if this exceeds the maximum number of
                         // messages. We're guaranteed to stop sending more
@@ -3371,7 +3352,7 @@ public class MslControl {
                         final SendResult newResult = send(ctx, keyxMsgCtx, out, keyxBuilder, openedStreams);
                         return new MslChannel(response, newResult.request);
                     }
-                    
+
                     // Otherwise the remote entity may still have to send us the
                     // application data in a reply.
                     else {
@@ -3391,7 +3372,7 @@ public class MslControl {
                             if (cancelled(e)) return null;
                             // Otherwise we don't care about an I/O exception on close.
                         }
-                        
+
                         return execute(keyxMsgCtx, keyxBuilder, timeout, msgCount);
                     }
                 } finally {
@@ -3399,11 +3380,11 @@ public class MslControl {
                     releaseMasterToken(ctx, keyxBuilder.getMasterToken());
                 }
             }
-            
+
             // Return the established MSL channel to the caller.
             return new MslChannel(response, request);
         }
-        
+
         /**
          * @return the established MSL channel or {@code null} if cancelled or
          *         interrupted.
@@ -3423,7 +3404,7 @@ public class MslControl {
                 try {
                     // Set up the connection.
                     remoteEntity.setTimeout(timeout);
-                    
+
                     // Connect. Keep track of how much time this takes to subtract
                     // that from the lock timeout timeout.
                     final long start = System.currentTimeMillis();
@@ -3437,12 +3418,12 @@ public class MslControl {
                     // master token read lock.
                     if (builder != null)
                         releaseMasterToken(ctx, builder.getMasterToken());
-                    
+
                     // Close any open streams.
                     // We don't care about an I/O exception on close.
                     if (out != null) try { out.close(); } catch (final IOException ioe) { }
                     if (in != null) try { in.close(); } catch (final IOException ioe) { }
-                    
+
                     // If we were cancelled then return null.
                     if (cancelled(e)) return null;
                     throw e;
@@ -3456,13 +3437,13 @@ public class MslControl {
                     // We don't care about an I/O exception on close.
                     if (out != null) try { out.close(); } catch (final IOException ioe) { }
                     if (in != null) try { in.close(); } catch (final IOException ioe) { }
-                    
+
                     throw e;
                 }
             } else {
                 lockTimeout = timeout;
             }
-            
+
             // If no builder was provided then build a new request. This will
             // acquire the master token lock.
             if (builder == null) {
@@ -3475,20 +3456,20 @@ public class MslControl {
                         try { out.close(); } catch (final IOException ioe) { }
                         try { in.close(); } catch (final IOException ioe) { }
                     }
-                    
+
                     // We were cancelled so return null.
                     return null;
                 }
             }
-            
+
             try {
                 // Execute. This will release the master token lock.
                 final MslChannel channel = execute(msgCtx, builder, lockTimeout, msgCount);
-                
+
                 // If the channel was established clear the cached payloads.
                 if (channel != null && channel.output != null)
                     channel.output.stopCaching();
-                    
+
                 // Close the input stream if we opened it and there is no
                 // response. This may be necessary to transmit data
                 // buffered in the output stream, and the caller will not
@@ -3497,7 +3478,7 @@ public class MslControl {
                 // We don't care about an I/O exception on close.
                 if (openedStreams && (channel == null || channel.input == null))
                     try { in.close(); } catch (final IOException ioe) { }
-                
+
                 // Return the established channel.
                 return channel;
             } catch (final InterruptedException e) {
@@ -3507,7 +3488,7 @@ public class MslControl {
                     try { out.close(); } catch (final IOException ioe) { }
                     try { in.close(); } catch (final IOException ioe) { }
                 }
-                
+
                 // We were cancelled so return null.
                 return null;
             } catch (final MslException | IOException | RuntimeException | TimeoutException e) {
@@ -3517,14 +3498,14 @@ public class MslControl {
                     try { out.close(); } catch (final IOException ioe) { }
                     try { in.close(); } catch (final IOException ioe) { }
                 }
-                
+
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
                 throw e;
             }
         }
     }
-    
+
     /**
      * <p>This service sends a message to a remote entity.</p>
      *
@@ -3534,10 +3515,10 @@ public class MslControl {
     private class SendService implements Callable<MessageOutputStream> {
         /** The request service. */
         private final RequestService requestService;
-        
+
         /**
          * Create a new message send service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param remoteEntity remote entity URL.
@@ -3547,10 +3528,10 @@ public class MslControl {
         public SendService(final MslContext ctx, final MessageContext msgCtx, final Url remoteEntity, final int timeout) {
             this.requestService = new RequestService(ctx, msgCtx, remoteEntity, Receive.NEVER, timeout);
         }
-        
+
         /**
          * Create a new message send service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param in remote entity input stream.
@@ -3583,13 +3564,13 @@ public class MslControl {
     /**
      * <p>This service sends a message to the remote entity using a request as
      * the basis for the response.</p>
-     * 
+     *
      * <p>This class will only be used trusted network servers.</p>
      */
-    public class PushService extends RespondService {    
+    public class PushService extends RespondService {
         /**
          * Create a new message push service.
-         * 
+         *
          * @param ctx MSL context.
          * @param msgCtx message context.
          * @param in remote entity input stream.
@@ -3600,7 +3581,7 @@ public class MslControl {
         public PushService(final MslContext ctx, final MessageContext msgCtx, final InputStream in, final OutputStream out, final MessageInputStream request, final int timeout) {
             super(ctx, msgCtx, in, out, request, timeout);
         }
-        
+
         /**
          * @return a {@link MslChannel} on success or {@code null} if cancelled,
          *         interrupted, if the response could not be sent encrypted or
@@ -3615,7 +3596,7 @@ public class MslControl {
         @Override
         public MslChannel call() throws MslException, MslErrorResponseException, IOException {
             final MessageDebugContext debugCtx = msgCtx.getDebugContext();
-            
+
             final MessageHeader requestHeader = request.getMessageHeader();
             final MessageBuilder builder;
             try {
@@ -3623,7 +3604,7 @@ public class MslControl {
             } catch (final MslException e) {
                 // If we were cancelled then return null.
                 if (cancelled(e)) return null;
-                
+
                 try {
                     final MslError error = e.getError();
                     final MessageCapabilities caps = requestHeader.getMessageCapabilities();
@@ -3637,7 +3618,7 @@ public class MslControl {
             } catch (final Throwable t) {
                 // If we were cancelled then return null.
                 if (cancelled(t)) return null;
-                
+
                 try {
                     sendError(ctx, debugCtx, requestHeader, null, MslError.INTERNAL_EXCEPTION, null, out);
                 } catch (final Throwable rt) {
@@ -3645,15 +3626,15 @@ public class MslControl {
                 }
                 throw new MslInternalException("Error building the message.", t);
             }
-            
+
             try {
                 // Send the message. This will release the master token lock.
                 final MslChannel channel = trustedNetworkExecute(builder, 0);
-                
+
                 // Clear any cached payloads.
                 if (channel != null)
                     channel.output.stopCaching();
-                
+
                 // Return the established channel.
                 return channel;
             } catch (final InterruptedException e) {
@@ -3670,7 +3651,7 @@ public class MslControl {
                 } catch (final Throwable rt) {
                     // If we were cancelled then return null.
                     if (cancelled(rt)) return null;
-                    
+
                     throw new MslErrorResponseException("Error pushing the message.", rt, e);
                 }
                 throw e;
@@ -3711,38 +3692,38 @@ public class MslControl {
             }
         }
     }
-    
+
     /**
      * <p>Send a message to the entity at the provided URL.</p>
-     * 
+     *
      * <p>Use of this method is not recommended as it does not confirm delivery
      * or acceptance of the message. Establishing a MSL channel to send
      * application data without requiring the remote entity to acknowledge
      * receipt in the response application data is the recommended approach.
      * Only use this method if guaranteed receipt is not required.</p>
-     * 
+     *
      * <p>This method should only be used by trusted network clients and per-
      * to-peer entities when no response is expected from the remote entity.
      * The remote entity should be using
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
      * and should not attempt to send a response.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return a {@code MessageOutputStream}
      * containing the final {@code MessageOutputStream} that should be used to
      * send any additional application data not already sent via
      * {@link MessageContext#write(MessageOutputStream)}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return {@code null} if
      * {@link #cancelled(Throwable) cancelled or interrupted}, if an error
      * response was received resulting in a failure to send the message, or if
      * the maximum number of messages is hit without sending the message.</p>
-     * 
+     *
      * <p>The {@code Future} may throw an {@code ExecutionException} whose
      * cause is a {@code MslException}, {@code IOException}, or
      * {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The caller must close the returned message output stream.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param remoteEntity remote entity URL.
@@ -3755,40 +3736,40 @@ public class MslControl {
         final SendService service = new SendService(ctx, sendMsgCtx, remoteEntity, timeout);
         return executor.submit(service);
     }
-    
+
     /**
      * <p>Send a message over the provided output stream.</p>
-     * 
+     *
      * <p>Use of this method is not recommended as it does not confirm delivery
      * or acceptance of the message. Establishing a MSL channel to send
      * application data without requiring the remote entity to acknowledge
      * receipt in the response application data is the recommended approach.
      * Only use this method if guaranteed receipt is not required.</p>
-     * 
+     *
      * <p>This method should only be used by trusted network clients and peer-
      * to-peer entities when no response is expected from the remote entity.
      * The remote entity should be using
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
      * and should not attempt to send a response.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return a {@code MessageOutputStream}
      * containing the final {@code MessageOutputStream} that should be used to
      * send any additional application data not already sent via
      * {@link MessageContext#write(MessageOutputStream)}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return {@code null} if
      * {@link #cancelled(Throwable) cancelled or interrupted}, if an error
      * response was received resulting in a failure to send the message, or if
      * the maximum number of messages is hit without sending the message.</p>
-     * 
+     *
      * <p>The {@code Future} may throw an {@code ExecutionException} whose
      * cause is a {@code MslException}, {@code IOException}, or
      * {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The caller must close the returned message output stream. The remote
      * entity output stream will not be closed when the message output stream
      * is closed, in case the caller wishes to reuse them.</p>
-     * 
+     *
      * TODO once Java supports the WebSocket protocol we can remove this method
      * in favor of the one accepting a URL parameter. (Or is it the other way
      * around?)
@@ -3810,13 +3791,13 @@ public class MslControl {
     /**
      * <p>Push a message over the provided output stream based on a message
      * received from the remote entity.</p>
-     * 
+     *
      * <p>Use of this method is not recommended as it does not perform master
      * token or user ID token issuance or renewal which the remote entity may
      * be attempting to perform. Only use this method if there is some other
      * means by which the client will be able to acquire and renew its master
      * token or user ID token on a regular basis.</p>
-     * 
+     *
      * <p>This method should only be used by trusted network servers that wish
      * to send multiple responses to a trusted network client. The remote
      * entity should be using
@@ -3824,18 +3805,18 @@ public class MslControl {
      * {@link #send(MslContext, MessageContext, InputStream, OutputStream, int)}
      * and
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
-     * 
+     *
      * <p>This method must not be used if
      * {@link MslControl#respond(MslContext, MessageContext, InputStream, OutputStream, MessageInputStream, int)}
      * has already been used with the same {@code MessageInputStream}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return a {@code MslChannel}
      * containing the same {@code MessageInputStream} that was provided and the
      * final {@code MessageOutputStream} that should be used to send any
      * additional application data not already sent via
      * {@link MessageContext#write(MessageOutputStream)} to the remote
      * entity.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return {@code null} if
      * {@link #cancelled(Throwable) canncelled or interrupted}, if the message
      * could not be sent with encryption or integrity protection when required,
@@ -3845,14 +3826,14 @@ public class MslControl {
      * new message from the remote entity to be received by a call to
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
      * before attempting to push another message.</p>
-     * 
+     *
      * <p>The {@code Future} may throw an {@code ExecutionException} whose
      * cause is a {@code MslException}, {@code MslErrorResponseException},
      * {@code IOException}, or {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The remote entity input and output streams will not be closed in case
      * the caller wishes to reuse them.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param in remote entity input stream.
@@ -3872,13 +3853,13 @@ public class MslControl {
         final PushService service = new PushService(ctx, msgCtx, in, out, request, timeout);
         return executor.submit(service);
     }
-    
+
     /**
      * <p>Receive a request over the provided input stream.</p>
-     * 
+     *
      * <p>If there is an error with the message an error response will be sent
      * over the provided output stream.</p>
-     * 
+     *
      * <p>This method should only be used to receive a request initiated by the
      * remote entity. The remote entity should have used one of the request
      * methods
@@ -3887,7 +3868,7 @@ public class MslControl {
      * or one of the send methods
      * {@link #send(MslContext, MessageContext, Url, int)} or
      * {@link #send(MslContext, MessageContext, InputStream, OutputStream, int)}.<p>
-     * 
+     *
      * <p>The returned {@code Future} will return the received
      * {@code MessageInputStream} on completion or {@code null} if a reply was
      * automatically sent (for example in response to a handshake request) or
@@ -3898,10 +3879,10 @@ public class MslControl {
      * throw an {@code ExecutionException} whose cause is a
      * {@code MslException}, {@code MslErrorResponseException},
      * {@code IOException}, or {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The remote entity input and output streams will not be closed in case
      * the caller wishes to reuse them.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param in remote entity input stream.
@@ -3913,24 +3894,24 @@ public class MslControl {
         final ReceiveService service = new ReceiveService(ctx, msgCtx, in, out, timeout);
         return executor.submit(service);
     }
-    
+
     /**
      * <p>Send a response over the provided output stream.</p>
-     * 
+     *
      * <p>This method should only be used by trusted network servers and peer-
      * to-peer entities after receiving a request via
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.
      * The remote entity should have used one of the request methods
      * {@link #request(MslContext, MessageContext, Url, int)} or
      * {@link #request(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return a {@code MslChannel}
      * containing the final {@code MessageOutputStream} that should be used to
      * send any additional application data not already sent via
      * {@link MessageContext#write(MessageOutputStream)} to the remote entity,
      * and in peer-to-peer mode may also contain a {@code MessageInputStream}
      * as described below.</p>
-     * 
+     *
      * <p>In peer-to-peer mode a new {@code MessageInputStream} may be returned
      * which should be used in place of the previous {@code MessageInputStream}
      * being responded to. This will only occur if the initial response sent
@@ -3939,7 +3920,7 @@ public class MslControl {
      * already read off of the previous {@code MessageInputStream}; it will
      * only contain new application data that is a continuation of the previous
      * message's application data.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return {@code null} if
      * {@link #cancelled(Throwable) cancelled or interrupted}, if an error
      * response was received (peer-to-peer only) resulting in a failure to
@@ -3950,14 +3931,14 @@ public class MslControl {
      * sending the message. In these cases the remote entity's next message can
      * be received by another call to
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
-     * 
+     *
      * <p>The {@code Future} may throw an {@code ExecutionException} whose
      * cause is a {@code MslException}, {@code MslErrorResponseException},
      * {@code IOException}, or {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The remote entity input and output streams will not be closed in case
      * the caller wishes to reuse them.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param in remote entity input stream.
@@ -3974,26 +3955,26 @@ public class MslControl {
         final RespondService service = new RespondService(ctx, msgCtx, in, out, request, timeout);
         return executor.submit(service);
     }
-    
+
     /**
      * <p>Send an error response over the provided output stream. Any replies
      * to the error response may be received by a subsequent call to
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.</p>
-     * 
+     *
      * <p>This method should only be used by trusted network servers and peer-
      * to-peer entities after receiving a request via
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}.
      * The remote entity should have used
      * {@link #request(MslContext, MessageContext, Url, int)}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return true on success or false if
      * {@link #cancelled(Throwable) cancelled or interrupted}. The
      * {@code Future} may throw an {@code ExecutionException} whose cause is a
      * {@code MslException} or {@code IOException}.</p>
-     * 
+     *
      * <p>The remote entity input and output streams will not be closed in case
      * the caller wishes to reuse them.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param err error type.
@@ -4012,13 +3993,13 @@ public class MslControl {
 
     /**
      * <p>Send a request to the entity at the provided URL.</p>
-     * 
+     *
      * <p>This method should only be used by trusted network clients when
      * initiating a new request. The remote entity should be using
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
      * and
      * {@link #respond(MslContext, MessageContext, InputStream, OutputStream, MessageInputStream, int)}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return a {@code MslChannel}
      * containing the final {@code MessageOutputStream} that should be used to
      * send any additional application data not already sent via
@@ -4026,7 +4007,7 @@ public class MslControl {
      * {@code MessageInputStream} of the established MSL communication
      * channel. If an error message was received then the MSL channel's message
      * output stream will be {@code null}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return {@code null} if
      * {@link #cancelled(Throwable) cancelled or interrupted}. The returned
      * message may be an error message if the maximum number of messages is hit
@@ -4034,10 +4015,10 @@ public class MslControl {
      * {@code Future} may throw an {@code ExecutionException} whose cause is a
      * {@code MslException}, {@code IOException}, or
      * {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The caller must close the returned message input stream and message
      * outut stream.</p>
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param remoteEntity remote entity URL.
@@ -4052,17 +4033,17 @@ public class MslControl {
         final RequestService service = new RequestService(ctx, msgCtx, remoteEntity, Receive.ALWAYS, timeout);
         return executor.submit(service);
     }
-    
+
     /**
      * <p>Send a request to the remote entity over the provided output stream
      * and receive a resposne over the provided input stream.</p>
-     * 
+     *
      * <p>This method should only be used by peer-to-peer entities when
      * initiating a new request. The remote entity should be using
      * {@link #receive(MslContext, MessageContext, InputStream, OutputStream, int)}
      * and
      * {@link #respond(MslContext, MessageContext, InputStream, OutputStream, MessageInputStream, int)}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return a {@code MslChannel}
      * containing the final {@code MessageOutputStream} that should be used to
      * send any additional application data not already sent via
@@ -4070,7 +4051,7 @@ public class MslControl {
      * {@code MessageInputStream} of the established MSL communication
      * channel. If an error message was received then the MSL channel's message
      * output stream will be {@code null}.</p>
-     * 
+     *
      * <p>The returned {@code Future} will return {@code null} if
      * {@link #cancelled(Throwable) cancelled or interrupted}. The returned
      * message may be an error message if the maximum number of messages is hit
@@ -4078,16 +4059,16 @@ public class MslControl {
      * {@code Future} may throw an {@code ExecutionException} whose cause is a
      * {@code MslException}, {@code IOException}, or
      * {@code TimeoutException}.</p>
-     * 
+     *
      * <p>The caller must close the returned message input stream and message
      * outut stream. The remote entity input and output streams will not be
      * closed when the message input and output streams are closed, in case the
      * caller wishes to reuse them.</p>
-     * 
+     *
      * TODO once Java supports the WebSocket protocol we can remove this method
      * in favor of the one accepting a URL parameter. (Or is it the other way
      * around?)
-     * 
+     *
      * @param ctx MSL context.
      * @param msgCtx message context.
      * @param in remote entity input stream.
@@ -4102,17 +4083,17 @@ public class MslControl {
         final RequestService service = new RequestService(ctx, msgCtx, in, out, Receive.ALWAYS, timeout);
         return executor.submit(service);
     }
-    
+
     /** MSL executor. */
     private final ExecutorService executor;
-    
+
     /** Message stream factory. */
     private final MessageStreamFactory streamFactory;
     /** Error message registry. */
     private final ErrorMessageRegistry messageRegistry;
     /** Filter stream factory. May be null. */
     private FilterStreamFactory filterFactory = null;
-    
+
     /**
      * Map tracking outstanding renewable messages by MSL context. The blocking
      * queue is used to wait for a master token from a different thread if the

--- a/core/src/main/java/com/netflix/msl/msg/ServerReceiveMessageContext.java
+++ b/core/src/main/java/com/netflix/msl/msg/ServerReceiveMessageContext.java
@@ -60,7 +60,7 @@ public class ServerReceiveMessageContext extends PublicMessageContext {
     }
 
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/core/src/main/javascript/MslError.js
+++ b/core/src/main/javascript/MslError.js
@@ -268,6 +268,7 @@
 	    MESSAGE_REPLAYED_UNRECOVERABLE : new MslError(6040, MslConstants.ResponseCode.ENTITY_REAUTH, "Non-replayable message replayed with a sequence number that is too far out of sync to recover."),
 	    UNEXPECTED_LOCAL_MESSAGE_SENDER : new MslError(6041, MslConstants.ResponseCode.FAIL, "Message sender is equal to the local entity."),
 	    UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA : new MslError(6042, MslConstants.ResponseCode.FAIL, "User authentication data included in unencrypted message header."),
+	    MESSAGE_SENDER_MISMATCH : new MslError(6043, MslConstants.ResponseCode.FAIL, "Message sender entity identity does not match expected identity."),
 
 	    // 7 Key Exchange
 	    UNIDENTIFIED_KEYX_SCHEME : new MslError(7000, MslConstants.ResponseCode.FAIL, "Unable to identify key exchange scheme."),

--- a/core/src/main/javascript/msg/MessageContext.js
+++ b/core/src/main/javascript/msg/MessageContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,16 +58,15 @@
 	    getCryptoContexts: function() {},
 	    
 	    /**
-	     * <p>Called to identify the entity identity the message application data
-	     * is intended for. If the identity is not known this method must return
-	     * {@code null}.</p> 
+	     * <p>Called to identify the expected remote entity identity. If the remote
+	     * entity identity is not known this method must return {@code null}.</p> 
 	     * 
 	     * <p>Trusted network servers may always return {@code null}.</p>
 	     * 
-	     * @return {string} the entity identity of the application data recipient or
-	     *         {@code null} if the identity is not known.
+	     * @return {string} the remote entity identity or {@code null} if the identity is
+	     *         not known.
 	     */
-	    getRecipient: function() {},
+	    getRemoteEntityIdentity: function() {},
 	
 	    /**
 	     * <p>Called to determine if the message application data must be

--- a/core/src/main/javascript/msg/MslControl.js
+++ b/core/src/main/javascript/msg/MslControl.js
@@ -269,8 +269,8 @@
         },
 
         /** @inheritDoc */
-        getRecipient: function getRecipient() {
-            return this._appCtx.getRecipient();
+        getRemoteEntityIdentity: function getRemoteEntityIdentity() {
+            return this._appCtx.getRemoteEntityIdentity();
         },
 
         /** @inheritDoc */
@@ -1885,7 +1885,7 @@
                                     
                                     // Reject if a recipient was specified and it is not equal to the
                                     // message entity identity.
-                                    var expectedIdentity = msgCtx.getRecipient();
+                                    var expectedIdentity = msgCtx.getRemoteEntityIdentity();
                                     if (expectedIdentity && sender && expectedIdentity != sender)
                                         throw new MslMessageException(MslError.MESSAGE_SENDER_MISMATCH, "expected " + expectedIdentity + "; received " + sender);
                                     

--- a/core/src/main/javascript/msg/ServerReceiveMessageContext.js
+++ b/core/src/main/javascript/msg/ServerReceiveMessageContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@
         },
 
         /** @inheritDoc */
-        getRecipient: function getRecipient() {
+        getRemoteEntityIdentity: function getRemoteEntityIdentity() {
             return null;
         },
 

--- a/examples/burp/src/main/java/burp/MSLHttpListener.java
+++ b/examples/burp/src/main/java/burp/MSLHttpListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,6 @@ public class MSLHttpListener implements IHttpListener {
     private static final String KEY_MASTER_TOKEN = "mastertoken";
     private static final String KEY_HEADERDATA = "headerdata";
     private static final String KEY_SIGNATURE = "signature";
-    private static final String KEY_SENDER = "sender";
     private static final String KEY_MESSAGE_ID = "messageid";
     private static final String KEY_RENEWABLE = "renewable";
     private static final String KEY_CAPABILITIES = "capabilities";
@@ -69,7 +68,6 @@ public class MSLHttpListener implements IHttpListener {
     private static final String KEY_USER_AUTHENTICATION_DATA = "userauthdata";
     private static final String KEY_USER_ID_TOKEN = "useridtoken";
     private static final String KEY_SERVICE_TOKENS = "servicetokens";
-    private static final String KEY_RECIPIENT = "recipient";
     private static final String KEY_NON_REPLAYABLE_ID = "nonreplayableid";
     private static final String KEY_HANDSHAKE = "handshake";
     private static final String KEY_PAYLOAD = "payload";
@@ -242,7 +240,6 @@ public class MSLHttpListener implements IHttpListener {
     
                 final MslObject errordataMo = encoder.createObject();
                 try {
-                    errordataMo.put(KEY_RECIPIENT, errorHeader.getRecipient());
                     errordataMo.put(KEY_MESSAGE_ID, errorHeader.getMessageId());
                     errordataMo.put(KEY_ERROR_CODE, errorHeader.getErrorCode().intValue());
                     errordataMo.put(KEY_INTERNAL_CODE, errorHeader.getInternalCode());
@@ -295,8 +292,6 @@ public class MSLHttpListener implements IHttpListener {
 
             final MslObject headerdataMo = encoder.createObject();
             try {
-                headerdataMo.put(KEY_SENDER, messageHeader.getSender());
-                headerdataMo.put(KEY_RECIPIENT, messageHeader.getRecipient());
                 headerdataMo.put(KEY_MESSAGE_ID, messageHeader.getMessageId());
                 headerdataMo.put(KEY_NON_REPLAYABLE_ID, messageHeader.getNonReplayableId());
                 headerdataMo.put(KEY_RENEWABLE, messageHeader.isRenewable());

--- a/examples/burp/src/main/java/burp/msl/msg/WiretapMessageContext.java
+++ b/examples/burp/src/main/java/burp/msl/msg/WiretapMessageContext.java
@@ -96,7 +96,7 @@ public class WiretapMessageContext implements MessageContext {
     }
 
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/kancolle/src/main/java/kancolle/msg/CriticalMessageContext.java
+++ b/examples/kancolle/src/main/java/kancolle/msg/CriticalMessageContext.java
@@ -47,7 +47,7 @@ public class CriticalMessageContext extends ReportMessageContext {
     }
 
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return callsign;
     }
     

--- a/examples/kancolle/src/main/java/kancolle/msg/KanColleMessageContext.java
+++ b/examples/kancolle/src/main/java/kancolle/msg/KanColleMessageContext.java
@@ -77,10 +77,10 @@ public abstract class KanColleMessageContext implements MessageContext {
      * <p>No recipient is specified.</p>
      * 
      * @return {@code null}.
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/kancolle/src/main/java/kancolle/msg/ReceiveMessageContext.java
+++ b/examples/kancolle/src/main/java/kancolle/msg/ReceiveMessageContext.java
@@ -44,7 +44,7 @@ public class ReceiveMessageContext implements MessageContext {
     }
 
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/mslcli/client/src/main/java/mslcli/client/msg/ClientRequestMessageContext.java
+++ b/examples/mslcli/client/src/main/java/mslcli/client/msg/ClientRequestMessageContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import mslcli.common.IllegalCmdArgumentException;
-import mslcli.common.MslConfig;
-import mslcli.common.msg.MessageConfig;
-import mslcli.common.util.ConfigurationException;
-import mslcli.common.util.SharedUtil;
-
 import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslEncodingException;
 import com.netflix.msl.MslException;
@@ -40,6 +34,12 @@ import com.netflix.msl.msg.MessageOutputStream;
 import com.netflix.msl.msg.MessageServiceTokenBuilder;
 import com.netflix.msl.tokens.MslUser;
 import com.netflix.msl.userauth.UserAuthenticationData;
+
+import mslcli.common.IllegalCmdArgumentException;
+import mslcli.common.MslConfig;
+import mslcli.common.msg.MessageConfig;
+import mslcli.common.util.ConfigurationException;
+import mslcli.common.util.SharedUtil;
 
 /**
  * <p>Client Request message context.</p>
@@ -102,10 +102,10 @@ public class ClientRequestMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/mslcli/server/src/main/java/mslcli/server/ServerMslConfig.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/ServerMslConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package mslcli.server;
-
-import com.netflix.msl.entityauth.RsaAuthenticationData;
 
 import mslcli.common.CmdArguments;
 import mslcli.common.IllegalCmdArgumentException;

--- a/examples/mslcli/server/src/main/java/mslcli/server/SimpleHttpServer.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/SimpleHttpServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,10 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.util.Date;
 
+import com.netflix.msl.MslException;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
-import com.netflix.msl.MslError;
-import com.netflix.msl.MslException;
 
 import mslcli.common.CmdArguments;
 import mslcli.common.util.ConfigurationException;
@@ -47,7 +45,7 @@ public class SimpleHttpServer {
      * HTTP server launcher
      * @param args command line arguments
      */
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         if (args.length < 1) {
             log("Parameters: config_file");
             System.exit(1);
@@ -61,13 +59,13 @@ public class SimpleHttpServer {
             server.setExecutor(null); // creates a default executor
             log(String.format("waiting for requests on http://localhost:%d/mslcli-server ...", prop.getServerPort()));
             server.start();
-        } catch (ConfigurationException e) {
+        } catch (final ConfigurationException e) {
             log("Server Configuration Error: " + e.getMessage());
             System.exit(1);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             log("Server Initialization Error: " + e.getMessage());
             System.exit(1);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log("Server Internal Error: " + e.getMessage());
             SharedUtil.getRootCause(e).printStackTrace(System.err);
             System.exit(1);
@@ -86,7 +84,7 @@ public class SimpleHttpServer {
         }
 
         @Override
-        public void handle(HttpExchange t) throws IOException {
+        public void handle(final HttpExchange t) throws IOException {
             log("Processing request");
             final long t_start = System.currentTimeMillis();
 
@@ -95,18 +93,18 @@ public class SimpleHttpServer {
                 // Allow requests from anywhere.
                 t.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
                 mslServer.processRequest(t.getRequestBody(), out);
-            } catch (ConfigurationException e) {
+            } catch (final ConfigurationException e) {
                 log("Server Configuration Error: " + e.getMessage());
-            } catch (ConfigurationRuntimeException e) {
+            } catch (final ConfigurationRuntimeException e) {
                 log("Server Configuration Error: " + e.getCause().getMessage());
-            } catch (MslException e) {
+            } catch (final MslException e) {
                 log(SharedUtil.getMslExceptionInfo(e));
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 final Throwable thr = SharedUtil.getRootCause(e);
                 log("IO-ERROR: " + e);
                 log("ROOT CAUSE:");
                 thr.printStackTrace(System.err);
-            } catch (RuntimeException e) {
+            } catch (final RuntimeException e) {
                 log("RT-ERROR: " + e);
                 log("ROOT CAUSE:");
                 SharedUtil.getRootCause(e).printStackTrace(System.err);

--- a/examples/mslcli/server/src/main/java/mslcli/server/SimpleMslServer.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/SimpleMslServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.Security;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -33,20 +32,15 @@ import javax.crypto.SecretKey;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-import com.netflix.msl.MslConstants;
-import com.netflix.msl.MslCryptoException;
 import com.netflix.msl.MslException;
 import com.netflix.msl.crypto.ICryptoContext;
 import com.netflix.msl.crypto.SymmetricCryptoContext;
-import com.netflix.msl.entityauth.KeySetStore;
-import com.netflix.msl.entityauth.RsaStore;
 import com.netflix.msl.msg.ConsoleFilterStreamFactory;
 import com.netflix.msl.msg.ErrorHeader;
 import com.netflix.msl.msg.MessageContext;
 import com.netflix.msl.msg.MessageInputStream;
 import com.netflix.msl.msg.MslControl;
 import com.netflix.msl.msg.MslControl.MslChannel;
-import com.netflix.msl.tokens.MslUser;
 import com.netflix.msl.util.MslContext;
 
 import mslcli.common.CmdArguments;
@@ -72,8 +66,6 @@ import mslcli.server.util.ServerMslContext;
  */
 
 public class SimpleMslServer {
-    /** for proper serialization */
-    private static final long serialVersionUID = -4593207843035538485L;
     /** timeout for reading request and producing response */
     private static final int TIMEOUT_MS = 120 * 1000;
 
@@ -136,7 +128,7 @@ public class SimpleMslServer {
         final Future<MessageInputStream> requestFuture = mslCtrl.receive(mslCtx, rcvMsgCtx, in, out, TIMEOUT_MS);
         try {
             requestInputStream = requestFuture.get();
-        } catch (ExecutionException e) {
+        } catch (final ExecutionException e) {
             final Throwable thr = SharedUtil.getRootCause(e);
             if (thr instanceof MslException) {
                 throw (MslException)thr;
@@ -147,7 +139,7 @@ public class SimpleMslServer {
             } else {
                 throw new IOException("ExecutionException", e);
             }
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             throw new IOException("InterruptedException", e);
         }
 
@@ -163,24 +155,22 @@ public class SimpleMslServer {
         }
 
         // Process request.
-        final String clientId = requestInputStream.getIdentity();
-        final MslUser user = requestInputStream.getUser();
         final byte[] request = SharedUtil.readIntoArray(requestInputStream);
 
         //  Set up the respond MSL message context. Echo back the initial request.
-        Set<Token> tokens = new HashSet<Token>();
+        final Set<Token> tokens = new HashSet<Token>();
         tokens.addAll(Arrays.asList(
             new Token("st_name1", "st_data1", true, true),
             new Token("st_name2", "st_data2", true, true)
         ));
-        final MessageContext responseMsgCtx = new ServerRespondMessageContext(clientId, true, request /*echo request*/, tokens, cryptoContexts);
+        final MessageContext responseMsgCtx = new ServerRespondMessageContext(true, request /*echo request*/, tokens, cryptoContexts);
 
         // Send response. We don't need the MslChannel because we are not
         // opening a persistent channel.
         final Future<MslChannel> channelFuture = mslCtrl.respond(mslCtx, responseMsgCtx, in, out, requestInputStream, TIMEOUT_MS);
         try {
             channelFuture.get();
-        } catch (ExecutionException e) {
+        } catch (final ExecutionException e) {
             final Throwable thr = SharedUtil.getRootCause(e);
             if (thr instanceof MslException) {
                 throw (MslException)thr;
@@ -191,7 +181,7 @@ public class SimpleMslServer {
             } else {
                 throw new IOException("ExecutionException", e);
             }
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             throw new IOException("ExecutionException", e);
         }
     }

--- a/examples/mslcli/server/src/main/java/mslcli/server/msg/ServerReceiveMessageContext.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/msg/ServerReceiveMessageContext.java
@@ -58,10 +58,10 @@ public class ServerReceiveMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/mslcli/server/src/main/java/mslcli/server/msg/ServerRespondMessageContext.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/msg/ServerRespondMessageContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,12 +79,10 @@ public class ServerRespondMessageContext implements MessageContext {
      * <p>Create a new response message context with the specified
      * properties.</p>
      * 
-     * @param recipient requesting entity identity.
      * @param encrypted true if the response data must be encrypted.
      * @param data application response data.
      */
-    public ServerRespondMessageContext(final String recipient, final boolean encrypted, final byte[] data) {
-        this.recipient = recipient;
+    public ServerRespondMessageContext(final boolean encrypted, final byte[] data) {
         this.encrypted = encrypted;
         this.data = data;
         this.tokens = Collections.emptySet();
@@ -95,14 +93,12 @@ public class ServerRespondMessageContext implements MessageContext {
      * <p>Create a new response message context with the specified
      * properties.</p>
      * 
-     * @param recipient requesting entity identity.
      * @param encrypted true if the response data must be encrypted.
      * @param data application response data.
      * @param tokens application service tokens.
      * @param cryptoContexts application service token crypto contexts.
      */
-    public ServerRespondMessageContext(final String recipient, final boolean encrypted, final byte[] data, final Set<Token> tokens, final Map<String,ICryptoContext> cryptoContexts) {
-        this.recipient = recipient;
+    public ServerRespondMessageContext(final boolean encrypted, final byte[] data, final Set<Token> tokens, final Map<String,ICryptoContext> cryptoContexts) {
         this.encrypted = encrypted;
         this.data = data;
         this.tokens = tokens;
@@ -122,7 +118,7 @@ public class ServerRespondMessageContext implements MessageContext {
      */
     @Override
     public String getRecipient() {
-        return recipient;
+        return null;
     }
 
     /* (non-Javadoc)
@@ -233,8 +229,6 @@ public class ServerRespondMessageContext implements MessageContext {
 
     /** Service token crypto contexts. */
     private final Map<String,ICryptoContext> cryptoContexts;
-    /** Recipient entity identity. */
-    private final String recipient;
     /** True if the response data must be encrypted. */
     private final boolean encrypted;
     /** Response data. */

--- a/examples/mslcli/server/src/main/java/mslcli/server/msg/ServerRespondMessageContext.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/msg/ServerRespondMessageContext.java
@@ -114,10 +114,10 @@ public class ServerRespondMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/mslcli/server/src/main/java/mslcli/server/tokens/ServerTokenFactory.java
+++ b/examples/mslcli/server/src/main/java/mslcli/server/tokens/ServerTokenFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,10 @@
 
 package mslcli.server.tokens;
 
-import java.math.BigInteger;
 import java.sql.Date;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.SecretKey;
-
-import mslcli.common.tokens.SimpleUser;
-import mslcli.common.util.AppContext;
-import mslcli.common.util.ConfigurationException;
-import mslcli.common.util.SharedUtil;
 
 import com.netflix.msl.MslConstants;
 import com.netflix.msl.MslCryptoException;
@@ -45,6 +38,11 @@ import com.netflix.msl.tokens.TokenFactory;
 import com.netflix.msl.tokens.UserIdToken;
 import com.netflix.msl.util.MslContext;
 import com.netflix.msl.util.MslUtils;
+
+import mslcli.common.tokens.SimpleUser;
+import mslcli.common.util.AppContext;
+import mslcli.common.util.ConfigurationException;
+import mslcli.common.util.SharedUtil;
 
 /**
  * <p>A server-side memory-backed token factory.</p>

--- a/examples/oneshot/src/main/java/oneshot/OneshotMessageContext.java
+++ b/examples/oneshot/src/main/java/oneshot/OneshotMessageContext.java
@@ -83,10 +83,10 @@ public class OneshotMessageContext extends SecretMessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/proxy/src/main/java/com/netflix/msl/msg/ReceiveMessageContext.java
+++ b/examples/proxy/src/main/java/com/netflix/msl/msg/ReceiveMessageContext.java
@@ -43,10 +43,10 @@ public class ReceiveMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/proxy/src/main/java/com/netflix/msl/msg/RespondMessageContext.java
+++ b/examples/proxy/src/main/java/com/netflix/msl/msg/RespondMessageContext.java
@@ -58,10 +58,10 @@ public class RespondMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/simple/src/main/java/server/SimpleServlet.java
+++ b/examples/simple/src/main/java/server/SimpleServlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,7 @@ public class SimpleServlet extends HttpServlet {
             // FIXME: Remove encryption requirement.
             // Encryption is required to avoid accidentally leaking
             // information in the error message.
-            responseMsgCtx = new SimpleRespondMessageContext(null, true, e.getMessage());
+            responseMsgCtx = new SimpleRespondMessageContext(true, e.getMessage());
         }
 
         // Send response. We don't need the MslChannel because we are not

--- a/examples/simple/src/main/java/server/msg/SimpleEchoRequest.java
+++ b/examples/simple/src/main/java/server/msg/SimpleEchoRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class SimpleEchoRequest extends SimpleRequest {
         final SimpleUser user = getUser();
         final String username = (user != null) ? user.toString() : null;
         final String data = username + "@" + getIdentity() + ": " + message;
-        return new SimpleRespondMessageContext(getIdentity(), true, data);
+        return new SimpleRespondMessageContext(true, data);
     }
 
     /** Message to echo. */

--- a/examples/simple/src/main/java/server/msg/SimpleLogRequest.java
+++ b/examples/simple/src/main/java/server/msg/SimpleLogRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,7 +157,7 @@ public class SimpleLogRequest extends SimpleRequest {
         
         final Set<Token> tokens = new HashSet<Token>();
         tokens.add(new Token(SERVICETOKEN_LOGDATA_NAME, allMessages, true, true));
-        return new SimpleRespondMessageContext(getIdentity(), false, allMessages, tokens, cryptoContexts);
+        return new SimpleRespondMessageContext(false, allMessages, tokens, cryptoContexts);
     }
 
     /** Timestamp in seconds since the UNIX epoch. */

--- a/examples/simple/src/main/java/server/msg/SimpleProfileRequest.java
+++ b/examples/simple/src/main/java/server/msg/SimpleProfileRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,6 @@ public class SimpleProfileRequest extends SimpleRequest {
         }
         
         // Return the response.
-        return new SimpleRespondMessageContext(getIdentity(), true, response);
+        return new SimpleRespondMessageContext(true, response);
     }
 }

--- a/examples/simple/src/main/java/server/msg/SimpleQueryRequest.java
+++ b/examples/simple/src/main/java/server/msg/SimpleQueryRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public class SimpleQueryRequest extends SimpleRequest {
                     throw new SimpleRequestUserException("Error: access restricted to user " + data[0] + ".");
                 else
                     response = data[2];
-                return new SimpleRespondMessageContext(getIdentity(), true, response);
+                return new SimpleRespondMessageContext(true, response);
             }
         }
         

--- a/examples/simple/src/main/java/server/msg/SimpleQuitRequest.java
+++ b/examples/simple/src/main/java/server/msg/SimpleQuitRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,6 @@ public class SimpleQuitRequest extends SimpleRequest {
         }
 
         // Return the response.
-        return new SimpleRespondMessageContext(getIdentity(), true, response);
+        return new SimpleRespondMessageContext(true, response);
     }
 }

--- a/examples/simple/src/main/java/server/msg/SimpleReceiveMessageContext.java
+++ b/examples/simple/src/main/java/server/msg/SimpleReceiveMessageContext.java
@@ -54,10 +54,10 @@ public class SimpleReceiveMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/simple/src/main/java/server/msg/SimpleRespondMessageContext.java
+++ b/examples/simple/src/main/java/server/msg/SimpleRespondMessageContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,12 +77,10 @@ public class SimpleRespondMessageContext implements MessageContext {
      * <p>Create a new response message context with the specified
      * properties.</p>
      * 
-     * @param recipient requesting entity identity.
      * @param encrypted true if the response data must be encrypted.
      * @param data application response data.
      */
-    public SimpleRespondMessageContext(final String recipient, final boolean encrypted, final String data) {
-        this.recipient = recipient;
+    public SimpleRespondMessageContext(final boolean encrypted, final String data) {
         this.encrypted = encrypted;
         this.data = data;
         this.tokens = Collections.emptySet();
@@ -93,14 +91,12 @@ public class SimpleRespondMessageContext implements MessageContext {
      * <p>Create a new response message context with the specified
      * properties.</p>
      * 
-     * @param recipient requesting entity identity.
      * @param encrypted true if the response data must be encrypted.
      * @param data application response data.
      * @param tokens application service tokens.
      * @param cryptoContexts application service token crypto contexts.
      */
-    public SimpleRespondMessageContext(final String recipient, final boolean encrypted, final String data, final Set<Token> tokens, final Map<String,ICryptoContext> cryptoContexts) {
-        this.recipient = recipient;
+    public SimpleRespondMessageContext(final boolean encrypted, final String data, final Set<Token> tokens, final Map<String,ICryptoContext> cryptoContexts) {
         this.encrypted = encrypted;
         this.data = data;
         this.tokens = tokens;
@@ -120,7 +116,7 @@ public class SimpleRespondMessageContext implements MessageContext {
      */
     @Override
     public String getRecipient() {
-        return recipient;
+        return null;
     }
 
     /* (non-Javadoc)
@@ -233,8 +229,6 @@ public class SimpleRespondMessageContext implements MessageContext {
 
     /** Service token crypto contexts. */
     private final Map<String,ICryptoContext> cryptoContexts;
-    /** Recipient entity identity. */
-    private final String recipient;
     /** True if the response data must be encrypted. */
     private final boolean encrypted;
     /** Response data. */

--- a/examples/simple/src/main/java/server/msg/SimpleRespondMessageContext.java
+++ b/examples/simple/src/main/java/server/msg/SimpleRespondMessageContext.java
@@ -112,10 +112,10 @@ public class SimpleRespondMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequest.js
@@ -33,7 +33,7 @@
          * <p>Create an advanced request with the specified message properties
          * and application data.</p>
          *
-         * @param {string} recipient the intended recipient's entity identity.
+         * @param {string} identity the remote entity identity. May be null.
          * @param {boolean} isEncrypted true if encryption is required.
          * @param {boolean} isIntegrityProtected true if integrity protection
          *        is required.
@@ -43,12 +43,12 @@
          *        tokens in the response.
          * @param {Uint8Array} data the application data.
          */
-        init: function init(recipient, isEncrypted, isIntegrityProtected, isNonReplayable, isRequestingTokens, data) {
+        init: function init(identity, isEncrypted, isIntegrityProtected, isNonReplayable, isRequestingTokens, data) {
             // Set properties.
             var props = {
                 data: { value: data, writable: false, enumerable: true, configurable: false },
                 // Message context properties.
-                recipient: { value: recipient, writable: false, enuemrable: true, configurable: false },
+                remoteEntityIdentity: { value: identity, writable: false, enuemrable: true, configurable: false },
                 isEncrypted: { value: isEncrypted, writable: false, enumerable: true, configurable: false },
                 isIntegrityProtected: { value: isIntegrityProtected, writable: false, enumerable: true, configurable: false },
                 isNonReplayable: { value: isNonReplayable, writable: false, enumerable: true, configurable: false },

--- a/examples/simple/src/main/javascript/client/msg/AdvancedRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/AdvancedRequestMessageContext.js
@@ -63,8 +63,8 @@
         },
 
         /** @inheritDoc */
-        getRecipient: function() {
-            return this._request.recipient;
+        getRemoteEntityIdentity: function() {
+            return this._request.remoteEntityIdentity;
         },
 
         /** @inheritDoc */

--- a/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
+++ b/examples/simple/src/main/javascript/client/msg/SimpleRequestMessageContext.js
@@ -68,7 +68,7 @@
         },
 
         /** @inheritDoc */
-        getRecipient: function() {
+        getRemoteEntityIdentity: function() {
             return SimpleConstants.SERVER_ID;
         },
 

--- a/examples/websocket/src/main/java/server/msg/PushMessageContext.java
+++ b/examples/websocket/src/main/java/server/msg/PushMessageContext.java
@@ -54,10 +54,10 @@ public class PushMessageContext implements MessageContext {
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
+    public String getRemoteEntityIdentity() {
         return null;
     }
 

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/MultiPushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/MultiPushServlet.java
@@ -90,7 +90,7 @@ public class MultiPushServlet extends PushServlet {
             }
 
             @Override
-            public String getRecipient() {
+            public String getRemoteEntityIdentity() {
                 return null;
             }
 

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/PublicPushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/PublicPushServlet.java
@@ -90,7 +90,7 @@ public class PublicPushServlet extends PushServlet {
             }
 
             @Override
-            public String getRecipient() {
+            public String getRemoteEntityIdentity() {
                 return null;
             }
 

--- a/integ-tests/src/main/java/com/netflix/msl/server/servlet/SecretPushServlet.java
+++ b/integ-tests/src/main/java/com/netflix/msl/server/servlet/SecretPushServlet.java
@@ -90,7 +90,7 @@ public class SecretPushServlet extends PushServlet {
             }
 
             @Override
-            public String getRecipient() {
+            public String getRemoteEntityIdentity() {
                 return null;
             }
 

--- a/integ-tests/src/test/java/com/netflix/msl/client/common/BaseTestClass.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/common/BaseTestClass.java
@@ -243,7 +243,7 @@ public class BaseTestClass {
     public MessageInputStream sendReceive(final OutputStream out, final InputStream in,
                                           final MasterToken masterToken, final UserIdToken userIdToken, final Set<ServiceToken> serviceTokens,
                                           final boolean isRenewable, final boolean addKeyRequestData) throws MslException, IOException {
-        final MessageBuilder builder = MessageBuilder.createRequest(clientConfig.getMslContext(), masterToken, userIdToken, null);
+        final MessageBuilder builder = MessageBuilder.createRequest(clientConfig.getMslContext(), masterToken, userIdToken);
         builder.setRenewable(isRenewable);
         builder.setNonReplayable(clientConfig.getMessageContext().isNonReplayable());
 

--- a/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/configuration/ClientConfiguration.java
@@ -68,6 +68,7 @@ public class ClientConfiguration {
     private String scheme = "http";
     private String remoteHost = "localhost";
     private String path = "";
+    private String remoteEntityIdentity = null;
     private String userId = null;
     private boolean isPeerToPeer = false;
     private EntityAuthenticationScheme entityAuthenticationScheme = EntityAuthenticationScheme.PSK;
@@ -91,7 +92,10 @@ public class ClientConfiguration {
         return this;
     }
 
-
+    public ClientConfiguration setRemoteEntityIdentity(final String identity) {
+        remoteEntityIdentity = identity;
+        return this;
+    }
 
     public ClientConfiguration setUserAuthenticationScheme(final UserAuthenticationScheme scheme) {
         userAuthenticationScheme = scheme;
@@ -236,6 +240,8 @@ public class ClientConfiguration {
 
         /** create message context and configure */
         messageContext = new ClientMessageContext(mslContext, userId, userAuthenticationScheme, isMessageEncrypted, isIntegrityProtected);
+        if (remoteEntityIdentity != null)
+            messageContext.setRemoteEntityIdentity(remoteEntityIdentity);
         messageContext.resetKeyRequestData(keyExchangeScheme);
         if(this.clearKeyRequestData) {
             messageContext.clearKeyRequestData();

--- a/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
+++ b/integ-tests/src/test/java/com/netflix/msl/client/tests/ServiceTokenTests.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2014-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -125,7 +125,7 @@ public class ServiceTokenTests extends BaseTestClass {
 
 
     @Test(groups = "UnboundServiceTokenTests")
-    public void unboudServiceTokenWithData() throws InterruptedException, ExecutionException, MslException, IOException, MslEncoderException {
+    public void unboundServiceTokenWithData() throws InterruptedException, ExecutionException, MslException, IOException, MslEncoderException {
         final MasterToken masterToken = getMasterToken(new Date(System.currentTimeMillis() + 10000) /*renewableWindow*/,
                 new Date(System.currentTimeMillis() + 20000) /*expiration*/, TIME_OUT, 0  /*sequenceNumberOffset*/);
 
@@ -146,7 +146,7 @@ public class ServiceTokenTests extends BaseTestClass {
         assertEquals(serviceTokens, returnedServiceTokens, "Retured service tokens are not the same as the sent");
     }
 
-    @Test(dependsOnMethods = "unboudServiceTokenWithData", groups = "UnboundServiceTokenTests")
+    @Test(dependsOnMethods = "unboundServiceTokenWithData", groups = "UnboundServiceTokenTests")
     public void testUnboundServiceTokenWithoutData() throws InterruptedException, ExecutionException, MslException, IOException, MslEncoderException {
         final MasterToken masterToken = getMasterToken(new Date(System.currentTimeMillis() + 10000) /*renewableWindow*/,
                 new Date(System.currentTimeMillis() + 20000) /*expiration*/, TIME_OUT, 0  /*sequenceNumberOffset*/);

--- a/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
+++ b/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
@@ -102,7 +102,7 @@ public class MockMessageContext implements MessageContext {
      *         Hellman parameters.
      */
     public MockMessageContext(final MslContext ctx, final String userId, final UserAuthenticationScheme scheme) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, MslKeyExchangeException {
-        this.recipient = null;
+        this.remoteEntityIdentity = null;
         this.encrypted = false;
         this.integrityProtected = false;
         this.nonReplayable = false;
@@ -162,18 +162,18 @@ public class MockMessageContext implements MessageContext {
     }
     
     /**
-     * @param recipient the message recipient or {@code null} if unknown.
+     * @param remoteEntityIdentity the message recipient or {@code null} if unknown.
      */
-    public void setRecipient(final String recipient) {
-        this.recipient = recipient;
+    public void setRemoteEntityIdentity(final String remoteEntityIdentity) {
+        this.remoteEntityIdentity = remoteEntityIdentity;
     }
 
     /* (non-Javadoc)
-     * @see com.netflix.msl.msg.MessageContext#getRecipient()
+     * @see com.netflix.msl.msg.MessageContext#getRemoteEntityIdentity()
      */
     @Override
-    public String getRecipient() {
-        return recipient;
+    public String getRemoteEntityIdentity() {
+        return remoteEntityIdentity;
     }
     
     /**
@@ -327,7 +327,7 @@ public class MockMessageContext implements MessageContext {
     }
 
     /** Message recipient. */
-    private String recipient;
+    private String remoteEntityIdentity;
     /** Message requires encryption. */
     private boolean encrypted;
     /** Message requires integrity protection. */

--- a/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
+++ b/tests/src/main/java/com/netflix/msl/msg/MockMessageContext.java
@@ -162,7 +162,7 @@ public class MockMessageContext implements MessageContext {
     }
     
     /**
-     * @param remoteEntityIdentity the message recipient or {@code null} if unknown.
+     * @param remoteEntityIdentity the message remote entity identity or {@code null} if unknown.
      */
     public void setRemoteEntityIdentity(final String remoteEntityIdentity) {
         this.remoteEntityIdentity = remoteEntityIdentity;
@@ -326,7 +326,7 @@ public class MockMessageContext implements MessageContext {
         return debugContext;
     }
 
-    /** Message recipient. */
+    /** Message remote entity identity. */
     private String remoteEntityIdentity;
     /** Message requires encryption. */
     private boolean encrypted;

--- a/tests/src/main/javascript/msg/MockMessageContext.js
+++ b/tests/src/main/javascript/msg/MockMessageContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@
 
 	                // The properties.
 	                var props = {
-	                    recipient: { value: null, writable: true, enumerable: false, configurable: false },
+	                    remoteEntityIdentity: { value: null, writable: true, enumerable: false, configurable: false },
 	                    encrypted: { value: false, writable: true, enumerable: false, configurable: false },
 	                    integrityProtected: { value: false, writable: true, enumerable: false, configurable: false },
 	                    nonReplayable: { value: false, writable: true, enumerable: false, configurable: false },
@@ -196,15 +196,15 @@
 	    },
 	    
 	    /**
-	     * @param {string} recipient the message recipient or {@code null} if unknown.
+	     * @param {string} remoteEntityIdentity the remote entity identity or {@code null} if unknown.
 	     */
-	    setRecipient: function setRecipient(recipient) {
-	        this.recipient = recipient;
+	    setRemoteEntityIdentity: function setRemoteEntityIdentity(remoteEntityIdentity) {
+	        this.remoteEntityIdentity = remoteEntityIdentity;
 	    },
 	    
 	    /** @inheritDoc */
-	    getRecipient: function getRecipient() {
-	        return this.recipient;
+	    getRemoteEntityIdentity: function getRemoteEntityIdentity() {
+	        return this.remoteEntityIdentity;
 	    },
 	    
 	    /**

--- a/tests/src/test/java/com/netflix/msl/io/DefaultMslEncoderFactorySuite.java
+++ b/tests/src/test/java/com/netflix/msl/io/DefaultMslEncoderFactorySuite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -454,7 +454,7 @@ public class DefaultMslEncoderFactorySuite {
             final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
             
             // Create JSON version.
-            final HeaderData jsonHeaderData = new HeaderData(null, 1, null, false, false, jsonCaps, null, null, null, null, null);
+            final HeaderData jsonHeaderData = new HeaderData(1, null, false, false, jsonCaps, null, null, null, null, null);
             final MessageHeader jsonMessageHeader = new MessageHeader(ctx, entityAuthData, null, jsonHeaderData, peerData);
             final ICryptoContext jsonCryptoContext = jsonMessageHeader.getCryptoContext();
             final MessageOutputStream jsonMos = new MessageOutputStream(ctx, destination, jsonMessageHeader, jsonCryptoContext);

--- a/tests/src/test/java/com/netflix/msl/msg/ErrorHeaderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/ErrorHeaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,8 +77,6 @@ public class ErrorHeaderTest {
     private static final String KEY_SIGNATURE = "signature";
     
     // Message error data.
-    /** Key recipient. */
-    private static final String KEY_RECIPIENT = "recipient";
     /** Key timestamp. */
     private static final String KEY_TIMESTAMP = "timestamp";
     /** Key message ID. */
@@ -127,7 +125,6 @@ public class ErrorHeaderTest {
     private static ICryptoContext cryptoContext;
     
     private static EntityAuthenticationData ENTITY_AUTH_DATA;
-    private static final String RECIPIENT = "recipient";
     private static final long MESSAGE_ID = 17;
     private static final ResponseCode ERROR_CODE = ResponseCode.FAIL;
     private static final int INTERNAL_CODE = 621;
@@ -155,20 +152,19 @@ public class ErrorHeaderTest {
 
     @Test
     public void ctors() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         assertEquals(ENTITY_AUTH_DATA, errorHeader.getEntityAuthenticationData());
         assertEquals(ERROR_CODE, errorHeader.getErrorCode());
         assertEquals(ERROR_MSG, errorHeader.getErrorMessage());
         assertEquals(INTERNAL_CODE, errorHeader.getInternalCode());
         assertEquals(MESSAGE_ID, errorHeader.getMessageId());
         assertEquals(USER_MSG, errorHeader.getUserMessage());
-        assertEquals(RECIPIENT, errorHeader.getRecipient());
         assertTrue(isAboutNow(errorHeader.getTimestamp()));
     }
     
     @Test
     public void mslObject() throws MslEncodingException, MslEntityAuthException, MslEncoderException, UnsupportedEncodingException, MslMessageException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         
         final MslObject mo = MslTestUtils.toMslObject(encoder, errorHeader);
         final MslObject entityAuthDataMo = mo.getMslObject(KEY_ENTITY_AUTHENTICATION_DATA, encoder);
@@ -179,7 +175,6 @@ public class ErrorHeaderTest {
         final byte[] signature = mo.getBytes(KEY_SIGNATURE);
         assertTrue(cryptoContext.verify(ciphertext, signature, encoder));
 
-        assertEquals(RECIPIENT, errordata.getString(KEY_RECIPIENT));
         assertEquals(MESSAGE_ID, errordata.getLong(KEY_MESSAGE_ID));
         assertEquals(ERROR_CODE.intValue(), errordata.getInt(KEY_ERROR_CODE));
         assertEquals(INTERNAL_CODE, errordata.getInt(KEY_INTERNAL_CODE));
@@ -190,7 +185,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void negativeInternalCodeMslObject() throws MslEncodingException, MslEntityAuthException, MslEncoderException, MslMessageException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, -17, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, -17, ERROR_MSG, USER_MSG);
         assertEquals(-1, errorHeader.getInternalCode());
         
         final MslObject mo = MslTestUtils.toMslObject(encoder, errorHeader);
@@ -202,7 +197,6 @@ public class ErrorHeaderTest {
         final byte[] signature = mo.getBytes(KEY_SIGNATURE);
         assertTrue(cryptoContext.verify(ciphertext, signature, encoder));
 
-        assertEquals(RECIPIENT, errordata.getString(KEY_RECIPIENT));
         assertTrue(isAboutNowSeconds(errordata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, errordata.getLong(KEY_MESSAGE_ID));
         assertEquals(ERROR_CODE.intValue(), errordata.getInt(KEY_ERROR_CODE));
@@ -212,31 +206,8 @@ public class ErrorHeaderTest {
     }
     
     @Test
-    public void nullRecipientMslObject() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslEncoderException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, null, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
-        assertNull(errorHeader.getRecipient());
-        
-        final MslObject mo = MslTestUtils.toMslObject(encoder, errorHeader);
-        final MslObject entityAuthDataMo = mo.getMslObject(KEY_ENTITY_AUTHENTICATION_DATA, encoder);
-        assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, ENTITY_AUTH_DATA), entityAuthDataMo));
-        final byte[] ciphertext = mo.getBytes(KEY_ERRORDATA);
-        final byte[] plaintext = cryptoContext.decrypt(ciphertext, encoder);
-        final MslObject errordata = encoder.parseObject(plaintext);
-        final byte[] signature = mo.getBytes(KEY_SIGNATURE);
-        assertTrue(cryptoContext.verify(ciphertext, signature, encoder));
-
-        assertFalse(errordata.has(KEY_RECIPIENT));
-        assertTrue(isAboutNowSeconds(errordata.getLong(KEY_TIMESTAMP)));
-        assertEquals(MESSAGE_ID, errordata.getLong(KEY_MESSAGE_ID));
-        assertEquals(ERROR_CODE.intValue(), errordata.getInt(KEY_ERROR_CODE));
-        assertEquals(INTERNAL_CODE, errordata.getInt(KEY_INTERNAL_CODE));
-        assertEquals(ERROR_MSG, errordata.getString(KEY_ERROR_MESSAGE));
-        assertEquals(USER_MSG, errordata.getString(KEY_USER_MESSAGE));
-    }
-    
-    @Test
     public void nullErrorMessageMslObject() throws MslEncodingException, MslEntityAuthException, MslEncoderException, MslMessageException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, null, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, null, USER_MSG);
         assertNull(errorHeader.getErrorMessage());
         
         final MslObject mo = MslTestUtils.toMslObject(encoder, errorHeader);
@@ -248,7 +219,6 @@ public class ErrorHeaderTest {
         final byte[] signature = mo.getBytes(KEY_SIGNATURE);
         assertTrue(cryptoContext.verify(ciphertext, signature, encoder));
 
-        assertEquals(RECIPIENT, errordata.getString(KEY_RECIPIENT));
         assertTrue(isAboutNowSeconds(errordata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, errordata.getLong(KEY_MESSAGE_ID));
         assertEquals(ERROR_CODE.intValue(), errordata.getInt(KEY_ERROR_CODE));
@@ -259,7 +229,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void nullUserMessageMslObject() throws MslEncodingException, MslEntityAuthException, MslEncoderException, MslMessageException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, null);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, null);
         assertNull(errorHeader.getUserMessage());
         
         final MslObject mo = MslTestUtils.toMslObject(encoder, errorHeader);
@@ -271,7 +241,6 @@ public class ErrorHeaderTest {
         final byte[] signature = mo.getBytes(KEY_SIGNATURE);
         assertTrue(cryptoContext.verify(ciphertext, signature, encoder));
 
-        assertEquals(RECIPIENT, errordata.getString(KEY_RECIPIENT));
         assertTrue(isAboutNowSeconds(errordata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, errordata.getLong(KEY_MESSAGE_ID));
         assertEquals(ERROR_CODE.intValue(), errordata.getInt(KEY_ERROR_CODE));
@@ -282,7 +251,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void parseHeader() throws MslEncoderException, MslKeyExchangeException, MslUserAuthException, MslException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         final Header header = Header.parseHeader(ctx, errorHeaderMo, CRYPTO_CONTEXTS);
         assertNotNull(header);
@@ -295,7 +264,6 @@ public class ErrorHeaderTest {
         assertEquals(errorHeader.getErrorMessage(), moErrorHeader.getErrorMessage());
         assertEquals(errorHeader.getInternalCode(), moErrorHeader.getInternalCode());
         assertEquals(errorHeader.getMessageId(), moErrorHeader.getMessageId());
-        assertEquals(errorHeader.getRecipient(), moErrorHeader.getRecipient());
         assertEquals(errorHeader.getUserMessage(), moErrorHeader.getUserMessage());
     }
     
@@ -304,7 +272,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslMessageException.class);
         thrown.expectMslError(MslError.MESSAGE_ENTITY_NOT_FOUND);
 
-        new ErrorHeader(ctx, null, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        new ErrorHeader(ctx, null, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
     }
     
     @Test
@@ -312,7 +280,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslMessageException.class);
         thrown.expectMslError(MslError.MESSAGE_ENTITY_NOT_FOUND);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         assertNotNull(errorHeaderMo.remove(KEY_ENTITY_AUTHENTICATION_DATA));
@@ -325,7 +293,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         errorHeaderMo.put(KEY_ENTITY_AUTHENTICATION_DATA, "x");
@@ -338,7 +306,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         assertNotNull(errorHeaderMo.remove(KEY_SIGNATURE));
@@ -351,7 +319,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         errorHeaderMo.put(KEY_SIGNATURE, false);
@@ -364,7 +332,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslCryptoException.class);
         thrown.expectMslError(MslError.MESSAGE_VERIFICATION_FAILED);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         errorHeaderMo.put(KEY_SIGNATURE, Base64.decode("AAA="));
@@ -377,7 +345,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         assertNotNull(errorHeaderMo.remove(KEY_ERRORDATA));
@@ -390,7 +358,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslCryptoException.class);
         thrown.expectMslError(MslError.CIPHERTEXT_ENVELOPE_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // This tests invalid but trusted error data so we must sign it.
@@ -408,7 +376,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslMessageException.class);
         thrown.expectMslError(MslError.HEADER_DATA_MISSING);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // This tests empty but trusted error data so we must sign it.
@@ -422,7 +390,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void missingTimestamp() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
 
         // Before modifying the error data we need to decrypt it.
@@ -449,7 +417,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
 
         // Before modifying the error data we need to decrypt it.
@@ -476,7 +444,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -503,7 +471,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslEncodingException.class);
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
 
         // Before modifying the error data we need to decrypt it.
@@ -527,12 +495,12 @@ public class ErrorHeaderTest {
     
     @Test(expected = MslInternalException.class)
     public void negativeMessageIdCtor() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-        new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, -1, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        new ErrorHeader(ctx, ENTITY_AUTH_DATA, -1, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
     }
     
     @Test(expected = MslInternalException.class)
     public void tooLargeMessageIdCtor() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-        new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MslConstants.MAX_LONG_VALUE + 1, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        new ErrorHeader(ctx, ENTITY_AUTH_DATA, MslConstants.MAX_LONG_VALUE + 1, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
     }
     
     @Test
@@ -540,7 +508,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslMessageException.class);
         thrown.expectMslError(MslError.MESSAGE_ID_OUT_OF_RANGE);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
 
         // Before modifying the error data we need to decrypt it.
@@ -567,7 +535,7 @@ public class ErrorHeaderTest {
         thrown.expect(MslMessageException.class);
         thrown.expectMslError(MslError.MESSAGE_ID_OUT_OF_RANGE);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
 
         // Before modifying the error data we need to decrypt it.
@@ -595,7 +563,7 @@ public class ErrorHeaderTest {
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
         thrown.expectMessageId(MESSAGE_ID);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -623,7 +591,7 @@ public class ErrorHeaderTest {
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
         thrown.expectMessageId(MESSAGE_ID);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
 
         // Before modifying the error data we need to decrypt it.
@@ -647,7 +615,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void missingInternalCode() throws MslEncoderException, MslKeyExchangeException, MslUserAuthException, MslException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -676,7 +644,7 @@ public class ErrorHeaderTest {
         thrown.expectMslError(MslError.MSL_PARSE_ERROR);
         thrown.expectMessageId(MESSAGE_ID);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -704,7 +672,7 @@ public class ErrorHeaderTest {
         thrown.expectMslError(MslError.INTERNAL_CODE_NEGATIVE);
         thrown.expectMessageId(MESSAGE_ID);
 
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -728,7 +696,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void missingErrorMessage() throws UnsupportedEncodingException, MslEncoderException, MslKeyExchangeException, MslUserAuthException, MslException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -753,7 +721,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void missingUserMessage() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslKeyExchangeException, MslUserAuthException, MslEncoderException, MslException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final MslObject errorHeaderMo = MslTestUtils.toMslObject(encoder, errorHeader);
         
         // Before modifying the error data we need to decrypt it.
@@ -777,30 +745,10 @@ public class ErrorHeaderTest {
     }
     
     @Test
-    public void equalsRecipient() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
-        final String recipientA = "A";
-        final String recipientB = "B";
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, recipientA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, recipientB, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
-        final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
-
-        assertTrue(errorHeaderA.equals(errorHeaderA));
-        assertEquals(errorHeaderA.hashCode(), errorHeaderA.hashCode());
-        
-        assertFalse(errorHeaderA.equals(errorHeaderB));
-        assertFalse(errorHeaderB.equals(errorHeaderA));
-        assertTrue(errorHeaderA.hashCode() != errorHeaderB.hashCode());
-        
-        assertTrue(errorHeaderA.equals(errorHeaderA2));
-        assertTrue(errorHeaderA2.equals(errorHeaderA));
-        assertEquals(errorHeaderA.hashCode(), errorHeaderA2.hashCode());
-    }
-    
-    @Test
     public void equalsTimestamp() throws InterruptedException, MslKeyExchangeException, MslUserAuthException, MslEncoderException, MslException {
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         Thread.sleep(MILLISECONDS_PER_SECOND);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
 
         assertTrue(errorHeaderA.equals(errorHeaderA));
@@ -819,8 +767,8 @@ public class ErrorHeaderTest {
     public void equalsMessageId() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
         final long messageIdA = 1;
         final long messageIdB = 2;
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, messageIdA, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, messageIdB, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, messageIdA, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, messageIdB, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
 
         assertTrue(errorHeaderA.equals(errorHeaderA));
@@ -839,8 +787,8 @@ public class ErrorHeaderTest {
     public void equalsErrorCode() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
         final ResponseCode errorCodeA = ResponseCode.FAIL;
         final ResponseCode errorCodeB = ResponseCode.TRANSIENT_FAILURE;
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, errorCodeA, INTERNAL_CODE, ERROR_MSG, USER_MSG);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, errorCodeB, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, errorCodeA, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, errorCodeB, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
         
         assertTrue(errorHeaderA.equals(errorHeaderA));
@@ -859,8 +807,8 @@ public class ErrorHeaderTest {
     public void equalsInternalCode() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
         final int internalCodeA = 1;
         final int internalCodeB = 2;
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, internalCodeA, ERROR_MSG, USER_MSG);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, internalCodeB, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, internalCodeA, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, internalCodeB, ERROR_MSG, USER_MSG);
         final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
         
         assertTrue(errorHeaderA.equals(errorHeaderA));
@@ -879,9 +827,9 @@ public class ErrorHeaderTest {
     public void equalsErrorMessage() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
         final String errorMsgA = "A";
         final String errorMsgB = "B";
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, errorMsgA, USER_MSG);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, errorMsgB, USER_MSG);
-        final ErrorHeader errorHeaderC = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, null, USER_MSG);
+        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, errorMsgA, USER_MSG);
+        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, errorMsgB, USER_MSG);
+        final ErrorHeader errorHeaderC = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, null, USER_MSG);
         final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
         
         assertTrue(errorHeaderA.equals(errorHeaderA));
@@ -904,9 +852,9 @@ public class ErrorHeaderTest {
     public void equalsUserMessage() throws MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
         final String userMsgA = "A";
         final String userMsgB = "B";
-        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, userMsgA);
-        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, userMsgB);
-        final ErrorHeader errorHeaderC = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, null);
+        final ErrorHeader errorHeaderA = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, userMsgA);
+        final ErrorHeader errorHeaderB = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, userMsgB);
+        final ErrorHeader errorHeaderC = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, null);
         final ErrorHeader errorHeaderA2 = (ErrorHeader)Header.parseHeader(ctx, MslTestUtils.toMslObject(encoder, errorHeaderA), CRYPTO_CONTEXTS);
         
         assertTrue(errorHeaderA.equals(errorHeaderA));
@@ -927,7 +875,7 @@ public class ErrorHeaderTest {
     
     @Test
     public void equalsObject() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, RECIPIENT, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
+        final ErrorHeader errorHeader = new ErrorHeader(ctx, ENTITY_AUTH_DATA, MESSAGE_ID, ERROR_CODE, INTERNAL_CODE, ERROR_MSG, USER_MSG);
         assertFalse(errorHeader.equals(null));
         assertFalse(errorHeader.equals(ERROR_MSG));
         assertTrue(errorHeader.hashCode() != ERROR_MSG.hashCode());

--- a/tests/src/test/java/com/netflix/msl/msg/MessageBuilderSuite.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageBuilderSuite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,6 @@ import com.netflix.msl.util.MslTestUtils;
                MessageBuilderSuite.CreateErrorTest.class,
                MessageBuilderSuite.CreateResponseTest.class})
 public class MessageBuilderSuite {
-    private static final String RECIPIENT = "recipient";
     private static final String SERVICE_TOKEN_NAME = "serviceTokenName";
     private static final String USER_ID = "userid";
     private static final String PEER_USER_ID = "peeruserid";
@@ -262,7 +261,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void createNullRequest() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             assertTrue(builder.willEncryptHeader());
             assertTrue(builder.willEncryptPayloads());
             assertTrue(builder.willIntegrityProtectHeader());
@@ -283,7 +282,6 @@ public class MessageBuilderSuite {
             assertNull(header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().isEmpty());
             assertNull(header.getPeerUserIdToken());
-            assertNull(header.getRecipient());
             assertTrue(header.getServiceTokens().isEmpty());
             assertNull(header.getUserAuthenticationData());
             assertNull(header.getUserIdToken());
@@ -291,7 +289,7 @@ public class MessageBuilderSuite {
     
         @Test
         public void createNullPeerRequest() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null);
             assertTrue(builder.willEncryptHeader());
             assertTrue(builder.willEncryptPayloads());
             assertTrue(builder.willIntegrityProtectHeader());
@@ -312,7 +310,6 @@ public class MessageBuilderSuite {
             assertNull(header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().isEmpty());
             assertNull(header.getPeerUserIdToken());
-            assertNull(header.getRecipient());
             assertTrue(header.getServiceTokens().isEmpty());
             assertNull(header.getUserAuthenticationData());
             assertNull(header.getUserIdToken());
@@ -321,7 +318,7 @@ public class MessageBuilderSuite {
         @Test
         public void createRequest() throws MslException {
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, RECIPIENT);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -352,7 +349,6 @@ public class MessageBuilderSuite {
             assertNull(header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().isEmpty());
             assertNull(header.getPeerUserIdToken());
-            assertEquals(RECIPIENT, header.getRecipient());
             assertTrue(header.getServiceTokens().equals(serviceTokens));
             assertNull(header.getUserAuthenticationData());
             assertEquals(USER_ID_TOKEN, header.getUserIdToken());
@@ -362,7 +358,7 @@ public class MessageBuilderSuite {
         public void createRequestWithMessageId() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslException {
             final long messageId = 17;
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, RECIPIENT, messageId);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, messageId);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -392,7 +388,6 @@ public class MessageBuilderSuite {
             assertNull(header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().isEmpty());
             assertNull(header.getPeerUserIdToken());
-            assertEquals(RECIPIENT, header.getRecipient());
             assertTrue(header.getServiceTokens().equals(serviceTokens));
             assertNull(header.getUserAuthenticationData());
             assertEquals(USER_ID_TOKEN, header.getUserIdToken());
@@ -401,7 +396,7 @@ public class MessageBuilderSuite {
         @Test
         public void createPeerRequest() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, RECIPIENT);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
@@ -435,7 +430,6 @@ public class MessageBuilderSuite {
             assertEquals(PEER_MASTER_TOKEN, header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().equals(peerServiceTokens));
             assertEquals(PEER_USER_ID_TOKEN, header.getPeerUserIdToken());
-            assertEquals(RECIPIENT, header.getRecipient());
             assertTrue(header.getServiceTokens().equals(serviceTokens));
             assertNull(header.getUserAuthenticationData());
             assertEquals(USER_ID_TOKEN, header.getUserIdToken());
@@ -443,7 +437,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void createHandshakeRequest() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setNonReplayable(true);
             builder.setRenewable(false);
             builder.setHandshake(true);
@@ -466,7 +460,6 @@ public class MessageBuilderSuite {
             assertNull(header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().isEmpty());
             assertNull(header.getPeerUserIdToken());
-            assertNull(header.getRecipient());
             assertTrue(header.getServiceTokens().isEmpty());
             assertNull(header.getUserAuthenticationData());
             assertNull(header.getUserIdToken());
@@ -474,7 +467,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void createPeerHandshakeRequest() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null);
             builder.setNonReplayable(true);
             builder.setRenewable(false);
             builder.setHandshake(true);
@@ -497,7 +490,6 @@ public class MessageBuilderSuite {
             assertNull(header.getPeerMasterToken());
             assertTrue(header.getPeerServiceTokens().isEmpty());
             assertNull(header.getPeerUserIdToken());
-            assertNull(header.getRecipient());
             assertTrue(header.getServiceTokens().isEmpty());
             assertNull(header.getUserAuthenticationData());
             assertNull(header.getUserIdToken());
@@ -506,7 +498,7 @@ public class MessageBuilderSuite {
         @Test
         public void willEncryptX509EntityAuth() throws MslException {
             final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
-            final MessageBuilder builder = MessageBuilder.createRequest(x509Ctx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(x509Ctx, null, null);
             assertFalse(builder.willEncryptHeader());
             assertFalse(builder.willEncryptPayloads());
             assertTrue(builder.willIntegrityProtectHeader());
@@ -516,7 +508,7 @@ public class MessageBuilderSuite {
         @Test
         public void willIntegrityProtectNoneAuth() throws MslException {
             final MslContext noneCtx = new MockMslContext(EntityAuthenticationScheme.NONE, false);
-            final MessageBuilder builder = MessageBuilder.createRequest(noneCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(noneCtx, null, null);
             assertFalse(builder.willEncryptHeader());
             assertFalse(builder.willEncryptPayloads());
             assertFalse(builder.willIntegrityProtectHeader());
@@ -543,7 +535,7 @@ public class MessageBuilderSuite {
                     updatedServiceTokens.add(peerServiceToken);
             }
             
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             assertEquals(updatedServiceTokens, builder.getServiceTokens());
             assertTrue(builder.getPeerServiceTokens().isEmpty());
             final MessageHeader header = builder.getHeader();
@@ -580,7 +572,7 @@ public class MessageBuilderSuite {
                     updatedPeerServiceTokens.add(serviceToken);
             }
             
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             assertEquals(updatedServiceTokens, builder.getServiceTokens());
             assertEquals(updatedPeerServiceTokens, builder.getPeerServiceTokens());
@@ -595,7 +587,7 @@ public class MessageBuilderSuite {
             // Setting the user authentication data will replace the user ID token
             // and remove any user ID token bound service tokens.
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -628,7 +620,7 @@ public class MessageBuilderSuite {
         @Test
         public void setUserAuthDataNull() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -660,7 +652,7 @@ public class MessageBuilderSuite {
         @Test
         public void unsetUserAuthData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -693,7 +685,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void overwriteKeyRequestData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
@@ -719,7 +711,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void removeKeyRequestData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 builder.addKeyRequestData(keyRequestData);
             final KeyRequestData keyRequestData = KEY_REQUEST_DATA.toArray(new KeyRequestData[0])[0];
@@ -751,7 +743,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.NONREPLAYABLE_MESSAGE_REQUIRES_MASTERTOKEN);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setNonReplayable(true);
             builder.getHeader();
         }
@@ -761,7 +753,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             final byte[] data = new byte[1];
             random.nextBytes(data);
             final ServiceToken serviceToken = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
@@ -773,7 +765,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final byte[] data = new byte[1];
             random.nextBytes(data);
             final ServiceToken serviceToken = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, null, false, null, new NullCryptoContext());
@@ -787,7 +779,7 @@ public class MessageBuilderSuite {
 
             final UserIdToken userIdTokenA = MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER);
             final UserIdToken userIdTokenB = MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, userIdTokenA, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, userIdTokenA);
             final byte[] data = new byte[1];
             random.nextBytes(data);
             final ServiceToken serviceToken = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, userIdTokenB, false, null, new NullCryptoContext());
@@ -799,7 +791,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             final byte[] data = new byte[1];
             random.nextBytes(data);
             final ServiceToken serviceToken = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, USER_ID_TOKEN, false, null, new NullCryptoContext());
@@ -808,7 +800,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void excludeServiceToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final ServiceToken serviceToken : serviceTokens)
                 builder.addServiceToken(serviceToken);
@@ -825,7 +817,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void deleteServiceToken() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             
             // The service token must exist before it can be deleted.
             final byte[] data = new byte[1];
@@ -848,7 +840,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void deleteUnknownServiceToken() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.deleteServiceToken(SERVICE_TOKEN_NAME);
             final MessageHeader messageHeader = builder.getHeader();
             final Set<ServiceToken> tokens = messageHeader.getServiceTokens();
@@ -860,27 +852,27 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void notP2PCreatePeerRequest() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             
         }
         
         @Test(expected = MslInternalException.class)
         public void missingPeerMasterTokenCreatePeerRequest() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(null, PEER_USER_ID_TOKEN);
             
         }
         
         @Test(expected = MslException.class)
         public void mismatchedPeerMasterTokenCreatePeerRequest() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(MASTER_TOKEN, PEER_USER_ID_TOKEN);
         }
         
         @Test(expected = MslInternalException.class)
         public void notP2PAddPeerServiceToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final ServiceToken peerServiceToken = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, new byte[0], null, null, false, null, new NullCryptoContext());
             builder.addPeerServiceToken(peerServiceToken);
         }
@@ -890,7 +882,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final ServiceToken peerServiceToken = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, new byte[0], PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
             builder.addPeerServiceToken(peerServiceToken);
         }
@@ -900,7 +892,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             final ServiceToken peerServiceToken = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, new byte[0], MASTER_TOKEN, null, false, null, new NullCryptoContext());
             builder.addPeerServiceToken(peerServiceToken);
@@ -911,7 +903,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH);
 
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
             final ServiceToken peerServiceToken = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, new byte[0], PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, null, new NullCryptoContext());
             builder.addPeerServiceToken(peerServiceToken);
@@ -924,7 +916,7 @@ public class MessageBuilderSuite {
 
             final UserIdToken userIdTokenA = MslTestUtils.getUserIdToken(p2pCtx, PEER_MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER);
             final UserIdToken userIdTokenB = MslTestUtils.getUserIdToken(p2pCtx, PEER_MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, userIdTokenA);
             final ServiceToken peerServiceToken = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, new byte[0], PEER_MASTER_TOKEN, userIdTokenB, false, null, new NullCryptoContext());
             builder.addPeerServiceToken(peerServiceToken);
@@ -932,7 +924,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void excludePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -951,7 +943,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void deletePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             
             // The service token must exist before it can be deleted.
@@ -975,7 +967,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void deleteUnknownPeerServiceToken() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             builder.deletePeerServiceToken(SERVICE_TOKEN_NAME);
             final MessageHeader messageHeader = builder.getHeader();
@@ -998,7 +990,7 @@ public class MessageBuilderSuite {
             final Set<ServiceToken> peerServiceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             store.addServiceTokens(peerServiceTokens);
             
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setAuthTokens(MASTER_TOKEN, null);
             
             // The message service tokens will include all unbound service
@@ -1029,7 +1021,7 @@ public class MessageBuilderSuite {
             final Set<ServiceToken> peerServiceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             store.addServiceTokens(peerServiceTokens);
             
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             builder.setAuthTokens(MASTER_TOKEN, null);
             
             // The message service tokens will include all unbound service
@@ -1060,7 +1052,7 @@ public class MessageBuilderSuite {
             final Set<ServiceToken> peerServiceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             store.addServiceTokens(peerServiceTokens);
             
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setAuthTokens(MASTER_TOKEN, USER_ID_TOKEN);
             
             // The message service tokens will include all unbound service
@@ -1091,7 +1083,7 @@ public class MessageBuilderSuite {
             final Set<ServiceToken> peerServiceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             store.addServiceTokens(peerServiceTokens);
             
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             builder.setAuthTokens(MASTER_TOKEN, USER_ID_TOKEN);
             
             // The message service tokens will include all unbound service
@@ -1111,7 +1103,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setNullMasterToken() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setAuthTokens(null, null);
             final MessageHeader header = builder.getHeader();
             assertNotNull(header);
@@ -1122,13 +1114,13 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setMismatchedAuthTokens() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setAuthTokens(MASTER_TOKEN, PEER_USER_ID_TOKEN);
         }
         
         @Test
         public void setUser() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             builder.setUser(USER_ID_TOKEN.getUser());
             final UserIdToken userIdToken = builder.getUserIdToken();
             assertNotNull(userIdToken);
@@ -1137,19 +1129,19 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setUserNoMasterToken() throws MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             builder.setUser(USER_ID_TOKEN.getUser());
         }
         
         @Test(expected = MslInternalException.class)
         public void setUserHasUserIdToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setUser(USER_ID_TOKEN.getUser());
         }
         
         @Test
         public void setPeerUser() throws MslMessageException, MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
             builder.setUser(PEER_USER_ID_TOKEN.getUser());
             final UserIdToken userIdToken = builder.getPeerUserIdToken();
@@ -1159,25 +1151,25 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setPeerUserNoPeerMasterToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null);
             builder.setUser(PEER_USER_ID_TOKEN.getUser());
         }
         
         @Test(expected = MslInternalException.class)
         public void setPeerUserHasPeerUserIdToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder builder = MessageBuilder.createRequest(p2pCtx, null, null);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             builder.setUser(USER_ID_TOKEN.getUser());
         }
         
         @Test(expected = MslInternalException.class)
         public void negativeMessageId() throws MslException {
-            MessageBuilder.createRequest(trustedNetCtx, null, null, null, -1);
+            MessageBuilder.createRequest(trustedNetCtx, null, null, -1);
         }
         
         @Test(expected = MslInternalException.class)
         public void tooLargeMessageId() throws MslException {
-            MessageBuilder.createRequest(trustedNetCtx, null, null, null, MslConstants.MAX_LONG_VALUE + 1);
+            MessageBuilder.createRequest(trustedNetCtx, null, null, MslConstants.MAX_LONG_VALUE + 1);
         }
     }
     
@@ -1189,63 +1181,58 @@ public class MessageBuilderSuite {
         
         @Test
         public void ctor() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE);
+            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE);
             assertNotNull(errorHeader);
             assertEquals(MSL_ERROR.getResponseCode(), errorHeader.getErrorCode());
             assertEquals(MSL_ERROR.getMessage(), errorHeader.getErrorMessage());
             assertEquals(USER_MESSAGE, errorHeader.getUserMessage());
-            assertEquals(RECIPIENT, errorHeader.getRecipient());
             assertEquals(REQUEST_MESSAGE_ID + 1, errorHeader.getMessageId());
         }
         
         @Test
         public void nullRecipient() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, null, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE);
+            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE);
             assertNotNull(errorHeader);
             assertEquals(MSL_ERROR.getResponseCode(), errorHeader.getErrorCode());
             assertEquals(MSL_ERROR.getMessage(), errorHeader.getErrorMessage());
             assertEquals(USER_MESSAGE, errorHeader.getUserMessage());
-            assertNull(errorHeader.getRecipient());
             assertEquals(REQUEST_MESSAGE_ID + 1, errorHeader.getMessageId());
         }
         
         @Test
         public void maxMessageId() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
             final Long messageId = MslConstants.MAX_LONG_VALUE;
-            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, messageId, MSL_ERROR, USER_MESSAGE);
+            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, messageId, MSL_ERROR, USER_MESSAGE);
             assertNotNull(errorHeader);
             assertEquals(MSL_ERROR.getResponseCode(), errorHeader.getErrorCode());
             assertEquals(MSL_ERROR.getMessage(), errorHeader.getErrorMessage());
             assertEquals(USER_MESSAGE, errorHeader.getUserMessage());
-            assertEquals(RECIPIENT, errorHeader.getRecipient());
             assertEquals(0, errorHeader.getMessageId());
         }
         
         @Test
         public void nullMessageId() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, null, MSL_ERROR, USER_MESSAGE);
+            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, null, MSL_ERROR, USER_MESSAGE);
             assertNotNull(errorHeader);
             assertEquals(MSL_ERROR.getResponseCode(), errorHeader.getErrorCode());
             assertEquals(MSL_ERROR.getMessage(), errorHeader.getErrorMessage());
             assertEquals(USER_MESSAGE, errorHeader.getUserMessage());
-            assertEquals(RECIPIENT, errorHeader.getRecipient());
             assertTrue(errorHeader.getMessageId() > 0);
         }
         
         @Test(expected = MslInternalException.class)
         public void negativeMessageId() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
             final Long messageId = -12L;
-            MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, messageId, MSL_ERROR, USER_MESSAGE);
+            MessageBuilder.createErrorResponse(trustedNetCtx, messageId, MSL_ERROR, USER_MESSAGE);
         }
         
         @Test
         public void nullUserMessage() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
-            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, REQUEST_MESSAGE_ID, MSL_ERROR, null);
+            final ErrorHeader errorHeader = MessageBuilder.createErrorResponse(trustedNetCtx, REQUEST_MESSAGE_ID, MSL_ERROR, null);
             assertNotNull(errorHeader);
             assertEquals(MSL_ERROR.getResponseCode(), errorHeader.getErrorCode());
             assertEquals(MSL_ERROR.getMessage(), errorHeader.getErrorMessage());
             assertNull(errorHeader.getUserMessage());
-            assertEquals(RECIPIENT, errorHeader.getRecipient());
             assertEquals(REQUEST_MESSAGE_ID + 1, errorHeader.getMessageId());
         }
     }
@@ -1303,7 +1290,7 @@ public class MessageBuilderSuite {
         public void createNullResponse() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslException {
             // This will not exercise any of the complex logic, so no key
             // request data, entity auth data, or user auth data. Just tokens.
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final ServiceToken serviceToken : serviceTokens)
                 requestBuilder.addServiceToken(serviceToken);
@@ -1330,7 +1317,6 @@ public class MessageBuilderSuite {
             assertNull(response.getPeerMasterToken());
             assertTrue(response.getPeerServiceTokens().isEmpty());
             assertNull(response.getPeerUserIdToken());
-            assertEquals(MASTER_TOKEN.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(serviceTokens));
             assertNull(response.getUserAuthenticationData());
             assertEquals(USER_ID_TOKEN, response.getUserIdToken());
@@ -1340,7 +1326,7 @@ public class MessageBuilderSuite {
         public void createNullPeerResponse() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
             // This will not exercise any of the complex logic, so no key
             // request data, entity auth data, or user auth data. Just tokens.
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             requestBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -1373,13 +1359,12 @@ public class MessageBuilderSuite {
             assertNull(response.getUserAuthenticationData());
             assertEquals(PEER_USER_ID_TOKEN, response.getUserIdToken());
             assertTrue(response.getPeerServiceTokens().equals(serviceTokens));
-            assertEquals(MASTER_TOKEN.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(peerServiceTokens));
         }
         
         @Test
         public void createEntityAuthResponse() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, null, null);
             for (final ServiceToken serviceToken : serviceTokens)
                 requestBuilder.addServiceToken(serviceToken);
@@ -1407,7 +1392,6 @@ public class MessageBuilderSuite {
             assertNull(response.getPeerMasterToken());
             assertTrue(response.getPeerServiceTokens().isEmpty());
             assertNull(response.getPeerUserIdToken());
-            assertEquals(entityAuthData.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(serviceTokens));
             assertNull(response.getUserAuthenticationData());
             assertNull(response.getUserIdToken());
@@ -1415,7 +1399,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void createEntityAuthPeerResponse() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
             requestBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, null, null);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -1447,16 +1431,13 @@ public class MessageBuilderSuite {
             assertNull(response.getPeerUserIdToken());
             assertNull(response.getUserAuthenticationData());
             assertEquals(PEER_USER_ID_TOKEN, response.getUserIdToken());
-            final EntityAuthenticationData entityAuthData = p2pCtx.getEntityAuthenticationData(null);
-            assertEquals(entityAuthData.getIdentity(), response.getRecipient());
             assertTrue(response.getPeerServiceTokens().equals(serviceTokens));
-            assertEquals(trustedNetCtx.getEntityAuthenticationData(null).getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(peerServiceTokens));
         }
         
         @Test
         public void createResponse() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -1487,7 +1468,6 @@ public class MessageBuilderSuite {
             assertNull(response.getPeerMasterToken());
             assertTrue(response.getPeerServiceTokens().isEmpty());
             assertNull(response.getPeerUserIdToken());
-            assertEquals(MASTER_TOKEN.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(serviceTokens));
             assertEquals(USER_AUTH_DATA, response.getUserAuthenticationData());
             assertEquals(USER_ID_TOKEN, response.getUserIdToken());
@@ -1495,7 +1475,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void createPeerResponse() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslMessageException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(p2pCtx, request);
@@ -1526,7 +1506,6 @@ public class MessageBuilderSuite {
             assertEquals(PEER_USER_ID_TOKEN, response.getPeerUserIdToken());
             assertEquals(USER_AUTH_DATA, response.getUserAuthenticationData());
             assertTrue(response.getPeerServiceTokens().equals(peerServiceTokens));
-            assertEquals(PEER_MASTER_TOKEN.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(serviceTokens));
             assertNull(response.getUserIdToken());
         }
@@ -1535,7 +1514,7 @@ public class MessageBuilderSuite {
         public void createHandshakeResponse() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslException {
             // This will not exercise any of the complex logic, so no key
             // request data, entity auth data, or user auth data. Just tokens.
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final ServiceToken serviceToken : serviceTokens)
                 requestBuilder.addServiceToken(serviceToken);
@@ -1565,7 +1544,6 @@ public class MessageBuilderSuite {
             assertNull(response.getPeerMasterToken());
             assertTrue(response.getPeerServiceTokens().isEmpty());
             assertNull(response.getPeerUserIdToken());
-            assertEquals(MASTER_TOKEN.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(serviceTokens));
             assertNull(response.getUserAuthenticationData());
             assertEquals(USER_ID_TOKEN, response.getUserIdToken());
@@ -1575,7 +1553,7 @@ public class MessageBuilderSuite {
         public void createPeerHandshakeResponse() throws MslEncodingException, MslCryptoException, MslMessageException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
             // This will not exercise any of the complex logic, so no key
             // request data, entity auth data, or user auth data. Just tokens.
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             requestBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final ServiceToken serviceToken : serviceTokens)
@@ -1612,14 +1590,13 @@ public class MessageBuilderSuite {
             assertNull(response.getUserAuthenticationData());
             assertEquals(PEER_USER_ID_TOKEN, response.getUserIdToken());
             assertTrue(response.getPeerServiceTokens().equals(serviceTokens));
-            assertEquals(MASTER_TOKEN.getIdentity(), response.getRecipient());
             assertTrue(response.getServiceTokens().equals(peerServiceTokens));
         }
 
         @Test
         public void willEncryptX509EntityAuth() throws MslException {
             final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(x509Ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(x509Ctx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(x509Ctx, request);
@@ -1630,7 +1607,7 @@ public class MessageBuilderSuite {
         @Test
         public void willEncryptX509EntityAuthKeyExchange() throws MslException {
             final MslContext x509Ctx = new MockMslContext(EntityAuthenticationScheme.X509, false);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(x509Ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(x509Ctx, null, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1643,7 +1620,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void storedServiceTokens() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             assertTrue(request.getServiceTokens().isEmpty());
             
@@ -1676,7 +1653,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void storedPeerServiceTokens() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             assertTrue(request.getServiceTokens().isEmpty());
             assertTrue(request.getPeerServiceTokens().isEmpty());
@@ -1719,7 +1696,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void keyxAddServiceToken() throws MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1745,7 +1722,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -1761,7 +1738,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1780,7 +1757,7 @@ public class MessageBuilderSuite {
             thrown.expect(MslMessageException.class);
             thrown.expectMslError(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH);
 
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1799,7 +1776,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void maxRequestMessageId() throws MslKeyExchangeException, MslUserAuthException, MslException {
-            final HeaderData headerData = new HeaderData(null, MslConstants.MAX_LONG_VALUE, null, false, false, null, null, null, null, null, null);
+            final HeaderData headerData = new HeaderData(MslConstants.MAX_LONG_VALUE, null, false, false, null, null, null, null, null, null);
             final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
             final MessageHeader request = new MessageHeader(trustedNetCtx, null, MASTER_TOKEN, headerData, peerData);
             
@@ -1813,7 +1790,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1835,7 +1812,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(p2pCtx, renewalWindow, expirationWindow, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, requestMasterToken, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1858,7 +1835,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expirationWindow, MslConstants.MAX_LONG_VALUE, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1883,7 +1860,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() + 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 20000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expirationWindow, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1904,7 +1881,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
             final Date expirationWindow = new Date(System.currentTimeMillis() - 10000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expirationWindow, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -1926,7 +1903,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() + 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 20000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expirationWindow, MslConstants.MAX_LONG_VALUE, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null);
             requestBuilder.setNonReplayable(true);
             final MessageHeader request = requestBuilder.getHeader();
             
@@ -1949,7 +1926,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(ctx, renewalWindow, expirationWindow, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final HeaderData headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            final HeaderData headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
             final MessageHeader request = new MessageHeader(trustedNetCtx, null, requestMasterToken, headerData, peerData);
                         
@@ -1966,7 +1943,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(ctx, renewalWindow, expirationWindow, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, requestMasterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, requestMasterToken, null);
             requestBuilder.setRenewable(true);
             // This should place the supported key exchange scheme in the
             // middle, guaranteeing that we will have to skip one unsupported
@@ -1994,7 +1971,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expirationWindow = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(ctx, renewalWindow, expirationWindow, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-            final HeaderData headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            final HeaderData headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
             final MessageHeader request = new MessageHeader(ctx, null, requestMasterToken, headerData, peerData);
             
@@ -2029,7 +2006,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void keyResponseData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder localRequestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder localRequestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             localRequestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 localRequestBuilder.addKeyRequestData(keyRequestData);
@@ -2049,7 +2026,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void peerKeyResponseData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder localRequestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder localRequestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
             localRequestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 localRequestBuilder.addKeyRequestData(keyRequestData);
@@ -2079,7 +2056,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void entityAuthDataNotRenewable() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2093,7 +2070,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void entityAuthDataRenewable() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -2110,7 +2087,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void peerEntityAuthDataRenewable() throws MslKeyExchangeException, MslMasterTokenException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -2137,7 +2114,7 @@ public class MessageBuilderSuite {
             for (final KeyExchangeScheme scheme : KeyExchangeScheme.values())
                 ctx.removeKeyExchangeFactories(scheme);
             
-            final HeaderData headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            final HeaderData headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
             final MessageHeader request = new MessageHeader(ctx, ctx.getEntityAuthenticationData(null), null, headerData, peerData);
             
@@ -2151,7 +2128,7 @@ public class MessageBuilderSuite {
                 ctx.removeKeyExchangeFactories(scheme);
             ctx.addKeyExchangeFactory(new AsymmetricWrappedExchange(new MockAuthenticationUtils()));
             
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null);
             requestBuilder.setRenewable(true);
             // This should place the supported key exchange scheme in the
             // middle, guaranteeing that we will have to skip one unsupported
@@ -2171,7 +2148,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final UserIdToken requestUserIdToken = new UserIdToken(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken);
             requestBuilder.setRenewable(true);
             final MessageHeader request = requestBuilder.getHeader();
             
@@ -2191,7 +2168,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final UserIdToken requestUserIdToken = new UserIdToken(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2211,7 +2188,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 10000);
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final UserIdToken requestUserIdToken = new UserIdToken(p2pCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, requestUserIdToken);
             requestBuilder.setRenewable(true);
             final MessageHeader request = requestBuilder.getHeader();
             
@@ -2232,7 +2209,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
             final Date expiration = new Date(System.currentTimeMillis() - 10000);
             final UserIdToken requestUserIdToken = new UserIdToken(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken);
             requestBuilder.setRenewable(true);
             final MessageHeader request = requestBuilder.getHeader();
             
@@ -2252,7 +2229,7 @@ public class MessageBuilderSuite {
             final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
             final Date expiration = new Date(System.currentTimeMillis() - 10000);
             final UserIdToken requestUserIdToken = new UserIdToken(trustedNetCtx, renewalWindow, expiration, MASTER_TOKEN, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2281,7 +2258,7 @@ public class MessageBuilderSuite {
             // Now rebuild the user ID token and the build the request.
             final MslObject userIdTokenMo = MslTestUtils.toMslObject(encoder, requestUserIdToken);
             final UserIdToken unverifiedUserIdToken = new UserIdToken(ctx, userIdTokenMo, MASTER_TOKEN);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, MASTER_TOKEN, unverifiedUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, MASTER_TOKEN, unverifiedUserIdToken);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(ctx, request);
@@ -2302,7 +2279,7 @@ public class MessageBuilderSuite {
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
             final UserIdToken requestUserIdToken = new UserIdToken(trustedNetCtx, renewalWindow, expiration, requestMasterToken, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -2330,7 +2307,7 @@ public class MessageBuilderSuite {
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
             final UserIdToken requestUserIdToken = new UserIdToken(trustedNetCtx, renewalWindow, expiration, requestMasterToken, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken);
             requestBuilder.setRenewable(true);
             final MessageHeader request = requestBuilder.getHeader();
 
@@ -2353,7 +2330,7 @@ public class MessageBuilderSuite {
             final Date expiration = new Date(System.currentTimeMillis() + 10000);
             final MasterToken requestMasterToken = new MasterToken(p2pCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
             final UserIdToken requestUserIdToken = new UserIdToken(p2pCtx, renewalWindow, expiration, requestMasterToken, 1L, ISSUER_DATA, USER);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, requestMasterToken, requestUserIdToken, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, requestMasterToken, requestUserIdToken);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -2379,7 +2356,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void masterTokenUserAuthData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2395,7 +2372,7 @@ public class MessageBuilderSuite {
         public void masterTokenUserAuthenticated() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
             final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
             
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, MASTER_TOKEN, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2417,7 +2394,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void peerMasterTokenUserAuthData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2434,7 +2411,7 @@ public class MessageBuilderSuite {
         public void peerMasterTokenUserAuthenticated() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
             final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, true);
             
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, MASTER_TOKEN, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2456,7 +2433,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void entityAuthDataUserAuthData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
@@ -2480,7 +2457,7 @@ public class MessageBuilderSuite {
         public void entityAuthDataUserAuthenticatedData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
             final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
             
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
@@ -2510,7 +2487,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void entityUserAuthNoKeyRequestData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2525,7 +2502,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void peerEntityAuthDataUserAuthData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
@@ -2549,7 +2526,7 @@ public class MessageBuilderSuite {
         public void peerEntityAuthDataUserAuthenticatedData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslKeyExchangeException, MslUserAuthException, MslException, MslEncoderException {
             final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, true);
             
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null);
             requestBuilder.setRenewable(true);
             requestBuilder.setUserAuthenticationData(USER_AUTH_DATA);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
@@ -2587,7 +2564,7 @@ public class MessageBuilderSuite {
             for (final UserAuthenticationScheme scheme : UserAuthenticationScheme.values())
                 ctx.removeUserAuthenticationFactory(scheme);
             
-            final HeaderData headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, null, null, USER_AUTH_DATA, null, null);
+            final HeaderData headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, null, null, USER_AUTH_DATA, null, null);
             final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
             final MessageHeader request = new MessageHeader(ctx, null, MASTER_TOKEN, headerData, peerData);
             
@@ -2596,7 +2573,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setMasterToken() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MslStore store = trustedNetCtx.getMslStore();
@@ -2626,7 +2603,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setExistingMasterToken() throws MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MslStore store = trustedNetCtx.getMslStore();
@@ -2656,7 +2633,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setAuthTokens() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MslStore store = trustedNetCtx.getMslStore();
@@ -2686,7 +2663,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setExistingAuthTokens() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MslStore store = trustedNetCtx.getMslStore();
@@ -2716,7 +2693,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setNullMasterToken() throws MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2729,7 +2706,7 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setMismatchedAuthTokens() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2747,7 +2724,7 @@ public class MessageBuilderSuite {
             final SecretKey hmacKey = MockPresharedAuthenticationFactory.KPH;
             final MasterToken masterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1, 1, null, identity, encryptionKey, hmacKey);
                 
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, masterToken, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, masterToken, null);
             requestBuilder.setRenewable(true);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
@@ -2759,7 +2736,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setMasterTokenHasPeerKeyExchangeData() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             for (final KeyRequestData keyRequestData : KEY_REQUEST_DATA)
                 requestBuilder.addKeyRequestData(keyRequestData);
             final MessageHeader request = requestBuilder.getHeader();
@@ -2802,7 +2779,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setUser() throws MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2814,7 +2791,7 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setUserNoMasterToken() throws MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2823,7 +2800,7 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setUserHasUserIdToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(trustedNetCtx, request);
@@ -2832,7 +2809,7 @@ public class MessageBuilderSuite {
         
         @Test
         public void setPeerUser() throws MslMessageException, MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(p2pCtx, request);
@@ -2844,7 +2821,7 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setPeerUserNoPeerMasterToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(p2pCtx, request);
@@ -2853,7 +2830,7 @@ public class MessageBuilderSuite {
         
         @Test(expected = MslInternalException.class)
         public void setPeerUserHasPeerUserIdToken() throws MslEncodingException, MslCryptoException, MslException {
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final MessageHeader request = requestBuilder.getHeader();
             
             final MessageBuilder responseBuilder = MessageBuilder.createResponse(p2pCtx, request);
@@ -2871,7 +2848,7 @@ public class MessageBuilderSuite {
             final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
             final MessageCapabilities caps = new MessageCapabilities(gzipOnly, null, null);
             ctx.setMessageCapabilities(caps);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             assertEquals(caps, request.getMessageCapabilities());
             
@@ -2889,7 +2866,7 @@ public class MessageBuilderSuite {
             
             final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
             ctx.setMessageCapabilities(null);
-            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null, null);
+            final MessageBuilder requestBuilder = MessageBuilder.createRequest(ctx, null, null);
             final MessageHeader request = requestBuilder.getHeader();
             assertNull(request.getMessageCapabilities());
             

--- a/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,12 +191,12 @@ public class MessageInputStreamTest {
         random.nextBytes(DATA);
         buffer = new byte[MAX_PAYLOAD_CHUNKS * MAX_DATA_SIZE];
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         MESSAGE_HEADER = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
 
-        ERROR_HEADER =  new ErrorHeader(trustedNetCtx, entityAuthData, null, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
+        ERROR_HEADER =  new ErrorHeader(trustedNetCtx, entityAuthData, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
 
         final KeyRequestData keyRequest = new SymmetricWrappedExchange.RequestData(KeyId.PSK);
         KEY_REQUEST_DATA.add(keyRequest);
@@ -274,7 +274,7 @@ public class MessageInputStreamTest {
 
     @Test
     public void entityAuthDataIdentity() throws MslException, IOException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
@@ -290,7 +290,7 @@ public class MessageInputStreamTest {
     @Test
     public void masterTokenIdentity() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final MasterToken masterToken = MslTestUtils.getMasterToken(trustedNetCtx, 1, 1);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
 
@@ -305,7 +305,7 @@ public class MessageInputStreamTest {
     @Test
     public void errorHeaderIdentity() throws MslEncodingException, MslEntityAuthException, MslCryptoException, MslUserAuthException, MslMessageException, MslKeyExchangeException, MslMasterTokenException, IOException, MslException, MslEncoderException {
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
-        final ErrorHeader errorHeader = new ErrorHeader(trustedNetCtx, entityAuthData, null, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
+        final ErrorHeader errorHeader = new ErrorHeader(trustedNetCtx, entityAuthData, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
 
         final InputStream is = generateInputStream(errorHeader, payloads);
         final MessageInputStream mis = new MessageInputStream(trustedNetCtx, is, KEY_REQUEST_DATA, cryptoContexts);
@@ -325,7 +325,7 @@ public class MessageInputStreamTest {
         final UnauthenticatedAuthenticationFactory factory = new UnauthenticatedAuthenticationFactory(authutils);
         ctx.addEntityAuthenticationFactory(factory);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
@@ -346,7 +346,7 @@ public class MessageInputStreamTest {
         ctx.setTokenFactory(factory);
 
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -370,7 +370,7 @@ public class MessageInputStreamTest {
     public void userIdTokenUser() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
         final MasterToken masterToken = MslTestUtils.getMasterToken(trustedNetCtx, 1, 1);
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, masterToken, 1, MockEmailPasswordAuthenticationFactory.USER);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
 
@@ -393,7 +393,7 @@ public class MessageInputStreamTest {
 
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(ctx, masterToken, 1, MockEmailPasswordAuthenticationFactory.USER);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -414,7 +414,7 @@ public class MessageInputStreamTest {
 
         final MasterToken masterToken = MslTestUtils.getMasterToken(ctx, 1, 1);
         final UserIdToken userIdToken = MslTestUtils.getUntrustedUserIdToken(ctx, masterToken, 1, MockEmailPasswordAuthenticationFactory.USER);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -427,7 +427,7 @@ public class MessageInputStreamTest {
     // FIXME This can be removed once the old handshake logic is removed.
     @Test
     public void explicitHandshake() throws IOException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, MslException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
@@ -443,7 +443,7 @@ public class MessageInputStreamTest {
     // FIXME This can be removed once the old handshake logic is removed.
     @Test
     public void inferredHandshake() throws MslException, IOException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
@@ -460,7 +460,7 @@ public class MessageInputStreamTest {
     // FIXME This can be removed once the old handshake logic is removed.
     @Test
     public void notHandshake() throws IOException, MslException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
@@ -476,7 +476,7 @@ public class MessageInputStreamTest {
 
     @Test
     public void keyExchange() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
@@ -495,7 +495,7 @@ public class MessageInputStreamTest {
 
     @Test
     public void peerKeyExchange() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, MslException, IOException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = p2pCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, entityAuthData, null, headerData, peerData);
@@ -522,7 +522,7 @@ public class MessageInputStreamTest {
         final MockMslContext ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
         ctx.removeKeyExchangeFactories(KeyExchangeScheme.SYMMETRIC_WRAPPED);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
@@ -542,7 +542,7 @@ public class MessageInputStreamTest {
         thrown.expectMslError(MslError.KEYX_RESPONSE_REQUEST_MISMATCH);
         thrown.expectMessageId(MSG_ID);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = ctx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
@@ -573,7 +573,7 @@ public class MessageInputStreamTest {
         final KeyExchangeData keyExchangeData = factory.generateResponse(ctx, ENCODER_FORMAT, keyRequest, entityAuthData);
         final KeyResponseData keyResponseData = keyExchangeData.keyResponseData;
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, entityAuthData, null, headerData, peerData);
 
@@ -598,7 +598,7 @@ public class MessageInputStreamTest {
         final KeyExchangeData keyExchangeData = factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequest, entityAuthData);
         final KeyResponseData keyResponseData = keyExchangeData.keyResponseData;
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
 
@@ -612,7 +612,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
 
@@ -626,7 +626,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(p2pCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, null, masterToken, headerData, peerData);
 
@@ -646,7 +646,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
 
@@ -666,7 +666,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(trustedNetCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, null, masterToken, headerData, peerData);
 
@@ -684,7 +684,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(ctx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -715,7 +715,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(p2pCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, null, masterToken, headerData, peerData);
 
@@ -733,7 +733,7 @@ public class MessageInputStreamTest {
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
         final Date expiration = new Date(System.currentTimeMillis() - 10000);
         final MasterToken masterToken = new MasterToken(p2pCtx, renewalWindow, expiration, 1L, 1L, null, MockPresharedAuthenticationFactory.PSK_ESN, MockPresharedAuthenticationFactory.KPE, MockPresharedAuthenticationFactory.KPH);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, null, masterToken, headerData, peerData);
 
@@ -749,7 +749,7 @@ public class MessageInputStreamTest {
         thrown.expectMessageId(MSG_ID);
 
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, false, true, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, 1L, false, true, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
 
@@ -765,7 +765,7 @@ public class MessageInputStreamTest {
         thrown.expectMessageId(MSG_ID);
 
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, true, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, 1L, true, true, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
 
@@ -781,7 +781,7 @@ public class MessageInputStreamTest {
         thrown.expectMessageId(MSG_ID);
 
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);
 
@@ -797,7 +797,7 @@ public class MessageInputStreamTest {
         thrown.expectMessageId(MSG_ID);
 
         final EntityAuthenticationData entityAuthData = p2pCtx.getEntityAuthenticationData(null);
-        final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(p2pCtx, entityAuthData, null, headerData, peerData);
 
@@ -820,7 +820,7 @@ public class MessageInputStreamTest {
         factory.setLargestNonReplayableId(nonReplayableId);
         ctx.setTokenFactory(factory);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -843,7 +843,7 @@ public class MessageInputStreamTest {
         factory.setLargestNonReplayableId(nonReplayableId);
         ctx.setTokenFactory(factory);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, nonReplayableId - 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, nonReplayableId - 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -867,7 +867,7 @@ public class MessageInputStreamTest {
             try {
                 factory.setLargestNonReplayableId(largestNonReplayableId);
 
-                final HeaderData headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+                final HeaderData headerData = new HeaderData(MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
                 final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
                 final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -901,7 +901,7 @@ public class MessageInputStreamTest {
             try {
                 factory.setLargestNonReplayableId(largestNonReplayableId);
 
-                final HeaderData headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+                final HeaderData headerData = new HeaderData(MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
                 final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
                 final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -931,7 +931,7 @@ public class MessageInputStreamTest {
         factory.setLargestNonReplayableId(1L);
         ctx.setTokenFactory(factory);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -953,7 +953,7 @@ public class MessageInputStreamTest {
         factory.setLargestNonReplayableId(1L);
         ctx.setTokenFactory(factory);
 
-        final HeaderData headerData = new HeaderData(null, MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, 1L, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, null, masterToken, headerData, peerData);
 
@@ -990,7 +990,7 @@ public class MessageInputStreamTest {
 
     @Test
     public void readFromHandshakeMessage() throws IOException, MslUserAuthException, MslKeyExchangeException, MslUserIdTokenException, MslException, MslEncoderException {
-        final HeaderData headerData = new HeaderData(null, MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
+        final HeaderData headerData = new HeaderData(MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final EntityAuthenticationData entityAuthData = trustedNetCtx.getEntityAuthenticationData(null);
         final MessageHeader messageHeader = new MessageHeader(trustedNetCtx, entityAuthData, null, headerData, peerData);

--- a/tests/src/test/java/com/netflix/msl/msg/MessageOutputStreamTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageOutputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,13 +112,13 @@ public class MessageOutputStreamTest {
         ctx = new MockMslContext(EntityAuthenticationScheme.PSK, false);
         encoder = ctx.getMslEncoderFactory();
         
-        final HeaderData headerData = new HeaderData(null, 1, null, false, false, ctx.getMessageCapabilities(), null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(1, null, false, false, ctx.getMessageCapabilities(), null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         ENTITY_AUTH_DATA = ctx.getEntityAuthenticationData(null);
         MESSAGE_HEADER = new MessageHeader(ctx, ENTITY_AUTH_DATA, null, headerData, peerData);
         PAYLOAD_CRYPTO_CONTEXT = MESSAGE_HEADER.getCryptoContext();
         
-        ERROR_HEADER =  new ErrorHeader(ctx, ENTITY_AUTH_DATA, null, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
+        ERROR_HEADER =  new ErrorHeader(ctx, ENTITY_AUTH_DATA, 1, ResponseCode.FAIL, 3, "errormsg", "usermsg");
     }
     
     @AfterClass
@@ -491,7 +491,7 @@ public class MessageOutputStreamTest {
     
     @Test(expected = MslInternalException.class)
     public void writeHandshakeMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, IOException {
-        final HeaderData headerData = new HeaderData(null, 1, null, false, true, ctx.getMessageCapabilities(), null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(1, null, false, true, ctx.getMessageCapabilities(), null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, ENTITY_AUTH_DATA, null, headerData, peerData);
         
@@ -672,7 +672,7 @@ public class MessageOutputStreamTest {
     
     @Test
     public void noRequestCompressionAlgorithm() throws IOException, MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException {
-        final HeaderData headerData = new HeaderData(null, 1, null, false, false, null, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(1, null, false, false, null, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, ENTITY_AUTH_DATA, null, headerData, peerData);
         
@@ -723,7 +723,7 @@ public class MessageOutputStreamTest {
         algos.add(CompressionAlgorithm.GZIP);
         final MessageCapabilities capabilities = new MessageCapabilities(algos, null, null);
 
-        final HeaderData headerData = new HeaderData(null, 1, null, false, false, capabilities, null, null, null, null, null);
+        final HeaderData headerData = new HeaderData(1, null, false, false, capabilities, null, null, null, null, null);
         final HeaderPeerData peerData = new HeaderPeerData(null, null, null);
         final MessageHeader messageHeader = new MessageHeader(ctx, ENTITY_AUTH_DATA, null, headerData, peerData);
 

--- a/tests/src/test/java/com/netflix/msl/msg/MessageServiceTokenBuilderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageServiceTokenBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void primaryMasterToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertTrue(tokenBuilder.isPrimaryMasterTokenAvailable());
@@ -143,7 +143,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void primaryMasterTokenKeyx() throws MslException {
-        final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+        final MessageBuilder requestBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
         requestBuilder.setRenewable(true);
         requestBuilder.addKeyRequestData(KEY_REQUEST_DATA);
         final MessageHeader request = requestBuilder.getHeader();
@@ -161,7 +161,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void primaryUserIdToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertTrue(tokenBuilder.isPrimaryMasterTokenAvailable());
@@ -172,7 +172,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void peerMasterToken() throws MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -184,7 +184,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void peerMasterTokenKeyx() throws MslException {
-        final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder requestBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         requestBuilder.setRenewable(true);
         requestBuilder.addKeyRequestData(KEY_REQUEST_DATA);
         final MessageHeader request = requestBuilder.getHeader();
@@ -200,7 +200,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void peerUserIdToken() throws MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -212,7 +212,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void getPrimaryServiceTokens() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         for (final ServiceToken serviceToken : serviceTokens)
             msgBuilder.addServiceToken(serviceToken);
@@ -224,7 +224,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void getPeerServiceTokens() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final Set<ServiceToken> peerServiceTokens = MslTestUtils.getServiceTokens(p2pCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         for (final ServiceToken peerServiceToken : peerServiceTokens)
@@ -237,7 +237,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void getBothServiceTokens() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         for (final ServiceToken serviceToken : serviceTokens)
             msgBuilder.addServiceToken(serviceToken);
@@ -253,7 +253,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPrimaryServiceTokens().isEmpty());
         
@@ -268,7 +268,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void mismatchedMasterTokenAddPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
@@ -278,7 +278,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void mismatchedUserIdTokenAddPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(p2pCtx, MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
@@ -289,7 +289,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noMasterTokenAddPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, null, false, null, new NullCryptoContext());
@@ -299,7 +299,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noUserIdTokenAddPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, false, null, new NullCryptoContext());
@@ -309,7 +309,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPeerServiceTokens().isEmpty());
@@ -325,7 +325,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void mismatchedMasterTokenAddPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -336,7 +336,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void mismatchedUserIdTokenAddPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -348,7 +348,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noMasterTokenAddPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
@@ -358,7 +358,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noUserIdTokenAddPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -369,7 +369,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test(expected = MslInternalException.class)
     public void trustedNetAddPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         final ServiceToken serviceToken = new ServiceToken(trustedNetCtx, TOKEN_NAME, DATA, null, null, false, null, new NullCryptoContext());
@@ -378,7 +378,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addUnboundPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPrimaryServiceTokens().isEmpty());
         
@@ -399,7 +399,7 @@ public class MessageServiceTokenBuilderTest {
         p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
         p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
         
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUnboundPrimaryServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -411,7 +411,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addMasterBoundPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPrimaryServiceTokens().isEmpty());
         
@@ -429,7 +429,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noMasterTokenAddMasterBoundPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addMasterBoundPrimaryServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -444,7 +444,7 @@ public class MessageServiceTokenBuilderTest {
         p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
         p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
         
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addMasterBoundPrimaryServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -456,7 +456,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addUserBoundPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPrimaryServiceTokens().isEmpty());
         
@@ -474,7 +474,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noMasterTokenAddUserBoundPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUserBoundPrimaryServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -486,7 +486,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noUserIdTokenAddUserBoundPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUserBoundPrimaryServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -501,7 +501,7 @@ public class MessageServiceTokenBuilderTest {
         p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
         p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
         
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUserBoundPrimaryServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -513,7 +513,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void excludePrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addServiceToken(serviceToken);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
@@ -527,7 +527,7 @@ public class MessageServiceTokenBuilderTest {
 
     @Test
     public void excludeUnknownPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME));
@@ -535,7 +535,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void deletePrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addServiceToken(serviceToken);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
@@ -563,7 +563,7 @@ public class MessageServiceTokenBuilderTest {
 
     @Test
     public void deleteUnknownPrimaryServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME));
@@ -571,7 +571,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addUnboundPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPeerServiceTokens().isEmpty());
         
@@ -589,7 +589,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test(expected = MslInternalException.class)
     public void trustedNetAddUnboundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(trustedNetCtx, trustedNetMsgCtx, msgBuilder);
         
         tokenBuilder.addUnboundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO);
@@ -600,7 +600,7 @@ public class MessageServiceTokenBuilderTest {
         p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
         p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
         
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUnboundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -612,7 +612,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addMasterBoundPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPeerServiceTokens().isEmpty());
@@ -631,7 +631,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noMasterTokenAddMasterBoundPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addMasterBoundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -646,7 +646,7 @@ public class MessageServiceTokenBuilderTest {
         p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
         p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
         
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -659,7 +659,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void trustedNetAddMasterBoundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(trustedNetCtx, trustedNetMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addMasterBoundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -667,7 +667,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void addUserBoundPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertTrue(tokenBuilder.getPeerServiceTokens().isEmpty());
@@ -686,7 +686,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noMasterTokenAddUserBoundPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, null, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUserBoundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -698,7 +698,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void noUserIdTokenAddUserBoundPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, null);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -714,7 +714,7 @@ public class MessageServiceTokenBuilderTest {
         p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
         p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
         
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -727,7 +727,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void trustedNetAddUserBoundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(trustedNetCtx, trustedNetMsgCtx, msgBuilder);
         
         assertFalse(tokenBuilder.addUserBoundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
@@ -735,7 +735,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void excludePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addPeerServiceToken(serviceToken);
@@ -750,7 +750,7 @@ public class MessageServiceTokenBuilderTest {
 
     @Test
     public void excludeUnknownPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
@@ -759,7 +759,7 @@ public class MessageServiceTokenBuilderTest {
     
     @Test
     public void deletePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addPeerServiceToken(serviceToken);
@@ -788,7 +788,7 @@ public class MessageServiceTokenBuilderTest {
 
     @Test
     public void deleteUnknownPeerServiceToken() throws MslException {
-        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null);
+        final MessageBuilder msgBuilder = MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         

--- a/tests/src/test/javascript/io/DefaultMslEncoderFactorySuite.js
+++ b/tests/src/test/javascript/io/DefaultMslEncoderFactorySuite.js
@@ -421,7 +421,7 @@ describe("DefaultMslEncoderFactory", function() {
                 var jsonMessageHeader;
                 runs(function() {
                     // Create JSON version.
-                    var jsonHeaderData = new MessageHeader.HeaderData(null, 1, null, false, false, jsonCaps, null, null, null, null, null);
+                    var jsonHeaderData = new MessageHeader.HeaderData(1, null, false, false, jsonCaps, null, null, null, null, null);
                     MessageHeader.create(ctx, entityAuthData, null, jsonHeaderData, peerData, {
                         result: function(x) { jsonMessageHeader = x; },
                         error: function(e) { expect(function() { throw e; }).not.toThrow(); },

--- a/tests/src/test/javascript/msg/MessageBuilderSuite.js
+++ b/tests/src/test/javascript/msg/MessageBuilderSuite.js
@@ -58,7 +58,6 @@ describe("MessageBuilder", function() {
     var MockAuthenticationUtils = require('msl-tests/util/MockAuthenticationUtils.js');
     var MockPresharedAuthenticationFactory = require('msl-tests/entityauth/MockPresharedAuthenticationFactory.js');
     
-    var RECIPIENT = "recipient";
 	var SERVICE_TOKEN_NAME = "serviceTokenName";
 	var USER_ID = "userid";
 	var PEER_USER_ID = "peeruserid";
@@ -265,7 +264,7 @@ describe("MessageBuilder", function() {
 		it("create null request", function() {
 			var builder;
 			runs(function() {
-				MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+				MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 					result: function(b) { builder = b; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -301,7 +300,6 @@ describe("MessageBuilder", function() {
 				expect(header.peerMasterToken).toBeNull();
 				expect(header.peerServiceTokens.length).toEqual(0);
 				expect(header.peerUserIdToken).toBeNull();
-				expect(header.recipient).toBeNull();
 				expect(header.serviceTokens.length).toEqual(0);
 				expect(header.userAuthenticationData).toBeNull();
 				expect(header.userIdToken).toBeNull();
@@ -311,7 +309,7 @@ describe("MessageBuilder", function() {
 		it("p2p create null request", function() {
 			var builder;
 			runs(function() {
-				MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+				MessageBuilder.createRequest(p2pCtx, null, null, null, {
 					result: function(b) { builder = b; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -349,7 +347,6 @@ describe("MessageBuilder", function() {
 				expect(header.peerMasterToken).toBeNull();
 				expect(header.peerServiceTokens.length).toEqual(0);
 				expect(header.peerUserIdToken).toBeNull();
-                expect(header.recipient).toBeNull();
 				expect(header.serviceTokens.length).toEqual(0);
 				expect(header.userAuthenticationData).toBeNull();
 				expect(header.userIdToken).toBeNull();
@@ -368,7 +365,7 @@ describe("MessageBuilder", function() {
 			
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, RECIPIENT, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -414,7 +411,6 @@ describe("MessageBuilder", function() {
 				expect(header.peerMasterToken).toBeNull();
 				expect(header.peerServiceTokens.length).toEqual(0);
 				expect(header.peerUserIdToken).toBeNull();
-				expect(header.recipient).toEqual(RECIPIENT);
 				expect(Arrays.containEachOther(header.serviceTokens, serviceTokens)).toBeTruthy();
 				expect(header.userAuthenticationData).toBeNull();
 				expect(header.userIdToken).toEqual(USER_ID_TOKEN);
@@ -425,7 +421,7 @@ describe("MessageBuilder", function() {
 			var messageId = 17;
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, RECIPIENT, messageId, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, messageId, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -479,7 +475,6 @@ describe("MessageBuilder", function() {
 				expect(header.peerMasterToken).toBeNull();
 				expect(header.peerServiceTokens.length).toEqual(0);
 				expect(header.peerUserIdToken).toBeNull();
-                expect(header.recipient).toEqual(RECIPIENT);
 				expect(Arrays.containEachOther(header.serviceTokens, serviceTokens)).toBeTruthy();
 				expect(header.userAuthenticationData).toBeNull();
 				expect(header.userIdToken).toEqual(USER_ID_TOKEN);
@@ -502,7 +497,7 @@ describe("MessageBuilder", function() {
 			
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, RECIPIENT, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -552,7 +547,6 @@ describe("MessageBuilder", function() {
 				expect(header.peerMasterToken).toEqual(PEER_MASTER_TOKEN);
 				expect(Arrays.containEachOther(header.peerServiceTokens, peerServiceTokens)).toBeTruthy();
 				expect(header.peerUserIdToken).toEqual(PEER_USER_ID_TOKEN);
-				expect(header.recipient).toEqual(RECIPIENT);
 				expect(Arrays.containEachOther(header.serviceTokens, serviceTokens)).toBeTruthy();
 				expect(header.userAuthenticationData).toBeNull();
 				expect(header.userIdToken).toEqual(USER_ID_TOKEN);
@@ -562,7 +556,7 @@ describe("MessageBuilder", function() {
 		it("create handshake request", function() {
 		    var builder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { builder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -600,7 +594,6 @@ describe("MessageBuilder", function() {
                 expect(header.peerMasterToken).toBeNull();
                 expect(header.peerServiceTokens.length).toEqual(0);
                 expect(header.peerUserIdToken).toBeNull();
-                expect(header.recipient).toBeNull();
                 expect(header.serviceTokens.length).toEqual(0);
                 expect(header.userAuthenticationData).toBeNull();
                 expect(header.userIdToken).toBeNull();
@@ -610,7 +603,7 @@ describe("MessageBuilder", function() {
 		it("p2p create handshake request", function() {
 		    var builder;
             runs(function() {
-                MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+                MessageBuilder.createRequest(p2pCtx, null, null, null, {
                     result: function(b) { builder = b; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -648,7 +641,6 @@ describe("MessageBuilder", function() {
                 expect(header.peerMasterToken).toBeNull();
                 expect(header.peerServiceTokens.length).toEqual(0);
                 expect(header.peerUserIdToken).toBeNull();
-                expect(header.recipient).toBeNull();
                 expect(header.serviceTokens.length).toEqual(0);
                 expect(header.userAuthenticationData).toBeNull();
                 expect(header.userIdToken).toBeNull();
@@ -667,7 +659,7 @@ describe("MessageBuilder", function() {
 			
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(rsaCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(rsaCtx, null, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -694,7 +686,7 @@ describe("MessageBuilder", function() {
             
             var builder;
             runs(function() {
-                MessageBuilder.createRequest(noneCtx, null, null, null, null, {
+                MessageBuilder.createRequest(noneCtx, null, null, null, {
                     result: function(x) { builder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -742,7 +734,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-				MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+				MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 					result: function(x) { builder = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -802,7 +794,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-				MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+				MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 					result: function(x) { builder = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -840,7 +832,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -901,7 +893,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -959,7 +951,7 @@ describe("MessageBuilder", function() {
 			
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1009,7 +1001,7 @@ describe("MessageBuilder", function() {
 		it("overwrite key request data", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1056,7 +1048,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1101,7 +1093,7 @@ describe("MessageBuilder", function() {
 		it("non-replayable with null master token", function() {
 		    var builder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { builder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -1138,7 +1130,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1167,7 +1159,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1209,7 +1201,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, userIdTokenA, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, userIdTokenA, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1238,7 +1230,7 @@ describe("MessageBuilder", function() {
 			
             var builder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
                     result: function(x) { builder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -1265,7 +1257,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1315,7 +1307,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1359,7 +1351,7 @@ describe("MessageBuilder", function() {
 		it("delete unknown service token", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1397,7 +1389,7 @@ describe("MessageBuilder", function() {
 		it("trusted network create peer request", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1415,7 +1407,7 @@ describe("MessageBuilder", function() {
 		it("p2p create peer request with missing peer master token", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1433,7 +1425,7 @@ describe("MessageBuilder", function() {
 		it("p2p create peer request with mismatched peer master token", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1460,7 +1452,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1487,7 +1479,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1514,7 +1506,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1542,7 +1534,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1583,7 +1575,7 @@ describe("MessageBuilder", function() {
 
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1611,7 +1603,7 @@ describe("MessageBuilder", function() {
 			
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1663,7 +1655,7 @@ describe("MessageBuilder", function() {
 			
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1708,7 +1700,7 @@ describe("MessageBuilder", function() {
 		it("delete unknown peer service token", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1768,7 +1760,7 @@ describe("MessageBuilder", function() {
 				store.addServiceTokens(serviceTokens);
 				store.addServiceTokens(peerServiceTokens);
 
-				MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+				MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 					result: function(x) { builder = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -1823,7 +1815,7 @@ describe("MessageBuilder", function() {
 		    	store.addServiceTokens(serviceTokens);
 		    	store.addServiceTokens(peerServiceTokens);
 
-		    	MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+		    	MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 		    		result: function(x) { builder = x; },
 		    		error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    	});
@@ -1879,7 +1871,7 @@ describe("MessageBuilder", function() {
 			    store.addServiceTokens(serviceTokens);
 			    store.addServiceTokens(peerServiceTokens);
 
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			    	result: function(x) { builder = x; },
 			    	error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1935,7 +1927,7 @@ describe("MessageBuilder", function() {
 				store.addServiceTokens(serviceTokens);
 				store.addServiceTokens(peerServiceTokens);
 
-				MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+				MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 					result: function(x) { builder = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -1969,7 +1961,7 @@ describe("MessageBuilder", function() {
 		it("set null master token", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -1998,7 +1990,7 @@ describe("MessageBuilder", function() {
 		it("set mismatched authentication tokens", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2016,7 +2008,7 @@ describe("MessageBuilder", function() {
 		it("set user", function() {
 			var builder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 			        result: function(x) { builder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2042,7 +2034,7 @@ describe("MessageBuilder", function() {
         it("set user with no master token", function() {
             var builder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { builder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -2067,7 +2059,7 @@ describe("MessageBuilder", function() {
         it("set user with existing user ID token", function() {
     		var builder;
     		runs(function() {
-    		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+    		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
     		        result: function(x) { builder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -2092,7 +2084,7 @@ describe("MessageBuilder", function() {
         it("p2p set user", function() {
             var builder;
             runs(function() {
-                MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+                MessageBuilder.createRequest(p2pCtx, null, null, null, {
                     result: function(x) { builder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -2119,7 +2111,7 @@ describe("MessageBuilder", function() {
         it("p2p set user with no peer master token", function() {
     		var builder;
     		runs(function() {
-    		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+    		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
     		        result: function(x) { builder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -2144,7 +2136,7 @@ describe("MessageBuilder", function() {
         it("p2p set user with existing peer user ID token", function() {
     		var builder;
     		runs(function() {
-    		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+    		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
     		        result: function(x) { builder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -2170,7 +2162,7 @@ describe("MessageBuilder", function() {
 		it("negative message ID", function() {
 			var exception;
 			runs(function() {
-				MessageBuilder.createRequest(trustedNetCtx, null, null, null, -1, {
+				MessageBuilder.createRequest(trustedNetCtx, null, null, -1, {
 					result: function() {},
 					error: function(e) { exception = e; }
 				});
@@ -2186,7 +2178,7 @@ describe("MessageBuilder", function() {
 		it("too large message ID", function() {
 			var exception;
 			runs(function() {
-				MessageBuilder.createRequest(trustedNetCtx, null, null, null, MslConstants.MAX_LONG_VALUE + 2, {
+				MessageBuilder.createRequest(trustedNetCtx, null, null, MslConstants.MAX_LONG_VALUE + 2, {
 					result: function() {},
 					error: function(e) { exception = e; }
 				});
@@ -2209,7 +2201,7 @@ describe("MessageBuilder", function() {
 		it("ctor", function() {
 			var errorHeader;
 			runs(function() {
-			    MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE, {
+			    MessageBuilder.createErrorResponse(trustedNetCtx, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE, {
 			        result: function(x) { errorHeader = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2221,36 +2213,15 @@ describe("MessageBuilder", function() {
 				expect(errorHeader.errorCode).toEqual(MSL_ERROR.responseCode);
 				expect(errorHeader.errorMessage).toEqual(MSL_ERROR.message);
 				expect(errorHeader.userMessage).toEqual(USER_MESSAGE);
-				expect(errorHeader.recipient).toEqual(RECIPIENT);
 				expect(errorHeader.messageId).toEqual(REQUEST_MESSAGE_ID + 1);
 			});
-		});
-		
-		it("null recipient", function() {
-		    var errorHeader;
-            runs(function() {
-                MessageBuilder.createErrorResponse(trustedNetCtx, null, REQUEST_MESSAGE_ID, MSL_ERROR, USER_MESSAGE, {
-                    result: function(x) { errorHeader = x; },
-                    error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-                });
-            });
-            waitsFor(function() { return errorHeader; }, "errorHeader not received", MslTestConstants.TIMEOUT);
-            
-            runs(function() {
-                expect(errorHeader).not.toBeNull();
-                expect(errorHeader.errorCode).toEqual(MSL_ERROR.responseCode);
-                expect(errorHeader.errorMessage).toEqual(MSL_ERROR.message);
-                expect(errorHeader.userMessage).toEqual(USER_MESSAGE);
-                expect(errorHeader.recipient).toBeNull();
-                expect(errorHeader.messageId).toEqual(REQUEST_MESSAGE_ID + 1);
-            });
 		});
 
 		it("max message ID", function() {
 			var messageId = MslConstants.MAX_LONG_VALUE;
 			var errorHeader;
 			runs(function() {
-			    MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, messageId, MSL_ERROR, USER_MESSAGE, {
+			    MessageBuilder.createErrorResponse(trustedNetCtx, messageId, MSL_ERROR, USER_MESSAGE, {
 			        result: function(x) { errorHeader = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2262,7 +2233,6 @@ describe("MessageBuilder", function() {
 				expect(errorHeader.errorCode).toEqual(MSL_ERROR.responseCode);
 				expect(errorHeader.errorMessage).toEqual(MSL_ERROR.message);
 				expect(errorHeader.userMessage).toEqual(USER_MESSAGE);
-                expect(errorHeader.recipient).toEqual(RECIPIENT);
 				expect(errorHeader.messageId).toEqual(0);
 			});
 		});
@@ -2270,7 +2240,7 @@ describe("MessageBuilder", function() {
 		it("null message ID", function() {
 			var errorHeader;
 			runs(function() {
-			    MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, null, MSL_ERROR, USER_MESSAGE, {
+			    MessageBuilder.createErrorResponse(trustedNetCtx, null, MSL_ERROR, USER_MESSAGE, {
 			        result: function(x) { errorHeader = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2282,7 +2252,6 @@ describe("MessageBuilder", function() {
 				expect(errorHeader.errorCode).toEqual(MSL_ERROR.responseCode);
 				expect(errorHeader.errorMessage).toEqual(MSL_ERROR.message);
 				expect(errorHeader.userMessage).toEqual(USER_MESSAGE);
-                expect(errorHeader.recipient).toEqual(RECIPIENT);
 				expect(errorHeader.messageId > 0).toBeTruthy();
 			});
 		});
@@ -2291,7 +2260,7 @@ describe("MessageBuilder", function() {
 			var exception;
 			runs(function() {
 				var messageId = -12;
-				MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, messageId, MSL_ERROR, USER_MESSAGE, {
+				MessageBuilder.createErrorResponse(trustedNetCtx, messageId, MSL_ERROR, USER_MESSAGE, {
 					result: function() {},
 					error: function(err) { exception = err; }
 				});
@@ -2307,7 +2276,7 @@ describe("MessageBuilder", function() {
 		it("null user message", function() {
             var errorHeader;
             runs(function() {
-                MessageBuilder.createErrorResponse(trustedNetCtx, RECIPIENT, REQUEST_MESSAGE_ID, MSL_ERROR, null, {
+                MessageBuilder.createErrorResponse(trustedNetCtx, REQUEST_MESSAGE_ID, MSL_ERROR, null, {
                     result: function(x) { errorHeader = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -2319,7 +2288,6 @@ describe("MessageBuilder", function() {
                 expect(errorHeader.errorCode).toEqual(MSL_ERROR.responseCode);
                 expect(errorHeader.errorMessage).toEqual(MSL_ERROR.message);
                 expect(errorHeader.userMessage).toBeNull();
-                expect(errorHeader.recipient).toEqual(RECIPIENT);
                 expect(errorHeader.messageId).toEqual(REQUEST_MESSAGE_ID + 1);
             });
 		});
@@ -2384,7 +2352,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2444,7 +2412,6 @@ describe("MessageBuilder", function() {
 				expect(response.peerMasterToken).toBeNull();
 				expect(response.peerServiceTokens.length).toEqual(0);
 				expect(response.peerUserIdToken).toBeNull();
-				expect(response.recipient).toEqual(MASTER_TOKEN.identity);
 				expect(Arrays.containEachOther(response.serviceTokens, serviceTokens)).toBeTruthy();
 				expect(response.userAuthenticationData).toBeNull();
 				expect(response.userIdToken).toEqual(USER_ID_TOKEN);
@@ -2469,7 +2436,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2534,7 +2501,6 @@ describe("MessageBuilder", function() {
 				expect(response.userAuthenticationData).toBeNull();
 				expect(response.userIdToken).toEqual(PEER_USER_ID_TOKEN);
 				expect(Arrays.containEachOther(response.peerServiceTokens, serviceTokens)).toBeTruthy();
-				expect(response.recipient).toEqual(MASTER_TOKEN.identity);
 				expect(Arrays.containEachOther(response.serviceTokens, peerServiceTokens)).toBeTruthy();
 			});
 		});
@@ -2551,7 +2517,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -2615,7 +2581,6 @@ describe("MessageBuilder", function() {
                 expect(response.peerMasterToken).toBeNull();
                 expect(response.peerServiceTokens.length).toEqual(0);
                 expect(response.peerUserIdToken).toBeNull();
-                expect(response.recipient).toEqual(entityAuthData.getIdentity());
                 expect(Arrays.containEachOther(response.serviceTokens, serviceTokens)).toBeTruthy();
                 expect(response.userAuthenticationData).toBeNull();
                 expect(response.userIdToken).toBeNull();
@@ -2638,7 +2603,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+                MessageBuilder.createRequest(p2pCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -2707,9 +2672,7 @@ describe("MessageBuilder", function() {
                 expect(response.peerUserIdToken).toBeNull();
                 expect(response.userAuthenticationData).toBeNull();
                 expect(response.userIdToken).toEqual(PEER_USER_ID_TOKEN);
-                expect(response.recipient).toEqual(entityAuthData.getIdentity());
                 expect(Arrays.containEachOther(response.peerServiceTokens, serviceTokens)).toBeTruthy();
-                expect(response.recipient).toEqual(MASTER_TOKEN.identity);
                 expect(Arrays.containEachOther(response.serviceTokens, peerServiceTokens)).toBeTruthy();
             });
 		});
@@ -2717,7 +2680,7 @@ describe("MessageBuilder", function() {
 		it("create response", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2790,7 +2753,6 @@ describe("MessageBuilder", function() {
 				expect(response.peerMasterToken).toBeNull();
 				expect(response.peerServiceTokens.length).toEqual(0);
 				expect(response.peerUserIdToken).toBeNull();
-				expect(response.recipient).toEqual(MASTER_TOKEN.identity);
 				expect(Arrays.containEachOther(response.serviceTokens, serviceTokens)).toBeTruthy();
 				expect(response.userAuthenticationData).toEqual(USER_AUTH_DATA);
 				expect(response.userIdToken).toEqual(USER_ID_TOKEN);
@@ -2800,7 +2762,7 @@ describe("MessageBuilder", function() {
 		it("p2p create response", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -2874,7 +2836,6 @@ describe("MessageBuilder", function() {
 				expect(response.peerMasterToken).toEqual(PEER_MASTER_TOKEN);
 				expect(response.peerUserIdToken).toEqual(PEER_USER_ID_TOKEN);
 				expect(response.userAuthenticationData).toEqual(USER_AUTH_DATA);
-				expect(response.recipient).toEqual(PEER_MASTER_TOKEN.identity);
 				expect(Arrays.containEachOther(response.peerServiceTokens, peerServiceTokens)).toBeTruthy();
 				expect(Arrays.containEachOther(response.serviceTokens, serviceTokens)).toBeTruthy();
 				expect(response.userIdToken).toBeNull();
@@ -2895,7 +2856,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -2958,7 +2919,6 @@ describe("MessageBuilder", function() {
                 expect(response.peerMasterToken).toBeNull();
                 expect(response.peerServiceTokens.length).toEqual(0);
                 expect(response.peerUserIdToken).toBeNull();
-                expect(response.recipient).toEqual(MASTER_TOKEN.identity);
                 expect(Arrays.containEachOther(response.serviceTokens, serviceTokens)).toBeTruthy();
                 expect(response.userAuthenticationData).toBeNull();
                 expect(response.userIdToken).toEqual(USER_ID_TOKEN);
@@ -2983,7 +2943,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+                MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -3051,7 +3011,6 @@ describe("MessageBuilder", function() {
                 expect(response.userAuthenticationData).toBeNull();
                 expect(response.userIdToken).toEqual(PEER_USER_ID_TOKEN);
                 expect(Arrays.containEachOther(response.peerServiceTokens, serviceTokens)).toBeTruthy();
-                expect(response.recipient).toEqual(MASTER_TOKEN.identity);
                 expect(Arrays.containEachOther(response.serviceTokens, peerServiceTokens)).toBeTruthy();
             });
 		});
@@ -3068,7 +3027,7 @@ describe("MessageBuilder", function() {
 			
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(rsaCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(rsaCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3112,7 +3071,7 @@ describe("MessageBuilder", function() {
 			
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(rsaCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(rsaCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3151,7 +3110,7 @@ describe("MessageBuilder", function() {
 		it("stored service tokens", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3224,7 +3183,7 @@ describe("MessageBuilder", function() {
 		it("stored peer service tokens", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3307,7 +3266,7 @@ describe("MessageBuilder", function() {
 		it("add service token with key response data", function() {
 		    var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -3372,7 +3331,7 @@ describe("MessageBuilder", function() {
         it("add service token with no key exchange data", function() {
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -3422,7 +3381,7 @@ describe("MessageBuilder", function() {
         it("add service token with mismatched key exchange data master token", function() {
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -3477,7 +3436,7 @@ describe("MessageBuilder", function() {
         it("p2p add service token with mismatched key exchange data master token", function() {
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+                MessageBuilder.createRequest(p2pCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -3535,7 +3494,7 @@ describe("MessageBuilder", function() {
 		it("max request message ID", function() {
 			var request;
 			runs(function() {
-				var headerData = new HeaderData(null, MslConstants.MAX_LONG_VALUE, null, false, false, null, null, null, null, null, null);
+				var headerData = new HeaderData(MslConstants.MAX_LONG_VALUE, null, false, false, null, null, null, null, null, null);
 				var peerData = new HeaderPeerData(null, null, null);
 			    MessageHeader.create(trustedNetCtx, null, MASTER_TOKEN, headerData, peerData, {
 			        result: function(x) { request = x; },
@@ -3581,7 +3540,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3645,7 +3604,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, requestMasterToken, null, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, requestMasterToken, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3710,7 +3669,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3777,7 +3736,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -3840,7 +3799,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3904,7 +3863,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -3968,7 +3927,7 @@ describe("MessageBuilder", function() {
 
 			var request;
 			runs(function() {
-				var headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+				var headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
 				var peerData = new HeaderPeerData(null, null, null);
 				MessageHeader.create(trustedNetCtx, null, requestMasterToken, headerData, peerData, {
 					result: function(x) { request = x; },
@@ -4020,7 +3979,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(ctx, requestMasterToken, null, null, null, {
+			    MessageBuilder.createRequest(ctx, requestMasterToken, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4103,7 +4062,7 @@ describe("MessageBuilder", function() {
 
 			var request;
 			runs(function() {
-				var headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+				var headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
 				var peerData = new HeaderPeerData(null, null, null);
 				MessageHeader.create(ctx, null, requestMasterToken, headerData, peerData, {
 					result: function(x) { request = x; },
@@ -4181,7 +4140,7 @@ describe("MessageBuilder", function() {
 		it("create response to request with key response data", function() {
 			var localRequestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { localRequestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4242,7 +4201,7 @@ describe("MessageBuilder", function() {
 		it("p2p create response to request with key response data", function() {
 			var localRequestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 			        result: function(x) { localRequestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4325,7 +4284,7 @@ describe("MessageBuilder", function() {
 		it("not renewable request with entity authentication data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			   MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4372,7 +4331,7 @@ describe("MessageBuilder", function() {
 		it("renewable request with entity authentication data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4422,7 +4381,7 @@ describe("MessageBuilder", function() {
 		it("p2p renewable request with entity authentication data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4492,7 +4451,7 @@ describe("MessageBuilder", function() {
 
 			var request;
 			runs(function() {
-				var headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+				var headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
 				var peerData = new HeaderPeerData(null, null, null);
 				MessageHeader.create(ctx, entityAuthData, null, headerData, peerData, {
 					result: function(x) { request = x; },
@@ -4533,7 +4492,7 @@ describe("MessageBuilder", function() {
 			
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(ctx, null, null, null, null, {
+			    MessageBuilder.createRequest(ctx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4600,7 +4559,7 @@ describe("MessageBuilder", function() {
 			
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4660,7 +4619,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4720,7 +4679,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4781,7 +4740,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4841,7 +4800,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -4932,7 +4891,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(ctx, MASTER_TOKEN, unverifiedUserIdToken, null, null, {
+			    MessageBuilder.createRequest(ctx, MASTER_TOKEN, unverifiedUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5002,7 +4961,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5080,7 +5039,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, requestMasterToken, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5150,7 +5109,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, requestMasterToken, requestUserIdToken, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, requestMasterToken, requestUserIdToken, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5209,7 +5168,7 @@ describe("MessageBuilder", function() {
 		it("master token with user authentication data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5264,7 +5223,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(ctx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(ctx, MASTER_TOKEN, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5330,7 +5289,7 @@ describe("MessageBuilder", function() {
 		it("p2p master token with user authentication data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5386,7 +5345,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(ctx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(ctx, MASTER_TOKEN, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5452,7 +5411,7 @@ describe("MessageBuilder", function() {
 		it("entity authentication data and user authentication data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5517,7 +5476,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(ctx, null, null, null, null, {
+			    MessageBuilder.createRequest(ctx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5593,7 +5552,7 @@ describe("MessageBuilder", function() {
 		it("entity authentication data and user authentication data with no key request data", function() {
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5640,7 +5599,7 @@ describe("MessageBuilder", function() {
 		it("p2p entity authentication data and user authentication data", function() {
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+                MessageBuilder.createRequest(p2pCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -5704,7 +5663,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(ctx, null, null, null, null, {
+                MessageBuilder.createRequest(ctx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -5788,7 +5747,7 @@ describe("MessageBuilder", function() {
 
 			var request;
 			runs(function() {
-				var headerData = new HeaderData(null, REQUEST_MESSAGE_ID, null, true, false, null, null, null, USER_AUTH_DATA, null, null);
+				var headerData = new HeaderData(REQUEST_MESSAGE_ID, null, true, false, null, null, null, USER_AUTH_DATA, null, null);
 				var peerData = new HeaderPeerData(null, null, null);
 				MessageHeader.create(ctx, null, MASTER_TOKEN, headerData, peerData, {
 					result: function(x) { request = x; },
@@ -5833,7 +5792,7 @@ describe("MessageBuilder", function() {
 
             var requestBuilder;
             runs(function() {
-                MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+                MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                     result: function(x) { requestBuilder = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -5901,7 +5860,7 @@ describe("MessageBuilder", function() {
 
 			var requestBuilder;
 			runs(function() {
-			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+			    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 			        result: function(x) { requestBuilder = x; },
 			        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			    });
@@ -5969,7 +5928,7 @@ describe("MessageBuilder", function() {
 
         	var requestBuilder;
         	runs(function() {
-        	    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+        	    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
         	        result: function(x) { requestBuilder = x; },
         	        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         	    });
@@ -6037,7 +5996,7 @@ describe("MessageBuilder", function() {
 
         	var requestBuilder;
         	runs(function() {
-        	    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+        	    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
         	        result: function(x) { requestBuilder = x; },
         	        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         	    });
@@ -6092,7 +6051,7 @@ describe("MessageBuilder", function() {
 		it("set null master token", function() {
         	var requestBuilder;
         	runs(function() {
-        	    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+        	    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
         	        result: function(x) { requestBuilder = x; },
         	        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         	    });
@@ -6136,7 +6095,7 @@ describe("MessageBuilder", function() {
 		it("set mismatched authentication tokens", function() {
         	var requestBuilder;
         	runs(function() {
-        	    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+        	    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
         	        result: function(x) { requestBuilder = x; },
         	        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         	    });
@@ -6188,7 +6147,7 @@ describe("MessageBuilder", function() {
 
         	var requestBuilder;
         	runs(function() {
-        	    MessageBuilder.createRequest(trustedNetCtx, masterToken, null, null, null, {
+        	    MessageBuilder.createRequest(trustedNetCtx, masterToken, null, null, {
         	        result: function(x) { requestBuilder = x; },
         	        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
         	    });
@@ -6228,7 +6187,7 @@ describe("MessageBuilder", function() {
 		it("p2p set master token when key exchange data exists", function() {
 		    var requestBuilder;
 		    runs(function() {
-		        MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		        MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		            result: function(x) { requestBuilder = x; },
 		            error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		        });
@@ -6305,7 +6264,7 @@ describe("MessageBuilder", function() {
         it("set user", function() {
     		var requestBuilder;
     		runs(function() {
-    		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+    		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
     		        result: function(x) { requestBuilder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -6349,7 +6308,7 @@ describe("MessageBuilder", function() {
         it("set user with no master token", function() {
     		var requestBuilder;
     		runs(function() {
-    		    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+    		    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
     		        result: function(x) { requestBuilder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -6392,7 +6351,7 @@ describe("MessageBuilder", function() {
         it("set user with existing user ID token", function() {
     		var requestBuilder;
     		runs(function() {
-    		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+    		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
     		        result: function(x) { requestBuilder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -6435,7 +6394,7 @@ describe("MessageBuilder", function() {
         it("p2p set user", function() {
     		var requestBuilder;
     		runs(function() {
-    		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+    		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
     		        result: function(x) { requestBuilder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -6479,7 +6438,7 @@ describe("MessageBuilder", function() {
         it("p2p set user with no peer master token", function() {
     		var requestBuilder;
     		runs(function() {
-    		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+    		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
     		        result: function(x) { requestBuilder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -6522,7 +6481,7 @@ describe("MessageBuilder", function() {
         it("p2p set user with existing peer user ID token", function() {
     		var requestBuilder;
     		runs(function() {
-    		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+    		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
     		        result: function(x) { requestBuilder = x; },
     		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
     		    });
@@ -6579,7 +6538,7 @@ describe("MessageBuilder", function() {
             var request;
             runs(function() {
                 ctx.setMessageCapabilities(caps);
-                MessageBuilder.createRequest(ctx, null, null, null, null, {
+                MessageBuilder.createRequest(ctx, null, null, null, {
                     result: function(requestBuilder) {
                         requestBuilder.getHeader({
                             result: function(x) { request = x; },
@@ -6628,7 +6587,7 @@ describe("MessageBuilder", function() {
             var request;
             runs(function() {
                 ctx.setMessageCapabilities(null);
-                MessageBuilder.createRequest(ctx, null, null, null, null, {
+                MessageBuilder.createRequest(ctx, null, null, null, {
                     result: function(requestBuilder) {
                         requestBuilder.getHeader({
                             result: function(x) { request = x; },

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,10 +69,6 @@ describe("MessageHeader", function() {
 	var KEY_SIGNATURE = "signature";
 
 	// Message header data.
-    /** Key sender. */
-    var KEY_SENDER = "sender";
-    /** Key recipient. */
-    var KEY_RECIPIENT = "recipient";
     /** Key timestamp. */
     var KEY_TIMESTAMP = "timestamp";
 	/** Key message ID. */
@@ -142,7 +138,6 @@ describe("MessageHeader", function() {
     var LANGUAGES = [ "en-US" ];
     var FORMATS = [ MslEncoderFormat.JSON ];
     
-    var RECIPIENT = "recipient";
 	var MESSAGE_ID = 1;
 	var NON_REPLAYABLE_ID = 1;
 	var RENEWABLE = true;
@@ -215,7 +210,6 @@ describe("MessageHeader", function() {
             function construct(tokens) {
                 AsyncExecutor(callback, function() {
                     var values = [];
-                    values[KEY_RECIPIENT] = RECIPIENT;
                     values[KEY_MESSAGE_ID] = MESSAGE_ID;
                     values[KEY_NON_REPLAYABLE_ID] = NON_REPLAYABLE_ID;
                     values[KEY_RENEWABLE] = RENEWABLE;
@@ -262,7 +256,6 @@ describe("MessageHeader", function() {
          * @return {HeaderData} the header data.
          */
         build: function build() {
-            var recipient = this._values[KEY_RECIPIENT];
             var messageId = this._values[KEY_MESSAGE_ID];
             var nonReplayableId = this._values[KEY_NON_REPLAYABLE_ID];
             var renewable = this._values[KEY_RENEWABLE];
@@ -273,7 +266,7 @@ describe("MessageHeader", function() {
             var userAuthData = this._values[KEY_USER_AUTHENTICATION_DATA];
             var userIdToken = this._values[KEY_USER_ID_TOKEN];
             var serviceTokens = this._values[KEY_SERVICE_TOKENS];
-            return new HeaderData(recipient, messageId, nonReplayableId, renewable, handshake, capabilities, keyRequestData, keyResponseData, userAuthData, userIdToken, serviceTokens);
+            return new HeaderData(messageId, nonReplayableId, renewable, handshake, capabilities, keyRequestData, keyResponseData, userAuthData, userIdToken, serviceTokens);
         }
 	});
 
@@ -481,8 +474,6 @@ describe("MessageHeader", function() {
 			expect(Arrays.contains(keyRequestData, KEY_REQUEST_DATA)).toBeTruthy();
 			expect(messageHeader.keyResponseData).toEqual(KEY_RESPONSE_DATA);
 			expect(messageHeader.masterToken).toBeNull();
-			expect(messageHeader.sender).toBeNull();
-			expect(messageHeader.recipient).toEqual(RECIPIENT);
 			expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
 			expect(messageHeader.messageId).toEqual(MESSAGE_ID);
 			expect(messageHeader.peerMasterToken).toBeNull();
@@ -537,8 +528,6 @@ describe("MessageHeader", function() {
             expect(Arrays.contains(keyRequestData, KEY_REQUEST_DATA)).toBeTruthy();
             expect(messageHeader.keyResponseData).toEqual(KEY_RESPONSE_DATA);
             expect(messageHeader.masterToken).toBeNull();
-            expect(messageHeader.sender).toBeNull();
-            expect(messageHeader.recipient).toEqual(RECIPIENT);
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toBeNull();
@@ -639,8 +628,6 @@ describe("MessageHeader", function() {
             expect(headerdata.getMslObject(KEY_CAPABILITIES, encoder)).toEqual(CAPABILITIES_MO);
             expect(headerdata.getMslArray(KEY_KEY_REQUEST_DATA)).toEqual(KEY_REQUEST_DATA_MA);
             expect(headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)).toEqual(KEY_RESPONSE_DATA_MO);
-            expect(headerdata.has(KEY_SENDER)).toBeFalsy();
-            expect(headerdata.getString(KEY_RECIPIENT)).toEqual(RECIPIENT);
             expect(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP))).toBeTruthy();
             expect(headerdata.getLong(KEY_MESSAGE_ID)).toEqual(MESSAGE_ID);
             expect(headerdata.has(KEY_PEER_MASTER_TOKEN)).toBeFalsy();
@@ -740,8 +727,6 @@ describe("MessageHeader", function() {
             expect(headerdata.getMslObject(KEY_CAPABILITIES, encoder)).toEqual(CAPABILITIES_MO);
             expect(headerdata.getMslArray(KEY_KEY_REQUEST_DATA)).toEqual(KEY_REQUEST_DATA_MA);
             expect(headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)).toEqual(KEY_RESPONSE_DATA_MO);
-            expect(headerdata.has(KEY_SENDER)).toBeFalsy();
-            expect(headerdata.getString(KEY_RECIPIENT)).toEqual(RECIPIENT);
             expect(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP))).toBeTruthy();
             expect(headerdata.getLong(KEY_MESSAGE_ID)).toEqual(MESSAGE_ID);
             expect(headerdata.has(KEY_PEER_MASTER_TOKEN)).toBeFalsy();
@@ -795,8 +780,6 @@ describe("MessageHeader", function() {
             expect(Arrays.contains(keyRequestData, PEER_KEY_REQUEST_DATA)).toBeTruthy();
             expect(messageHeader.keyResponseData).toEqual(PEER_KEY_RESPONSE_DATA);
             expect(messageHeader.masterToken).toBeNull();
-            expect(messageHeader.sender).toBeNull();
-            expect(messageHeader.recipient).toEqual(RECIPIENT);
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toEqual(PEER_MASTER_TOKEN);
@@ -853,8 +836,6 @@ describe("MessageHeader", function() {
             expect(Arrays.contains(keyRequestData, PEER_KEY_REQUEST_DATA)).toBeTruthy();
             expect(messageHeader.keyResponseData).toEqual(PEER_KEY_RESPONSE_DATA);
             expect(messageHeader.masterToken).toBeNull();
-            expect(messageHeader.sender).toBeNull();
-            expect(messageHeader.recipient).toEqual(RECIPIENT);
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toEqual(PEER_MASTER_TOKEN);
@@ -961,8 +942,6 @@ describe("MessageHeader", function() {
             expect(headerdata.getMslObject(KEY_CAPABILITIES, encoder)).toEqual(CAPABILITIES_MO);
             expect(headerdata.getMslArray(KEY_KEY_REQUEST_DATA)).toEqual(PEER_KEY_REQUEST_DATA_MA);
             expect(headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)).toEqual(PEER_KEY_RESPONSE_DATA_MO);
-            expect(headerdata.has(KEY_SENDER)).toBeFalsy();
-            expect(headerdata.getString(KEY_RECIPIENT)).toEqual(RECIPIENT);
             expect(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP))).toBeTruthy();
             expect(headerdata.getLong(KEY_MESSAGE_ID)).toEqual(MESSAGE_ID);
             expect(headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)).toEqual(PEER_MASTER_TOKEN_MO);
@@ -1068,8 +1047,6 @@ describe("MessageHeader", function() {
             expect(headerdata.getMslObject(KEY_CAPABILITIES, encoder)).toEqual(CAPABILITIES_MO);
             expect(headerdata.getMslArray(KEY_KEY_REQUEST_DATA)).toEqual(PEER_KEY_REQUEST_DATA_MA);
             expect(headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)).toEqual(PEER_KEY_RESPONSE_DATA_MO);
-            expect(headerdata.has(KEY_SENDER)).toBeFalsy();
-            expect(headerdata.getString(KEY_RECIPIENT)).toEqual(RECIPIENT);
             expect(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP))).toBeTruthy();
             expect(headerdata.getLong(KEY_MESSAGE_ID)).toEqual(MESSAGE_ID);
             expect(headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)).toEqual(PEER_MASTER_TOKEN_MO);
@@ -1121,8 +1098,6 @@ describe("MessageHeader", function() {
             expect(Arrays.contains(keyRequestData, KEY_REQUEST_DATA)).toBeTruthy();
             expect(messageHeader.keyResponseData).toEqual(KEY_RESPONSE_DATA);
             expect(messageHeader.masterToken).toEqual(MASTER_TOKEN);
-            expect(messageHeader.sender).toEqual(ENTITY_AUTH_DATA.getIdentity());
-            expect(messageHeader.recipient).toEqual(RECIPIENT);
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toBeNull();
@@ -1216,8 +1191,6 @@ describe("MessageHeader", function() {
             expect(headerdata.getMslObject(KEY_CAPABILITIES, encoder)).toEqual(CAPABILITIES_MO);
             expect(headerdata.getMslArray(KEY_KEY_REQUEST_DATA)).toEqual(KEY_REQUEST_DATA_MA);
             expect(headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)).toEqual(KEY_RESPONSE_DATA_MO);
-            expect(headerdata.getString(KEY_SENDER)).toEqual(ENTITY_AUTH_DATA.getIdentity());
-            expect(headerdata.getString(KEY_RECIPIENT)).toEqual(RECIPIENT);
             expect(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP))).toBeTruthy();
             expect(headerdata.getLong(KEY_MESSAGE_ID)).toEqual(MESSAGE_ID);
             expect(headerdata.has(KEY_PEER_MASTER_TOKEN)).toBeFalsy();
@@ -1273,8 +1246,6 @@ describe("MessageHeader", function() {
             expect(Arrays.contains(keyRequestData, PEER_KEY_REQUEST_DATA)).toBeTruthy();
             expect(messageHeader.keyResponseData).toEqual(PEER_KEY_RESPONSE_DATA);
             expect(messageHeader.masterToken).toEqual(MASTER_TOKEN);
-            expect(messageHeader.sender).toEqual(PEER_ENTITY_AUTH_DATA.getIdentity());
-            expect(messageHeader.recipient).toEqual(RECIPIENT);
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toEqual(PEER_MASTER_TOKEN);
@@ -1382,8 +1353,6 @@ describe("MessageHeader", function() {
             expect(headerdata.getMslObject(KEY_CAPABILITIES, encoder)).toEqual(CAPABILITIES_MO);
             expect(headerdata.getMslArray(KEY_KEY_REQUEST_DATA)).toEqual(PEER_KEY_REQUEST_DATA_MA);
             expect(headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)).toEqual(PEER_KEY_RESPONSE_DATA_MO);
-            expect(headerdata.getString(KEY_SENDER)).toEqual(PEER_ENTITY_AUTH_DATA.getIdentity());
-            expect(headerdata.getString(KEY_RECIPIENT)).toEqual(RECIPIENT);
             expect(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP))).toBeTruthy();
             expect(headerdata.getLong(KEY_MESSAGE_ID)).toEqual(MESSAGE_ID);
             expect(headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)).toEqual(PEER_MASTER_TOKEN_MO);
@@ -1407,7 +1376,6 @@ describe("MessageHeader", function() {
 	    
 		var messageHeader;
 		runs(function() {
-		    builder.set(KEY_RECIPIENT, null);
 	        builder.set(KEY_CAPABILITIES, null);
 	        builder.set(KEY_KEY_REQUEST_DATA, null);
 	        builder.set(KEY_KEY_RESPONSE_DATA, null);
@@ -1432,8 +1400,6 @@ describe("MessageHeader", function() {
             expect(messageHeader.keyRequestData.length).toEqual(0);
             expect(messageHeader.keyResponseData).toBeNull();
             expect(messageHeader.masterToken).toBeNull();
-            expect(messageHeader.sender).toBeNull();
-            expect(messageHeader.recipient).toBeNull();
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toBeNull();
@@ -1460,7 +1426,6 @@ describe("MessageHeader", function() {
 		runs(function() {
             var serviceTokens = [];
             var keyRequestData = [];
-            builder.set(KEY_RECIPIENT, null);
             builder.set(KEY_CAPABILITIES, null);
             builder.set(KEY_KEY_REQUEST_DATA, keyRequestData);
             builder.set(KEY_KEY_RESPONSE_DATA, null);
@@ -1487,8 +1452,6 @@ describe("MessageHeader", function() {
             expect(messageHeader.keyRequestData.length).toEqual(0);
             expect(messageHeader.keyResponseData).toBeNull();
             expect(messageHeader.masterToken).toBeNull();
-            expect(messageHeader.sender).toBeNull();
-            expect(messageHeader.recipient).toBeNull();
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toBeNull();
@@ -1513,7 +1476,6 @@ describe("MessageHeader", function() {
         
 		var messageHeader;
 		runs(function() {
-            builder.set(KEY_RECIPIENT, null);
             builder.set(KEY_CAPABILITIES, null);
             builder.set(KEY_KEY_REQUEST_DATA, null);
             builder.set(KEY_KEY_RESPONSE_DATA, null);
@@ -1538,8 +1500,6 @@ describe("MessageHeader", function() {
             expect(messageHeader.keyRequestData.length).toEqual(0);
             expect(messageHeader.keyResponseData).toBeNull();
             expect(messageHeader.masterToken).toEqual(PEER_MASTER_TOKEN);
-            expect(messageHeader.sender).toEqual(PEER_ENTITY_AUTH_DATA.getIdentity());
-            expect(messageHeader.recipient).toBeNull();
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toBeNull();
@@ -1566,7 +1526,6 @@ describe("MessageHeader", function() {
 		runs(function() {
 			var serviceTokens = [];
 			var keyRequestData = [];
-	        builder.set(KEY_RECIPIENT, null);
 	        builder.set(KEY_CAPABILITIES, null);
 	        builder.set(KEY_KEY_REQUEST_DATA, keyRequestData);
 	        builder.set(KEY_KEY_RESPONSE_DATA, null);
@@ -1593,8 +1552,6 @@ describe("MessageHeader", function() {
             expect(messageHeader.keyRequestData.length).toEqual(0);
             expect(messageHeader.keyResponseData).toBeNull();
             expect(messageHeader.masterToken).toEqual(PEER_MASTER_TOKEN);
-            expect(messageHeader.sender).toEqual(PEER_ENTITY_AUTH_DATA.getIdentity());
-            expect(messageHeader.recipient).toBeNull();
             expect(isAboutNow(messageHeader.timestamp)).toBeTruthy();
             expect(messageHeader.messageId).toEqual(MESSAGE_ID);
             expect(messageHeader.peerMasterToken).toBeNull();
@@ -4542,238 +4499,6 @@ describe("MessageHeader", function() {
 			expect(f).toThrow(new MslException(MslError.NONE), MESSAGE_ID);
 		});
 	});
-	
-	it("master token with different sender", function() {
-	    var masterToken;
-	    runs(function() {
-            var renewalWindow = new Date(Date.now() - 10000);
-            var expiration = new Date(Date.now() + 10000);
-            var encryptionKey = MockPresharedAuthenticationFactory.KPE;
-            var hmacKey = MockPresharedAuthenticationFactory.KPH;
-            MasterToken.create(trustedNetCtx, renewalWindow, expiration, 1, 1, null, "IDENTITY", encryptionKey, hmacKey, {
-                result: function(x) { masterToken = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-	    });
-        waitsFor(function() { return masterToken; }, "masterToken", MslTestConstants.TIMEOUT);
-        
-        var builder;
-        runs(function() {
-            HeaderDataBuilder$create(trustedNetCtx, null, null, false, {
-                result: function(x) { builder = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
-        
-        var messageHeader;
-        runs(function() {
-            builder.set(KEY_KEY_REQUEST_DATA, null);
-            builder.set(KEY_KEY_RESPONSE_DATA, null);
-            builder.set(KEY_USER_AUTHENTICATION_DATA, null);
-            var headerData = builder.build();
-            var peerData = new HeaderPeerData(null, null, null);
-            MessageHeader.create(trustedNetCtx, null, masterToken, headerData, peerData, {
-                result: function(token) { messageHeader = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return messageHeader; }, "messageHeader not received", MslTestConstants.TIMEOUT);
-        
-        var ead;
-        runs(function() {
-            trustedNetCtx.getEntityAuthenticationData(null, {
-                result: function(x) { ead = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return ead; }, "entity authentication data", MslTestConstants.TIMEOUT);
-		
-		var mo;
-		runs(function() {
-			MslTestUtils.toMslObject(encoder, messageHeader, {
-				result: function(x) { mo = x; },
-				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-			});
-		});
-		waitsFor(function() { return mo; }, "mo", MslTestConstants.TIMEOUT);
-        
-        var header;
-        runs(function() {
-            expect(messageHeader.sender).toEqual(ead.getIdentity());
-            Header.parseHeader(trustedNetCtx, mo, null, {
-                result: function(h) { header = h; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return header; }, "header", MslTestConstants.TIMEOUT);
-        
-        runs(function() {
-            expect(header instanceof MessageHeader).toBeTruthy();
-            
-            var moMessageHeader = header;
-            expect(moMessageHeader.sender).toEqual(messageHeader.sender);
-        });
-	});
-	
-	it("missing sender", function() {
-        var builder;
-        runs(function() {
-            HeaderDataBuilder$create(trustedNetCtx, null, null, false, {
-                result: function(x) { builder = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
-        
-        var messageHeader;
-        runs(function() {
-            builder.set(KEY_KEY_REQUEST_DATA, null);
-            builder.set(KEY_KEY_RESPONSE_DATA, null);
-            builder.set(KEY_USER_AUTHENTICATION_DATA, null);
-            var headerData = builder.build();
-            var peerData = new HeaderPeerData(null, null, null);
-            MessageHeader.create(trustedNetCtx, null, MASTER_TOKEN, headerData, peerData, {
-                result: function(token) { messageHeader = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return messageHeader; }, "messageHeader not received", MslTestConstants.TIMEOUT);
-		
-		var messageHeaderMo;
-		runs(function() {
-			MslTestUtils.toMslObject(encoder, messageHeader, {
-				result: function(x) { messageHeaderMo = x; },
-				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-			});
-		});
-		waitsFor(function() { return messageHeaderMo; }, "messageHeaderMo", MslTestConstants.TIMEOUT);
-        
-        var header;
-        runs(function() {
-            // Before modifying the header data we need to decrypt it.
-            var cryptoContext = new SessionCryptoContext(trustedNetCtx, MASTER_TOKEN);
-            var ciphertext = messageHeaderMo.getBytes(KEY_HEADERDATA);
-            cryptoContext.decrypt(ciphertext, encoder, {
-                result: function(plaintext) {
-                    var headerdataMo = encoder.parseObject(plaintext);
-        
-                    // After modifying the header data we need to encrypt it.
-                    headerdataMo.remove(KEY_SENDER);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
-                    	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
-		                        result: function(headerdata) {
-		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
-		                    
-		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
-		                                result: function(signature) {
-		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
-		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
-		                                        result: function(h) { header = h; },
-		                                        error: function(err) { exception = err; },
-		                                    });
-		                                },
-		                                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-		                            });
-		                        },
-		                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-		                    });
-                        },
-                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-                    });
-                },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return header; }, "header", MslTestConstants.TIMEOUT);
-        
-        runs(function() {
-            expect(header instanceof MessageHeader).toBeTruthy();
-            
-            var moMessageHeader = header;
-            expect(moMessageHeader.sender).toEqual(null);
-        });
-	});
-	
-    it("invalid sender", function() {
-        var builder;
-        runs(function() {
-            HeaderDataBuilder$create(trustedNetCtx, null, null, false, {
-                result: function(x) { builder = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
-        
-        var messageHeader;
-        runs(function() {
-            builder.set(KEY_KEY_REQUEST_DATA, null);
-            builder.set(KEY_KEY_RESPONSE_DATA, null);
-            builder.set(KEY_USER_AUTHENTICATION_DATA, null);
-            var headerData = builder.build();
-            var peerData = new HeaderPeerData(null, null, null);
-            MessageHeader.create(p2pCtx, null, MASTER_TOKEN, headerData, peerData, {
-                result: function(token) { messageHeader = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return messageHeader; }, "messageHeader not received", MslTestConstants.TIMEOUT);
-        
-        var messageHeaderMo;
-        runs(function() {
-            MslTestUtils.toMslObject(encoder, messageHeader, {
-                result: function(x) { messageHeaderMo = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return messageHeaderMo; }, "messageHeaderMo", MslTestConstants.TIMEOUT);
-        
-        var exception;
-        runs(function() {
-            // Before modifying the header data we need to decrypt it.
-            var cryptoContext = new SessionCryptoContext(p2pCtx, MASTER_TOKEN);
-            var ciphertext = messageHeaderMo.getBytes(KEY_HEADERDATA);
-            cryptoContext.decrypt(ciphertext, encoder, {
-                result: function(plaintext) {
-                    var headerdataMo = encoder.parseObject(plaintext);
-        
-                    // After modifying the header data we need to encrypt it.
-                    headerdataMo.put(KEY_SENDER, 1234);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
-                        result: function(plaintext) {
-                            cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
-                                result: function(headerdata) {
-                                    messageHeaderMo.put(KEY_HEADERDATA, headerdata);
-                            
-                                    // The header data must be signed or it will not be processed.
-                                    cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
-                                        result: function(signature) {
-                                            messageHeaderMo.put(KEY_SIGNATURE, signature);
-                                            Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
-                                                result: function() {},
-                                                error: function(e) { exception = e; },
-                                            });
-                                        },
-                                        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-                                    });
-                                },
-                                error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-                            });
-                        },
-                        error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-                    });
-                },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return exception; }, "exception not received", 300);
-        runs(function() {
-            var f = function() { throw exception; };
-            expect(f).toThrow(new MslEncodingException(MslError.MSL_PARSE_ERROR));
-        });
-    });
 
 	it("missing timestamp", function() {
         var builder;
@@ -6842,129 +6567,6 @@ describe("MessageHeader", function() {
             expect(messageHeaderA2.uniqueKey()).toEqual(messageHeaderA.uniqueKey());
         });
 	});
-	
-	xit("equals sender", function() {
-	    var ctx;
-	    runs(function() {
-	        MockMslContext.create(EntityAuthenticationScheme.RSA, false, {
-	           result: function(x) { ctx = x; },
-	           error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-	        });
-	    });
-	    waitsFor(function() { return ctx; }, "ctx", MslTestConstants.TIMEOUT);
-	    
-        var builder;
-        runs(function() {
-            HeaderDataBuilder$create(trustedNetCtx, null, null, false, {
-                result: function(x) { builder = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
-	    
-	    var messageHeaderA, messageHeaderB;
-        runs(function() {
-            var headerData = builder.build();
-            var peerData = new HeaderPeerData(null, null, null);
-            MessageHeader.create(trustedNetCtx, null, MASTER_TOKEN, headerData, peerData, {
-                result: function(token) { messageHeaderA = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-            MessageHeader.create(ctx, null, MASTER_TOKEN, headerData, peerData, {
-                result: function(token) { messageHeaderB = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return messageHeaderA && messageHeaderB; }, "message headers not received", MslTestConstants.TIMEOUT);
-		var messageHeaderA2;
-		runs(function() {
-			MslTestUtils.toMslObject(encoder, messageHeaderA, {
-				result: function(mo) {
-					Header.parseHeader(trustedNetCtx, mo, CRYPTO_CONTEXTS, {
-						result: function(h) { messageHeaderA2 = h; },
-						error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-					});
-				},
-				error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			});
-		});
-		waitsFor(function() { return messageHeaderA2; }, "parsed header not received", MslTestConstants.TIMEOUT);
-
-        runs(function() {
-            expect(messageHeaderA.equals(messageHeaderA)).toBeTruthy();
-            expect(messageHeaderA.uniqueKey()).toEqual(messageHeaderA.uniqueKey());
-    
-            expect(messageHeaderA.equals(messageHeaderB)).toBeFalsy();
-            expect(messageHeaderB.equals(messageHeaderA)).toBeFalsy();
-            expect(messageHeaderA.uniqueKey() != messageHeaderB.uniqueKey()).toBeTruthy();
-    
-            expect(messageHeaderA.equals(messageHeaderA2)).toBeTruthy();
-            expect(messageHeaderA2.equals(messageHeaderA)).toBeTruthy();
-            expect(messageHeaderA2.uniqueKey()).toEqual(messageHeaderA.uniqueKey());
-        });
-	});
-    
-    xit("equals recipient", function() {
-        var serviceTokens;
-        runs(function() {
-            MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, {
-                result: function(tks) { serviceTokens = tks; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return serviceTokens; }, "serviceTokens not received", MslTestConstants.TIMEOUT);
-        
-        var builder;
-        runs(function() {
-            HeaderDataBuilder$create(trustedNetCtx, null, USER_ID_TOKEN, serviceTokens, {
-                result: function(x) { builder = x; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return builder; }, "builder", MslTestConstants.TIMEOUT);
-
-        var messageHeaderA, messageHeaderB;
-        runs(function() {
-            var headerDataA = builder.set(KEY_RECIPIENT, "recipientA").build();
-            var headerDataB = builder.set(KEY_RECIPIENT, "recipientB").build();
-            var peerData = new HeaderPeerData(null, null, null);
-            MessageHeader.create(trustedNetCtx, null, MASTER_TOKEN, headerDataA, peerData, {
-                result: function(token) { messageHeaderA = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-            MessageHeader.create(trustedNetCtx, null, MASTER_TOKEN, headerDataB, peerData, {
-                result: function(token) { messageHeaderB = token; },
-                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
-            });
-        });
-        waitsFor(function() { return messageHeaderA && messageHeaderB; }, "message headers not received", MslTestConstants.TIMEOUT);
-		var messageHeaderA2;
-		runs(function() {
-			MslTestUtils.toMslObject(encoder, messageHeaderA, {
-				result: function(mo) {
-					Header.parseHeader(trustedNetCtx, mo, CRYPTO_CONTEXTS, {
-						result: function(h) { messageHeaderA2 = h; },
-						error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-					});
-				},
-				error: function(e) { expect(function() { throw e; }).not.toThrow(); },
-			});
-		});
-		waitsFor(function() { return messageHeaderA2; }, "parsed header not received", MslTestConstants.TIMEOUT);
-
-        runs(function() {
-            expect(messageHeaderA.equals(messageHeaderA)).toBeTruthy();
-            expect(messageHeaderA.uniqueKey()).toEqual(messageHeaderA.uniqueKey());
-    
-            expect(messageHeaderA.equals(messageHeaderB)).toBeFalsy();
-            expect(messageHeaderB.equals(messageHeaderA)).toBeFalsy();
-            expect(messageHeaderA.uniqueKey() != messageHeaderB.uniqueKey()).toBeTruthy();
-    
-            expect(messageHeaderA.equals(messageHeaderA2)).toBeTruthy();
-            expect(messageHeaderA2.equals(messageHeaderA)).toBeTruthy();
-            expect(messageHeaderA2.uniqueKey()).toEqual(messageHeaderA.uniqueKey());
-        });
-    });
     
     xit("equals timestamp", function() {
         var builder;

--- a/tests/src/test/javascript/msg/MessageInputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageInputStreamTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,13 +202,13 @@ describe("MessageInputStream", function() {
             waitsFor(function() { return ENTITY_AUTH_DATA; }, "entityAuthData", MslTestConstants.TIMEOUT);
 
             runs(function() {
-                var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null, null);
+                var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null, null);
                 var peerData = new HeaderPeerData(null, null, null);
                 MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                     result: function(x) { MESSAGE_HEADER = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
-                ErrorHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, 1, MslConstants.ResponseCode.FAIL, 3, "errormsg", "usermsg", {
+                ErrorHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, 1, MslConstants.ResponseCode.FAIL, 3, "errormsg", "usermsg", {
                     result: function(x) { ERROR_HEADER = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -384,7 +384,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -447,7 +447,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -510,7 +510,7 @@ describe("MessageInputStream", function() {
 
         var errorHeader;
         runs(function() {
-            ErrorHeader.create(trustedNetCtx, entityAuthData, null, 1, MslConstants.ResponseCode.FAIL, 3, "errormsg", "usermsg", {
+            ErrorHeader.create(trustedNetCtx, entityAuthData, 1, MslConstants.ResponseCode.FAIL, 3, "errormsg", "usermsg", {
                 result: function(x) { errorHeader = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -583,7 +583,7 @@ describe("MessageInputStream", function() {
             factory = new MockUnauthenticatedAuthenticationFactory();
             ctx.addEntityAuthenticationFactory(factory);
 
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -652,7 +652,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -761,7 +761,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -845,7 +845,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -923,7 +923,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, userIdToken, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -972,7 +972,7 @@ describe("MessageInputStream", function() {
     it("explicit handshake message", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1033,7 +1033,7 @@ describe("MessageInputStream", function() {
     it("inferred handshake message", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1105,7 +1105,7 @@ describe("MessageInputStream", function() {
     it("not a handshake message", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1185,7 +1185,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1271,7 +1271,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(p2pCtx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1367,7 +1367,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1435,7 +1435,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, KEY_RESPONSE_DATA, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1520,7 +1520,7 @@ describe("MessageInputStream", function() {
         var messageHeader;
         runs(function() {
             var keyResponseData = keyExchangeData.keyResponseData;
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1596,7 +1596,7 @@ describe("MessageInputStream", function() {
         var messageHeader;
         runs(function() {
             var keyResponseData = keyExchangeData.keyResponseData;
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, keyResponseData, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, entityAuthData, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1659,7 +1659,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1722,7 +1722,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(p2pCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1787,7 +1787,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1847,7 +1847,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1916,7 +1916,7 @@ describe("MessageInputStream", function() {
         // rejected.
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1991,7 +1991,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(p2pCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2049,7 +2049,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(p2pCtx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2096,7 +2096,7 @@ describe("MessageInputStream", function() {
     it("non-renewable handshake message", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, 1, false, true, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, 1, false, true, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2143,7 +2143,7 @@ describe("MessageInputStream", function() {
     it("handshake message without key request data", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, 1, true, true, null, null, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, 1, true, true, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2190,7 +2190,7 @@ describe("MessageInputStream", function() {
     it("non-replayable client message without master token", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2237,7 +2237,7 @@ describe("MessageInputStream", function() {
     it("non-replayable peer message without master token", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(p2pCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2306,7 +2306,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2375,7 +2375,7 @@ describe("MessageInputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, nonReplayableId - 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, nonReplayableId - 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2457,7 +2457,7 @@ describe("MessageInputStream", function() {
 
             factory.setLargestNonReplayableId(largestNonReplayableId);
 
-            var headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(messageHeader) { generate(messageHeader); },
@@ -2541,7 +2541,7 @@ describe("MessageInputStream", function() {
 
             factory.setLargestNonReplayableId(largestNonReplayableId);
 
-            var headerData = new HeaderData(null, MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, nonReplayableId, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(messageHeader) { generate(messageHeader, i, nonReplayableId, largestNonReplayableId); },
@@ -2602,7 +2602,7 @@ describe("MessageInputStream", function() {
             factory.setLargestNonReplayableId(1);
             ctx.setTokenFactory(factory);
 
-            var headerData = new HeaderData(null, MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2671,7 +2671,7 @@ describe("MessageInputStream", function() {
             factory.setLargestNonReplayableId(1);
             ctx.setTokenFactory(factory);
 
-            var headerData = new HeaderData(null, MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, 1, true, false, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, null, masterToken, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2811,7 +2811,7 @@ describe("MessageInputStream", function() {
     it("read from handshake message", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
+            var headerData = new HeaderData(MSG_ID, null, true, true, null, KEY_REQUEST_DATA, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(trustedNetCtx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },

--- a/tests/src/test/javascript/msg/MessageOutputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageOutputStreamTest.js
@@ -107,13 +107,13 @@ describe("MessageOutputStream", function() {
             waitsFor(function() { return ENTITY_AUTH_DATA; }, "entity authentication data", MslTestConstants.TIMEOUT);
 
             runs(function() {
-                var headerData = new HeaderData(null, 1, null, false, false, ctx.getMessageCapabilities(), null, null, null, null, null);
+                var headerData = new HeaderData(1, null, false, false, ctx.getMessageCapabilities(), null, null, null, null, null);
                 var peerData = new HeaderPeerData(null, null, null);
                 MessageHeader.create(ctx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                     result: function(x) { MESSAGE_HEADER = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
-                ErrorHeader.create(ctx, ENTITY_AUTH_DATA, null, 1, MslConstants.ResponseCode.FAIL, 3, "errormsg", "usermsg", {
+                ErrorHeader.create(ctx, ENTITY_AUTH_DATA, 1, MslConstants.ResponseCode.FAIL, 3, "errormsg", "usermsg", {
                     result: function(x) { ERROR_HEADER = x; },
                     error: function(e) { expect(function() { throw e; }).not.toThrow(); }
                 });
@@ -1159,7 +1159,7 @@ describe("MessageOutputStream", function() {
     it("write to a handshake message", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, 1, null, false, true, null, null, null, null, null, null);
+            var headerData = new HeaderData(1, null, false, true, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -1839,7 +1839,7 @@ describe("MessageOutputStream", function() {
     it("no request compression algorithms", function() {
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, 1, null, false, false, null, null, null, null, null, null);
+            var headerData = new HeaderData(1, null, false, false, null, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },
@@ -2014,7 +2014,7 @@ describe("MessageOutputStream", function() {
 
         var messageHeader;
         runs(function() {
-            var headerData = new HeaderData(null, 1, null, false, false, capabilities, null, null, null, null, null);
+            var headerData = new HeaderData(1, null, false, false, capabilities, null, null, null, null, null);
             var peerData = new HeaderPeerData(null, null, null);
             MessageHeader.create(ctx, ENTITY_AUTH_DATA, null, headerData, peerData, {
                 result: function(x) { messageHeader = x; },

--- a/tests/src/test/javascript/msg/MessageServiceTokenBuilderTest.js
+++ b/tests/src/test/javascript/msg/MessageServiceTokenBuilderTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("primary master token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -157,7 +157,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("primary master token with key exchange data", function() {
         var requestBuilder;
         runs(function() {
-            MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+            MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
                 result: function(x) { requestBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -199,7 +199,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("primary user ID token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -219,7 +219,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("peer master token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -240,7 +240,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("peer master token with key exchange data", function() {
 	    var requestBuilder;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+            MessageBuilder.createRequest(p2pCtx, null, null, null, {
                 result: function(x) { requestBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -282,7 +282,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("peer user ID token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -303,7 +303,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("get primary service tokens", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -324,7 +324,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("get peer service tokens", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -346,7 +346,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("get both service tokens", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -371,7 +371,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add primary service token", function() {
 	    var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -396,7 +396,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add primary service token with mismatched master token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -417,7 +417,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add primary service token with mismatched user ID token", function() {
 	    var msgBuilder, userIdToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -447,7 +447,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add primary service token with no master token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+            MessageBuilder.createRequest(p2pCtx, null, null, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -468,7 +468,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add primary service token with no user ID token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -489,7 +489,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add peer service token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -515,7 +515,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add peer service token with mismatched master token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -537,7 +537,7 @@ describe("MessageServiceTokenBuilder", function() {
     it("add peer service token with mismatched user ID token", function() {
         var msgBuilder, userIdToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -568,7 +568,7 @@ describe("MessageServiceTokenBuilder", function() {
     it("add peer service token with no master token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -589,7 +589,7 @@ describe("MessageServiceTokenBuilder", function() {
     it("add peer service token with no user ID token", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -611,7 +611,7 @@ describe("MessageServiceTokenBuilder", function() {
     it("add peer service token to trusted network message", function() {
         var msgBuilder, serviceToken;
         runs(function() {
-            MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+            MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
                 result: function(x) { msgBuilder = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -634,7 +634,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add unbound primary service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -672,7 +672,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -700,7 +700,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add master bound primary service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -735,7 +735,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add master bound primary service token with no master token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -766,7 +766,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -794,7 +794,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add user bound primary service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -829,7 +829,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add user bound primary service token with no master token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -857,7 +857,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add user bound primary service token with no user ID token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -888,7 +888,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -925,7 +925,7 @@ describe("MessageServiceTokenBuilder", function() {
 		
 		var msgBuilder;
 		runs(function() {
-			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 				result: function(x) { msgBuilder = x; },
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -951,7 +951,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("exclude unknown primary service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -977,7 +977,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 				result: function(x) { msgBuilder = x; },
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1026,7 +1026,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("delete unknown primary service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1048,7 +1048,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("p2p add unbound peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1083,7 +1083,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("trusted network add unbound peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(trustedNetCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(trustedNetCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1112,7 +1112,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1140,7 +1140,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add master bound peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1176,7 +1176,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add master bound peer service token with no master token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1206,7 +1206,7 @@ describe("MessageServiceTokenBuilder", function() {
 		runs(function() {
 			p2pMsgCtx.removeCryptoContext(TOKEN_NAME);
 			p2pMsgCtx.removeCryptoContext(EMPTY_TOKEN_NAME);
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1235,7 +1235,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("trusted network add master bound peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1257,7 +1257,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add user bound peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1293,7 +1293,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add user bound peer service token with no master token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, null, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, null, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1321,7 +1321,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("add user bound peer service token with no user ID token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, null, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1353,7 +1353,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1382,7 +1382,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("trusted network add user bound peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1413,7 +1413,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 				result: function(x) { msgBuilder = x; },
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1436,7 +1436,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("exclude unknown peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });
@@ -1463,7 +1463,7 @@ describe("MessageServiceTokenBuilder", function() {
 
 		var msgBuilder;
 		runs(function() {
-			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+			MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 				result: function(x) { msgBuilder = x; },
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1508,7 +1508,7 @@ describe("MessageServiceTokenBuilder", function() {
 	it("delete unknown peer service token", function() {
 		var msgBuilder;
 		runs(function() {
-		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, null, {
+		    MessageBuilder.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN, null, {
 		        result: function(x) { msgBuilder = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 		    });


### PR DESCRIPTION
Fixes #254. Removes the sender and recipient fields from the message and error headers. All checks based on those fields are removed.
Fixes #173. Verifies the sender entity identity of a received message matches the remote entity identity if specified by the `MessageContext`.