### PR TITLE
Close MslTokenizer before closing backing input stream.

### DIFF
--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -590,6 +590,13 @@ public class MessageInputStream extends InputStream {
      */
     @Override
     public void close() throws IOException {
+        // Close the tokenizer.
+        try {
+            tokenizer.close();
+        } catch (final MslEncoderException e) {
+            // Ignore exceptions.
+        }
+
         // Only close the source if instructed to do so because we might want
         // to reuse the connection.
         if (closeSource) {
@@ -609,13 +616,6 @@ public class MessageInputStream extends InputStream {
             } catch (final MslException e) {
                 // Ignore exceptions.
             }
-        }
-        
-        // Close the tokenizer.
-        try {
-            tokenizer.close();
-        } catch (final MslEncoderException e) {
-            // Ignore exceptions.
         }
     }
 

--- a/examples/simple/src/main/javascript/client/App.js
+++ b/examples/simple/src/main/javascript/client/App.js
@@ -302,14 +302,27 @@ function sendRequest() {
                 if (errorHeader.userMessage)
                     errorMsg += "<br/>" + errorHeader.userMessage;
                 errorCallback(errorMsg);
-                return;
+            } else {
+                // Otherwise display the response.
+                showResponse(mis);
+    
+                // Check the username in case we logged in.
+                checkUsername();
             }
-
-            // Otherwise display the response.
-            showResponse(mis);
-
-            // Check the username in case we logged in.
-            checkUsername();
+            
+            // Close the channel.
+            if (channel.input)
+                channel.input.close(-1, {
+                    result: function() {},
+                    timeout: function() {},
+                    error: function(e) {}
+                });
+            if (channel.output)
+                channel.output.close(-1, {
+                    result: function() {},
+                    timeout: function() {},
+                    error: function(e) {}
+                });
         },
         error: function(e) {
             performButton.value = originalValue;


### PR DESCRIPTION
Make sure to close the MslTokenizer before closing the backing source input stream, as the tokenizer may perform some stream manipulations when it is being closed.

This also fixes a bug in the JavaScript behavior where a request might get sent out twice because the tokenizer backing stream is closed first, firing off a request, and then the tokenizer would try to manipulate the closed stream. Not entirely sure how this resulted in two requests being sent out but the reordering of operations fixed it.