### PR TITLE
Do not use synchronous Buffered classes.

### DIFF
--- a/core/src/main/java/com/netflix/msl/io/JsonMslTokenizer.java
+++ b/core/src/main/java/com/netflix/msl/io/JsonMslTokenizer.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
- * 
+ * Copyright (c) 2015-2018 Netflix, Inc.  All rights reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,6 @@
  */
 package com.netflix.msl.io;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -30,41 +29,46 @@ import com.netflix.msl.MslInternalException;
 /**
  * <p>Create a new {@link MslTokenizer} that parses JSON-encoded MSL
  * messages.</p>
- * 
+ *
  * <p>This implementation is backed by {@code org.json}.</p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class JsonMslTokenizer extends MslTokenizer {
     /**
      * <p>Create a new JSON MSL tokenzier that will read data off the provided
      * input stream.</p>
-     * 
+     *
      * @param encoder MSL encoder factory.
      * @param source JSON input stream.
      */
     public JsonMslTokenizer(final MslEncoderFactory encoder, final InputStream source) {
         this.encoder = encoder;
-        // We cannot use the standard InputStreamReader to support UTF-8 
-        // decoding because it makes use of StreamDecoder which will read
-        // {@code StreamDecoder.DEFAULT_BYTE_BUFFER_SIZE} bytes by default, and
-        // enforces a minimum of {@code StreamDecoder.MIN_BYTE_BUFFER_SIZE}.
-        // This will consume extra bytes and prevent the input stream from
-        // being used for future MSL messages.
+        // We cannot use the standard {@code InputStreamReader} to support
+        // UTF-8 decoding because it makes use of {@code StreamDecoder} which
+        // will read {@code StreamDecoder.DEFAULT_BYTE_BUFFER_SIZE} bytes by
+        // default, and enforces a minimum of
+        // {@code StreamDecoder.MIN_BYTE_BUFFER_SIZE}. This will consume extra
+        // bytes and prevent the input stream from being used for future MSL
+        // messages.
         //
-        // JSONTokenizer will consume one character at a time, but will default
-        // to a {@code BufferedReader} with the default buffer size, which will
-        // also consume extra bytes and prevent reuse of the input stream.
+        // {@code JSONTokener} will consume one character at a time, but will
+        // default to a {@code BufferedReader} with the default buffer size if
+        // an {@code InputStream} or {@code Reader} is provided that does not
+        // support mark, which will also consume extra bytes and prevent reuse
+        // of the input stream.
         //
-        // Ensure only the minimum number of bytes are consumed by explicitly
-        // using the {@code ThriftyUtf8Reader} and a {@code BufferedReader}
-        // with a buffer size of 1.
+        // Ensure none of that occurs and that only the minimum number of bytes
+        // are consumed by explicitly using the {@code ThriftyUtf8Reader} which
+        // reads characters one at a time and also supports mark.
+        //
+        // Make sure we're trying to parse UTF-8 data.
         if (StandardCharsets.UTF_8 != MslConstants.DEFAULT_CHARSET)
             throw new MslInternalException("Charset " + MslConstants.DEFAULT_CHARSET + " unsupported.");
-        final Reader reader = new BufferedReader(new ThriftyUtf8Reader(source), 1);
+        final Reader reader = new ThriftyUtf8Reader(source);
         this.tokenizer = new JSONTokener(reader);
     }
-    
+
     /* (non-Javadoc)
      * @see com.netflix.msl.io.MslTokenizer#next(int)
      */

--- a/core/src/main/java/com/netflix/msl/io/MslEncoderFactory.java
+++ b/core/src/main/java/com/netflix/msl/io/MslEncoderFactory.java
@@ -157,7 +157,7 @@ public abstract class MslEncoderFactory {
      */
     public MslTokenizer createTokenizer(final InputStream source) throws IOException, MslEncoderException {
         // Read the byte stream identifier (and only the identifier).
-        final InputStream bufferedSource = source.markSupported() ? source : new UnsynchronizedBufferedInputStream(source, 1);
+        final InputStream bufferedSource = source.markSupported() ? source : new UnsynchronizedBufferedInputStream(source);
         bufferedSource.mark(1);
         final byte id = (byte)bufferedSource.read();
         if (id == -1)

--- a/core/src/main/java/com/netflix/msl/io/MslEncoderFactory.java
+++ b/core/src/main/java/com/netflix/msl/io/MslEncoderFactory.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2015-2017 Netflix, Inc.  All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,6 @@
  */
 package com.netflix.msl.io;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -28,25 +27,25 @@ import com.netflix.msl.util.Base64;
  * <p>An abstract factory class for producing {@link MslTokener},
  * {@link MslObject}, and {@link MslArray} instances of various encoder
  * formats.</p>
- * 
+ *
  * <p>A concrete implementations must identify its supported and preferred
  * encoder formats and provide implementations for encoding and decoding those
  * formats.</p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public abstract class MslEncoderFactory {
     /**
      * <p>Escape and quote a string for print purposes.</p>
-     * 
+     *
      * <p>This is based on the org.json {@code MslObject.quote()} code.</p>
-     * 
+     *
      * @param string the string to quote. May be {@code null}.
      * @return the quoted string.
      */
     static String quote(final String string) {
         final StringBuilder sb = new StringBuilder();
-        
+
         // Return "" for null or zero-length string.
         if (string == null || string.length() == 0) {
             sb.append("\"\"");
@@ -103,12 +102,12 @@ public abstract class MslEncoderFactory {
         sb.append('"');
         return sb.toString();
     }
-    
+
     /**
      * <p>Convert a value to a string for print purposes.</p>
-     * 
+     *
      * <p>This is based on the org.json {@code MslObject.writeValue()} code.</p>
-     * 
+     *
      * @param value the value to convert to a string. May be {@code null}.
      * @return the string.
      */
@@ -132,23 +131,23 @@ public abstract class MslEncoderFactory {
             return quote(value.toString());
         }
     }
-    
+
     /**
      * Returns the most preferred encoder format from the provided set of
      * formats.
-     * 
+     *
      * @param formats the set of formats to choose from. May be {@code null} or
      *        empty.
      * @return the preferred format from the provided set or the default format
      *         if format set is {@code null} or empty.
      */
     public abstract MslEncoderFormat getPreferredFormat(final Set<MslEncoderFormat> formats);
-    
+
     /**
      * Create a new {@link MslTokenizer}. The encoder format will be
      * determined by inspecting the byte stream identifier located in the first
      * byte.
-     * 
+     *
      * @param source the binary data to tokenize.
      * @return the {@link MslTokenizer}.
      * @throws IOException if there is a problem reading the byte stream
@@ -158,41 +157,41 @@ public abstract class MslEncoderFactory {
      */
     public MslTokenizer createTokenizer(final InputStream source) throws IOException, MslEncoderException {
         // Read the byte stream identifier (and only the identifier).
-        final InputStream bufferedSource = source.markSupported() ? source : new BufferedInputStream(source, 1);
+        final InputStream bufferedSource = source.markSupported() ? source : new UnsynchronizedBufferedInputStream(source, 1);
         bufferedSource.mark(1);
         final byte id = (byte)bufferedSource.read();
         if (id == -1)
             throw new MslEncoderException("End of stream reached when attempting to read the byte stream identifier.");
-        
+
         // Identify the encoder format.
         final MslEncoderFormat format = MslEncoderFormat.getFormat(id);
         if (format == null)
             throw new MslEncoderException("Unidentified encoder format ID: (byte)" + id + ".");
-        
+
         // Reset the input stream and return the tokenizer.
         bufferedSource.reset();
         return generateTokenizer(bufferedSource, format);
     }
-    
+
     /**
      * Create a new {@link MslTokenizer} of the specified encoder format.
-     * 
+     *
      * @param source the binary data to tokenize.
      * @param format the encoder format.
      * @return the {@link MslTokenizer}.
      * @throws MslEncoderException if the encoder format is not supported.
      */
     protected abstract MslTokenizer generateTokenizer(final InputStream source, final MslEncoderFormat format) throws MslEncoderException;
-    
+
     /**
      * Create a new {@link MslObject}.
-     * 
+     *
      * @return the {@link MslObject}.
      */
     public MslObject createObject() {
         return createObject(null);
     }
-    
+
     /**
      * Create a new {@link MslObject} populated with the provided map.
      *
@@ -205,12 +204,12 @@ public abstract class MslEncoderFactory {
     public MslObject createObject(final Map<String,Object> map) {
         return new MslObject(map);
     }
-    
+
     /**
      * Identify the encoder format of the {@link MslObject} of the encoded
      * data. The format will be identified by inspecting the byte stream
      * identifier located in the first byte.
-     * 
+     *
      * @param encoding the encoded data.
      * @return the encoder format.
      * @throws MslEncoderException if the encoder format cannot be identified
@@ -220,7 +219,7 @@ public abstract class MslEncoderFactory {
         // Fail if the encoding is too short.
         if (encoding.length < 1)
             throw new MslEncoderException("No encoding identifier found.");
-        
+
         // Identify the encoder format.
         final byte id = encoding[0];
         final MslEncoderFormat format = MslEncoderFormat.getFormat(id);
@@ -228,22 +227,22 @@ public abstract class MslEncoderFactory {
             throw new MslEncoderException("Unidentified encoder format ID: (byte)" + id + ".");
         return format;
     }
-    
+
     /**
      * Parse a {@link MslObject} from encoded data. The encoder format will be
      * determined by inspecting the byte stream identifier located in the first
      * byte.
-     * 
+     *
      * @param encoding the encoded data to parse.
      * @return the {@link MslObject}.
      * @throws MslEncoderException if the encoder format is not supported or
      *         there is an error parsing the encoded data.
      */
     public abstract MslObject parseObject(final byte[] encoding) throws MslEncoderException;
-    
+
     /**
      * Encode a {@link MslObject} into the specified encoder format.
-     * 
+     *
      * @param object the {@link MslObject} to encode.
      * @param format the encoder format.
      * @return the encoded data.
@@ -254,7 +253,7 @@ public abstract class MslEncoderFactory {
 
     /**
      * Create a new {@link MslArray}.
-     * 
+     *
      * @return the {@link MslArray}.
      */
     public MslArray createArray() {
@@ -263,7 +262,7 @@ public abstract class MslEncoderFactory {
 
     /**
      * Create a new {@link MslArray} populated with the provided values.
-     * 
+     *
      * @param collection the collection of values. May be {@code null}.
      * @return the {@link MslArray}.
      * @throws IllegalArgumentException if one of the values is of an

--- a/core/src/main/java/com/netflix/msl/io/ThriftyUtf8Reader.java
+++ b/core/src/main/java/com/netflix/msl/io/ThriftyUtf8Reader.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2017 Netflix, Inc.  All rights reserved.
- * 
+ * Copyright (c) 2017-2018 Netflix, Inc.  All rights reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,16 +24,16 @@ import java.io.Reader;
  * necessary to decode the character, and does not close the underlying input
  * stream. This ensures any unneeded bytes remain on the input stream, which
  * can then be reused.</p>
- * 
+ *
  * <p>Based on Andy Clark's
  * {@code com.sun.org.apache.xerces.internal.impl.io.UTF8Reader}.</p>
- * 
+ *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class ThriftyUtf8Reader extends Reader {
     /** Default byte buffer size (8192). */
     public static final int DEFAULT_BUFFER_SIZE = 8192;
-    
+
     /** Input stream. */
     private final InputStream fInputStream;
     /** Byte buffer. */
@@ -42,11 +42,11 @@ public class ThriftyUtf8Reader extends Reader {
     private int fOffset = 0;
     /** Surrogate character. */
     private int fSurrogate = -1;
-    
+
     public ThriftyUtf8Reader(final InputStream inputStream) {
         fInputStream = inputStream;
     }
-    
+
     @Override
     public int read() throws IOException {
         // decode character
@@ -459,13 +459,53 @@ public class ThriftyUtf8Reader extends Reader {
     }
 
     @Override
-    public void reset() {
+    public long skip(final long n) throws IOException {
+        // Don't pass skip down to the backing input stream since we're being
+        // asked to skip characters and not bytes.
+        long remaining = n;
+        final char[] ch = new char[fBuffer.length];
+        do {
+            final int length = ch.length < remaining ? ch.length : (int)remaining;
+            final int count = read(ch, 0, length);
+            if (count > 0)
+                remaining -= count;
+            else
+                break;
+        } while (remaining > 0);
+
+        final long skipped = n - remaining;
+        return skipped;
+    }
+
+    /**
+     * Tell whether this stream supports the mark() operation.
+     */
+    @Override
+    public boolean markSupported() {
+        return fInputStream.markSupported();
+    }
+
+    @Override
+    public void mark(final int readLimit) throws IOException {
+        // This is complicated because the read limit is in characters but the
+        // backing input stream is in bytes. If we really want to be safe then
+        // we need to multiply by 4 bytes. Account for overflow.
+        final int safeLimit = Math.max(Integer.MAX_VALUE, 4 * readLimit);
+        fInputStream.mark(safeLimit);
+    }
+
+    @Override
+    public void reset() throws IOException {
         fOffset = 0;
         fSurrogate = -1;
+        fInputStream.reset();
     }
 
     @Override
     public void close() {
+        // Explicitly do not close the backing input stream for our use case.
+        // This is because we are using ThriftyUtf8Reader inside a stream
+        // parser.
     }
 
     /** Throws an exception for expected byte. */

--- a/core/src/main/java/com/netflix/msl/io/ThriftyUtf8Reader.java
+++ b/core/src/main/java/com/netflix/msl/io/ThriftyUtf8Reader.java
@@ -490,7 +490,8 @@ public class ThriftyUtf8Reader extends Reader {
         // This is complicated because the read limit is in characters but the
         // backing input stream is in bytes. If we really want to be safe then
         // we need to multiply by 4 bytes. Account for overflow.
-        final int safeLimit = Math.max(Integer.MAX_VALUE, 4 * readLimit);
+        final int byteLimit = 4 * readLimit;
+        final int safeLimit = (byteLimit < 0) ? Integer.MAX_VALUE : byteLimit;
         fInputStream.mark(safeLimit);
     }
 

--- a/core/src/main/java/com/netflix/msl/io/UnsynchronizedBufferedInputStream.java
+++ b/core/src/main/java/com/netflix/msl/io/UnsynchronizedBufferedInputStream.java
@@ -1,0 +1,464 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ */
+package com.netflix.msl.io;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * A <code>UnsynchronizedBufferedInputStream</code> is the exact same as a
+ * <code>BufferedInputStream</code> except its functions are not synchronized
+ * and the class is not thread-safe.
+ *
+ * @author Wesley Miaw <wmiaw@netflix.com>
+ */
+public class UnsynchronizedBufferedInputStream extends FilterInputStream {
+
+    private static int DEFAULT_BUFFER_SIZE = 8192;
+
+    /**
+     * The maximum size of array to allocate.
+     * Some VMs reserve some header words in an array.
+     * Attempts to allocate larger arrays may result in
+     * OutOfMemoryError: Requested array size exceeds VM limit
+     */
+    private static int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+
+    /**
+     * The internal buffer array where the data is stored. When necessary,
+     * it may be replaced by another array of
+     * a different size.
+     */
+    protected volatile byte buf[];
+
+    /**
+     * Atomic updater to provide compareAndSet for buf. This is
+     * necessary because closes can be asynchronous. We use nullness
+     * of buf[] as primary indicator that this stream is closed. (The
+     * "in" field is also nulled out on close.)
+     */
+    private static final
+        AtomicReferenceFieldUpdater<UnsynchronizedBufferedInputStream, byte[]> bufUpdater =
+        AtomicReferenceFieldUpdater.newUpdater
+        (UnsynchronizedBufferedInputStream.class,  byte[].class, "buf");
+
+    /**
+     * The index one greater than the index of the last valid byte in
+     * the buffer.
+     * This value is always
+     * in the range <code>0</code> through <code>buf.length</code>;
+     * elements <code>buf[0]</code>  through <code>buf[count-1]
+     * </code>contain buffered input data obtained
+     * from the underlying  input stream.
+     */
+    protected int count;
+
+    /**
+     * The current position in the buffer. This is the index of the next
+     * character to be read from the <code>buf</code> array.
+     * <p>
+     * This value is always in the range <code>0</code>
+     * through <code>count</code>. If it is less
+     * than <code>count</code>, then  <code>buf[pos]</code>
+     * is the next byte to be supplied as input;
+     * if it is equal to <code>count</code>, then
+     * the  next <code>read</code> or <code>skip</code>
+     * operation will require more bytes to be
+     * read from the contained  input stream.
+     *
+     * @see     java.io.BufferedInputStream#buf
+     */
+    protected int pos;
+
+    /**
+     * The value of the <code>pos</code> field at the time the last
+     * <code>mark</code> method was called.
+     * <p>
+     * This value is always
+     * in the range <code>-1</code> through <code>pos</code>.
+     * If there is no marked position in  the input
+     * stream, this field is <code>-1</code>. If
+     * there is a marked position in the input
+     * stream,  then <code>buf[markpos]</code>
+     * is the first byte to be supplied as input
+     * after a <code>reset</code> operation. If
+     * <code>markpos</code> is not <code>-1</code>,
+     * then all bytes from positions <code>buf[markpos]</code>
+     * through  <code>buf[pos-1]</code> must remain
+     * in the buffer array (though they may be
+     * moved to  another place in the buffer array,
+     * with suitable adjustments to the values
+     * of <code>count</code>,  <code>pos</code>,
+     * and <code>markpos</code>); they may not
+     * be discarded unless and until the difference
+     * between <code>pos</code> and <code>markpos</code>
+     * exceeds <code>marklimit</code>.
+     *
+     * @see     java.io.BufferedInputStream#mark(int)
+     * @see     java.io.BufferedInputStream#pos
+     */
+    protected int markpos = -1;
+
+    /**
+     * The maximum read ahead allowed after a call to the
+     * <code>mark</code> method before subsequent calls to the
+     * <code>reset</code> method fail.
+     * Whenever the difference between <code>pos</code>
+     * and <code>markpos</code> exceeds <code>marklimit</code>,
+     * then the  mark may be dropped by setting
+     * <code>markpos</code> to <code>-1</code>.
+     *
+     * @see     java.io.BufferedInputStream#mark(int)
+     * @see     java.io.BufferedInputStream#reset()
+     */
+    protected int marklimit;
+
+    /**
+     * Check to make sure that underlying input stream has not been
+     * nulled out due to close; if not return it;
+     */
+    private InputStream getInIfOpen() throws IOException {
+        final InputStream input = in;
+        if (input == null)
+            throw new IOException("Stream closed");
+        return input;
+    }
+
+    /**
+     * Check to make sure that buffer has not been nulled out due to
+     * close; if not return it;
+     */
+    private byte[] getBufIfOpen() throws IOException {
+        final byte[] buffer = buf;
+        if (buffer == null)
+            throw new IOException("Stream closed");
+        return buffer;
+    }
+
+    /**
+     * Creates a <code>BufferedInputStream</code>
+     * and saves its  argument, the input stream
+     * <code>in</code>, for later use. An internal
+     * buffer array is created and  stored in <code>buf</code>.
+     *
+     * @param   in   the underlying input stream.
+     */
+    public UnsynchronizedBufferedInputStream(final InputStream in) {
+        this(in, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Creates a <code>BufferedInputStream</code>
+     * with the specified buffer size,
+     * and saves its  argument, the input stream
+     * <code>in</code>, for later use.  An internal
+     * buffer array of length  <code>size</code>
+     * is created and stored in <code>buf</code>.
+     *
+     * @param   in     the underlying input stream.
+     * @param   size   the buffer size.
+     * @exception IllegalArgumentException if {@code size <= 0}.
+     */
+    public UnsynchronizedBufferedInputStream(final InputStream in, final int size) {
+        super(in);
+        if (size <= 0) {
+            throw new IllegalArgumentException("Buffer size <= 0");
+        }
+        buf = new byte[size];
+    }
+
+    /**
+     * Fills the buffer with more data, taking into account
+     * shuffling and other tricks for dealing with marks.
+     * Assumes that it is being called by a synchronized method.
+     * This method also assumes that all data has already been read in,
+     * hence pos > count.
+     */
+    private void fill() throws IOException {
+        byte[] buffer = getBufIfOpen();
+        if (markpos < 0)
+            pos = 0;            /* no mark: throw away the buffer */
+        else if (pos >= buffer.length)  /* no room left in buffer */
+            if (markpos > 0) {  /* can throw away early part of the buffer */
+                final int sz = pos - markpos;
+                System.arraycopy(buffer, markpos, buffer, 0, sz);
+                pos = sz;
+                markpos = 0;
+            } else if (buffer.length >= marklimit) {
+                markpos = -1;   /* buffer got too big, invalidate mark */
+                pos = 0;        /* drop buffer contents */
+            } else if (buffer.length >= MAX_BUFFER_SIZE) {
+                throw new OutOfMemoryError("Required array size too large");
+            } else {            /* grow buffer */
+                int nsz = (pos <= MAX_BUFFER_SIZE - pos) ?
+                        pos * 2 : MAX_BUFFER_SIZE;
+                if (nsz > marklimit)
+                    nsz = marklimit;
+                final byte nbuf[] = new byte[nsz];
+                System.arraycopy(buffer, 0, nbuf, 0, pos);
+                if (!bufUpdater.compareAndSet(this, buffer, nbuf)) {
+                    // Can't replace buf if there was an async close.
+                    // Note: This would need to be changed if fill()
+                    // is ever made accessible to multiple threads.
+                    // But for now, the only way CAS can fail is via close.
+                    // assert buf == null;
+                    throw new IOException("Stream closed");
+                }
+                buffer = nbuf;
+            }
+        count = pos;
+        final int n = getInIfOpen().read(buffer, pos, buffer.length - pos);
+        if (n > 0)
+            count = n + pos;
+    }
+
+    /**
+     * See
+     * the general contract of the <code>read</code>
+     * method of <code>InputStream</code>.
+     *
+     * @return     the next byte of data, or <code>-1</code> if the end of the
+     *             stream is reached.
+     * @exception  IOException  if this input stream has been closed by
+     *                          invoking its {@link #close()} method,
+     *                          or an I/O error occurs.
+     * @see        java.io.FilterInputStream#in
+     */
+    @Override
+    public int read() throws IOException {
+        if (pos >= count) {
+            fill();
+            if (pos >= count)
+                return -1;
+        }
+        return getBufIfOpen()[pos++] & 0xff;
+    }
+
+    /**
+     * Read characters into a portion of an array, reading from the underlying
+     * stream at most once if necessary.
+     */
+    private int read1(final byte[] b, final int off, final int len) throws IOException {
+        int avail = count - pos;
+        if (avail <= 0) {
+            /* If the requested length is at least as large as the buffer, and
+               if there is no mark/reset activity, do not bother to copy the
+               bytes into the local buffer.  In this way buffered streams will
+               cascade harmlessly. */
+            if (len >= getBufIfOpen().length && markpos < 0) {
+                return getInIfOpen().read(b, off, len);
+            }
+            fill();
+            avail = count - pos;
+            if (avail <= 0) return -1;
+        }
+        final int cnt = (avail < len) ? avail : len;
+        System.arraycopy(getBufIfOpen(), pos, b, off, cnt);
+        pos += cnt;
+        return cnt;
+    }
+
+    /**
+     * Reads bytes from this byte-input stream into the specified byte array,
+     * starting at the given offset.
+     *
+     * <p> This method implements the general contract of the corresponding
+     * <code>{@link InputStream#read(byte[], int, int) read}</code> method of
+     * the <code>{@link InputStream}</code> class.  As an additional
+     * convenience, it attempts to read as many bytes as possible by repeatedly
+     * invoking the <code>read</code> method of the underlying stream.  This
+     * iterated <code>read</code> continues until one of the following
+     * conditions becomes true: <ul>
+     *
+     *   <li> The specified number of bytes have been read,
+     *
+     *   <li> The <code>read</code> method of the underlying stream returns
+     *   <code>-1</code>, indicating end-of-file, or
+     *
+     *   <li> The <code>available</code> method of the underlying stream
+     *   returns zero, indicating that further input requests would block.
+     *
+     * </ul> If the first <code>read</code> on the underlying stream returns
+     * <code>-1</code> to indicate end-of-file then this method returns
+     * <code>-1</code>.  Otherwise this method returns the number of bytes
+     * actually read.
+     *
+     * <p> Subclasses of this class are encouraged, but not required, to
+     * attempt to read as many bytes as possible in the same fashion.
+     *
+     * @param      b     destination buffer.
+     * @param      off   offset at which to start storing bytes.
+     * @param      len   maximum number of bytes to read.
+     * @return     the number of bytes read, or <code>-1</code> if the end of
+     *             the stream has been reached.
+     * @exception  IOException  if this input stream has been closed by
+     *                          invoking its {@link #close()} method,
+     *                          or an I/O error occurs.
+     */
+    @Override
+    public int read(final byte b[], final int off, final int len)
+        throws IOException
+    {
+        getBufIfOpen(); // Check for closed stream
+        if ((off | len | (off + len) | (b.length - (off + len))) < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int n = 0;
+        for (;;) {
+            final int nread = read1(b, off + n, len - n);
+            if (nread <= 0)
+                return (n == 0) ? nread : n;
+            n += nread;
+            if (n >= len)
+                return n;
+            // if not closed but no bytes available, return
+            final InputStream input = in;
+            if (input != null && input.available() <= 0)
+                return n;
+        }
+    }
+
+    /**
+     * See the general contract of the <code>skip</code>
+     * method of <code>InputStream</code>.
+     *
+     * @exception  IOException  if the stream does not support seek,
+     *                          or if this input stream has been closed by
+     *                          invoking its {@link #close()} method, or an
+     *                          I/O error occurs.
+     */
+    @Override
+    public long skip(final long n) throws IOException {
+        getBufIfOpen(); // Check for closed stream
+        if (n <= 0) {
+            return 0;
+        }
+        long avail = count - pos;
+
+        if (avail <= 0) {
+            // If no mark position set then don't keep in buffer
+            if (markpos <0)
+                return getInIfOpen().skip(n);
+
+            // Fill in buffer to save bytes for reset
+            fill();
+            avail = count - pos;
+            if (avail <= 0)
+                return 0;
+        }
+
+        final long skipped = (avail < n) ? avail : n;
+        pos += skipped;
+        return skipped;
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read (or
+     * skipped over) from this input stream without blocking by the next
+     * invocation of a method for this input stream. The next invocation might be
+     * the same thread or another thread.  A single read or skip of this
+     * many bytes will not block, but may read or skip fewer bytes.
+     * <p>
+     * This method returns the sum of the number of bytes remaining to be read in
+     * the buffer (<code>count&nbsp;- pos</code>) and the result of calling the
+     * {@link java.io.FilterInputStream#in in}.available().
+     *
+     * @return     an estimate of the number of bytes that can be read (or skipped
+     *             over) from this input stream without blocking.
+     * @exception  IOException  if this input stream has been closed by
+     *                          invoking its {@link #close()} method,
+     *                          or an I/O error occurs.
+     */
+    @Override
+    public int available() throws IOException {
+        final int n = count - pos;
+        final int avail = getInIfOpen().available();
+        return n > (Integer.MAX_VALUE - avail)
+                    ? Integer.MAX_VALUE
+                    : n + avail;
+    }
+
+    /**
+     * See the general contract of the <code>mark</code>
+     * method of <code>InputStream</code>.
+     *
+     * @param   readlimit   the maximum limit of bytes that can be read before
+     *                      the mark position becomes invalid.
+     * @see     java.io.BufferedInputStream#reset()
+     */
+    @Override
+    public void mark(final int readlimit) {
+        marklimit = readlimit;
+        markpos = pos;
+    }
+
+    /**
+     * See the general contract of the <code>reset</code>
+     * method of <code>InputStream</code>.
+     * <p>
+     * If <code>markpos</code> is <code>-1</code>
+     * (no mark has been set or the mark has been
+     * invalidated), an <code>IOException</code>
+     * is thrown. Otherwise, <code>pos</code> is
+     * set equal to <code>markpos</code>.
+     *
+     * @exception  IOException  if this stream has not been marked or,
+     *                  if the mark has been invalidated, or the stream
+     *                  has been closed by invoking its {@link #close()}
+     *                  method, or an I/O error occurs.
+     * @see        java.io.BufferedInputStream#mark(int)
+     */
+    @Override
+    public void reset() throws IOException {
+        getBufIfOpen(); // Cause exception if closed
+        if (markpos < 0)
+            throw new IOException("Resetting to invalid mark");
+        pos = markpos;
+    }
+
+    /**
+     * Tests if this input stream supports the <code>mark</code>
+     * and <code>reset</code> methods. The <code>markSupported</code>
+     * method of <code>BufferedInputStream</code> returns
+     * <code>true</code>.
+     *
+     * @return  a <code>boolean</code> indicating if this stream type supports
+     *          the <code>mark</code> and <code>reset</code> methods.
+     * @see     java.io.InputStream#mark(int)
+     * @see     java.io.InputStream#reset()
+     */
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    /**
+     * Closes this input stream and releases any system resources
+     * associated with the stream.
+     * Once the stream has been closed, further read(), available(), reset(),
+     * or skip() invocations will throw an IOException.
+     * Closing a previously closed stream has no effect.
+     *
+     * @exception  IOException  if an I/O error occurs.
+     */
+    @Override
+    public void close() throws IOException {
+        byte[] buffer;
+        while ( (buffer = buf) != null) {
+            if (bufUpdater.compareAndSet(this, buffer, null)) {
+                final InputStream input = in;
+                in = null;
+                if (input != null)
+                    input.close();
+                return;
+            }
+            // Else retry in case a new buf was CASed in fill()
+        }
+    }
+}

--- a/core/src/main/java/com/netflix/msl/io/UnsynchronizedBufferedInputStream.java
+++ b/core/src/main/java/com/netflix/msl/io/UnsynchronizedBufferedInputStream.java
@@ -1,464 +1,199 @@
 /**
  * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.netflix.msl.io;
 
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 /**
- * A <code>UnsynchronizedBufferedInputStream</code> is the exact same as a
- * <code>BufferedInputStream</code> except its functions are not synchronized
- * and the class is not thread-safe.
+ * <p>A {@code UnsynchronizedBufferedInputStream} adds support for the
+ * {@code mark()} and {@code reset()} functions.</p>
  *
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class UnsynchronizedBufferedInputStream extends FilterInputStream {
-
-    private static int DEFAULT_BUFFER_SIZE = 8192;
-
     /**
-     * The maximum size of array to allocate.
-     * Some VMs reserve some header words in an array.
-     * Attempts to allocate larger arrays may result in
-     * OutOfMemoryError: Requested array size exceeds VM limit
+     * Buffer of data read since the last call to mark(). Null if
+     * mark() has not been called or if the read limit has been
+     * exceeded.
      */
-    private static int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+    protected byte buf[] = null;
+    /** Number of valid bytes in the buffer. */
+    protected int bufcount;
+    /** Current buffer read position. */
+    protected int bufpos;
 
     /**
-     * The internal buffer array where the data is stored. When necessary,
-     * it may be replaced by another array of
-     * a different size.
-     */
-    protected volatile byte buf[];
-
-    /**
-     * Atomic updater to provide compareAndSet for buf. This is
-     * necessary because closes can be asynchronous. We use nullness
-     * of buf[] as primary indicator that this stream is closed. (The
-     * "in" field is also nulled out on close.)
-     */
-    private static final
-        AtomicReferenceFieldUpdater<UnsynchronizedBufferedInputStream, byte[]> bufUpdater =
-        AtomicReferenceFieldUpdater.newUpdater
-        (UnsynchronizedBufferedInputStream.class,  byte[].class, "buf");
-
-    /**
-     * The index one greater than the index of the last valid byte in
-     * the buffer.
-     * This value is always
-     * in the range <code>0</code> through <code>buf.length</code>;
-     * elements <code>buf[0]</code>  through <code>buf[count-1]
-     * </code>contain buffered input data obtained
-     * from the underlying  input stream.
-     */
-    protected int count;
-
-    /**
-     * The current position in the buffer. This is the index of the next
-     * character to be read from the <code>buf</code> array.
-     * <p>
-     * This value is always in the range <code>0</code>
-     * through <code>count</code>. If it is less
-     * than <code>count</code>, then  <code>buf[pos]</code>
-     * is the next byte to be supplied as input;
-     * if it is equal to <code>count</code>, then
-     * the  next <code>read</code> or <code>skip</code>
-     * operation will require more bytes to be
-     * read from the contained  input stream.
+     * Creates a new <code>UnsynchronizedBufferedInputStream</code> without any
+     * mark position set.
      *
-     * @see     java.io.BufferedInputStream#buf
-     */
-    protected int pos;
-
-    /**
-     * The value of the <code>pos</code> field at the time the last
-     * <code>mark</code> method was called.
-     * <p>
-     * This value is always
-     * in the range <code>-1</code> through <code>pos</code>.
-     * If there is no marked position in  the input
-     * stream, this field is <code>-1</code>. If
-     * there is a marked position in the input
-     * stream,  then <code>buf[markpos]</code>
-     * is the first byte to be supplied as input
-     * after a <code>reset</code> operation. If
-     * <code>markpos</code> is not <code>-1</code>,
-     * then all bytes from positions <code>buf[markpos]</code>
-     * through  <code>buf[pos-1]</code> must remain
-     * in the buffer array (though they may be
-     * moved to  another place in the buffer array,
-     * with suitable adjustments to the values
-     * of <code>count</code>,  <code>pos</code>,
-     * and <code>markpos</code>); they may not
-     * be discarded unless and until the difference
-     * between <code>pos</code> and <code>markpos</code>
-     * exceeds <code>marklimit</code>.
-     *
-     * @see     java.io.BufferedInputStream#mark(int)
-     * @see     java.io.BufferedInputStream#pos
-     */
-    protected int markpos = -1;
-
-    /**
-     * The maximum read ahead allowed after a call to the
-     * <code>mark</code> method before subsequent calls to the
-     * <code>reset</code> method fail.
-     * Whenever the difference between <code>pos</code>
-     * and <code>markpos</code> exceeds <code>marklimit</code>,
-     * then the  mark may be dropped by setting
-     * <code>markpos</code> to <code>-1</code>.
-     *
-     * @see     java.io.BufferedInputStream#mark(int)
-     * @see     java.io.BufferedInputStream#reset()
-     */
-    protected int marklimit;
-
-    /**
-     * Check to make sure that underlying input stream has not been
-     * nulled out due to close; if not return it;
-     */
-    private InputStream getInIfOpen() throws IOException {
-        final InputStream input = in;
-        if (input == null)
-            throw new IOException("Stream closed");
-        return input;
-    }
-
-    /**
-     * Check to make sure that buffer has not been nulled out due to
-     * close; if not return it;
-     */
-    private byte[] getBufIfOpen() throws IOException {
-        final byte[] buffer = buf;
-        if (buffer == null)
-            throw new IOException("Stream closed");
-        return buffer;
-    }
-
-    /**
-     * Creates a <code>BufferedInputStream</code>
-     * and saves its  argument, the input stream
-     * <code>in</code>, for later use. An internal
-     * buffer array is created and  stored in <code>buf</code>.
-     *
-     * @param   in   the underlying input stream.
+     * @param in the backing input stream.
      */
     public UnsynchronizedBufferedInputStream(final InputStream in) {
-        this(in, DEFAULT_BUFFER_SIZE);
-    }
-
-    /**
-     * Creates a <code>BufferedInputStream</code>
-     * with the specified buffer size,
-     * and saves its  argument, the input stream
-     * <code>in</code>, for later use.  An internal
-     * buffer array of length  <code>size</code>
-     * is created and stored in <code>buf</code>.
-     *
-     * @param   in     the underlying input stream.
-     * @param   size   the buffer size.
-     * @exception IllegalArgumentException if {@code size <= 0}.
-     */
-    public UnsynchronizedBufferedInputStream(final InputStream in, final int size) {
         super(in);
-        if (size <= 0) {
-            throw new IllegalArgumentException("Buffer size <= 0");
-        }
-        buf = new byte[size];
     }
 
-    /**
-     * Fills the buffer with more data, taking into account
-     * shuffling and other tricks for dealing with marks.
-     * Assumes that it is being called by a synchronized method.
-     * This method also assumes that all data has already been read in,
-     * hence pos > count.
-     */
-    private void fill() throws IOException {
-        byte[] buffer = getBufIfOpen();
-        if (markpos < 0)
-            pos = 0;            /* no mark: throw away the buffer */
-        else if (pos >= buffer.length)  /* no room left in buffer */
-            if (markpos > 0) {  /* can throw away early part of the buffer */
-                final int sz = pos - markpos;
-                System.arraycopy(buffer, markpos, buffer, 0, sz);
-                pos = sz;
-                markpos = 0;
-            } else if (buffer.length >= marklimit) {
-                markpos = -1;   /* buffer got too big, invalidate mark */
-                pos = 0;        /* drop buffer contents */
-            } else if (buffer.length >= MAX_BUFFER_SIZE) {
-                throw new OutOfMemoryError("Required array size too large");
-            } else {            /* grow buffer */
-                int nsz = (pos <= MAX_BUFFER_SIZE - pos) ?
-                        pos * 2 : MAX_BUFFER_SIZE;
-                if (nsz > marklimit)
-                    nsz = marklimit;
-                final byte nbuf[] = new byte[nsz];
-                System.arraycopy(buffer, 0, nbuf, 0, pos);
-                if (!bufUpdater.compareAndSet(this, buffer, nbuf)) {
-                    // Can't replace buf if there was an async close.
-                    // Note: This would need to be changed if fill()
-                    // is ever made accessible to multiple threads.
-                    // But for now, the only way CAS can fail is via close.
-                    // assert buf == null;
-                    throw new IOException("Stream closed");
-                }
-                buffer = nbuf;
-            }
-        count = pos;
-        final int n = getInIfOpen().read(buffer, pos, buffer.length - pos);
-        if (n > 0)
-            count = n + pos;
-    }
-
-    /**
-     * See
-     * the general contract of the <code>read</code>
-     * method of <code>InputStream</code>.
-     *
-     * @return     the next byte of data, or <code>-1</code> if the end of the
-     *             stream is reached.
-     * @exception  IOException  if this input stream has been closed by
-     *                          invoking its {@link #close()} method,
-     *                          or an I/O error occurs.
-     * @see        java.io.FilterInputStream#in
-     */
     @Override
     public int read() throws IOException {
-        if (pos >= count) {
-            fill();
-            if (pos >= count)
-                return -1;
-        }
-        return getBufIfOpen()[pos++] & 0xff;
-    }
+        if (in == null)
+            throw new IOException("Stream is closed");
 
-    /**
-     * Read characters into a portion of an array, reading from the underlying
-     * stream at most once if necessary.
-     */
-    private int read1(final byte[] b, final int off, final int len) throws IOException {
-        int avail = count - pos;
-        if (avail <= 0) {
-            /* If the requested length is at least as large as the buffer, and
-               if there is no mark/reset activity, do not bother to copy the
-               bytes into the local buffer.  In this way buffered streams will
-               cascade harmlessly. */
-            if (len >= getBufIfOpen().length && markpos < 0) {
-                return getInIfOpen().read(b, off, len);
+        // If we have any data in the buffer, read it first.
+        if (bufpos < bufcount)
+            return buf[bufpos++];
+
+        // Otherwise read from the backing stream...
+        final int c = in.read();
+        if (c == -1) return -1;
+
+        // If we are buffering data...
+        if (buf != null) {
+            // Store the data if there is space.
+            if (bufcount < buf.length) {
+                buf[bufcount++] = (byte)c;
+                bufpos++;
             }
-            fill();
-            avail = count - pos;
-            if (avail <= 0) return -1;
+
+            // Otherwise we have exceeded the read limit. Stop buffering and
+            // invalidate the mark.
+            else {
+                buf = null;
+                bufcount = 0;
+                bufpos = 0;
+            }
         }
-        final int cnt = (avail < len) ? avail : len;
-        System.arraycopy(getBufIfOpen(), pos, b, off, cnt);
-        pos += cnt;
-        return cnt;
+
+        // Return the read data.
+        return c;
     }
 
-    /**
-     * Reads bytes from this byte-input stream into the specified byte array,
-     * starting at the given offset.
-     *
-     * <p> This method implements the general contract of the corresponding
-     * <code>{@link InputStream#read(byte[], int, int) read}</code> method of
-     * the <code>{@link InputStream}</code> class.  As an additional
-     * convenience, it attempts to read as many bytes as possible by repeatedly
-     * invoking the <code>read</code> method of the underlying stream.  This
-     * iterated <code>read</code> continues until one of the following
-     * conditions becomes true: <ul>
-     *
-     *   <li> The specified number of bytes have been read,
-     *
-     *   <li> The <code>read</code> method of the underlying stream returns
-     *   <code>-1</code>, indicating end-of-file, or
-     *
-     *   <li> The <code>available</code> method of the underlying stream
-     *   returns zero, indicating that further input requests would block.
-     *
-     * </ul> If the first <code>read</code> on the underlying stream returns
-     * <code>-1</code> to indicate end-of-file then this method returns
-     * <code>-1</code>.  Otherwise this method returns the number of bytes
-     * actually read.
-     *
-     * <p> Subclasses of this class are encouraged, but not required, to
-     * attempt to read as many bytes as possible in the same fashion.
-     *
-     * @param      b     destination buffer.
-     * @param      off   offset at which to start storing bytes.
-     * @param      len   maximum number of bytes to read.
-     * @return     the number of bytes read, or <code>-1</code> if the end of
-     *             the stream has been reached.
-     * @exception  IOException  if this input stream has been closed by
-     *                          invoking its {@link #close()} method,
-     *                          or an I/O error occurs.
-     */
     @Override
-    public int read(final byte b[], final int off, final int len)
-        throws IOException
-    {
-        getBufIfOpen(); // Check for closed stream
-        if ((off | len | (off + len) | (b.length - (off + len))) < 0) {
-            throw new IndexOutOfBoundsException();
-        } else if (len == 0) {
-            return 0;
+    public int read(final byte b[], final int off, final int len) throws IOException {
+        if (in == null)
+            throw new IOException("Stream is closed");
+
+        // Copy in any buffered data.
+        final int copied;
+        if (bufcount > bufpos) {
+            copied = Math.min(bufcount - bufpos, len);
+            System.arraycopy(buf, bufpos, b, off, copied);
+            bufpos += copied;
+        } else {
+            copied = 0;
         }
 
-        int n = 0;
-        for (;;) {
-            final int nread = read1(b, off + n, len - n);
-            if (nread <= 0)
-                return (n == 0) ? nread : n;
-            n += nread;
-            if (n >= len)
-                return n;
-            // if not closed but no bytes available, return
-            final InputStream input = in;
-            if (input != null && input.available() <= 0)
-                return n;
+        // Read any remaining data requested.
+        final int remaining = len - copied;
+        final int numread = in.read(b, copied, remaining);
+
+        // If we were unable to read, return the number of bytes copied or -1
+        // to indicate end-of-stream if we also didn't copy any bytes.
+        if (numread == -1)
+            return (copied > 0) ? copied : -1;
+
+        // If we are buffering data...
+        if (buf != null) {
+            // Store the data if there is space.
+            if (bufcount + numread <= buf.length) {
+                System.arraycopy(b, copied, buf, bufpos, numread);
+                bufcount += numread;
+                bufpos += numread;
+            }
+
+            // Otherwise we have exceeded the read limit. Stop buffering and
+            // invalidate the mark.
+            else {
+                buf = null;
+                bufcount = 0;
+                bufpos = 0;
+            }
         }
+
+        // Return number of bytes read.
+        return copied + numread;
     }
 
-    /**
-     * See the general contract of the <code>skip</code>
-     * method of <code>InputStream</code>.
-     *
-     * @exception  IOException  if the stream does not support seek,
-     *                          or if this input stream has been closed by
-     *                          invoking its {@link #close()} method, or an
-     *                          I/O error occurs.
-     */
     @Override
     public long skip(final long n) throws IOException {
-        getBufIfOpen(); // Check for closed stream
-        if (n <= 0) {
-            return 0;
-        }
-        long avail = count - pos;
+        if (in == null)
+            throw new IOException("Stream is closed");
 
-        if (avail <= 0) {
-            // If no mark position set then don't keep in buffer
-            if (markpos <0)
-                return getInIfOpen().skip(n);
-
-            // Fill in buffer to save bytes for reset
-            fill();
-            avail = count - pos;
-            if (avail <= 0)
-                return 0;
+        // If we have enough buffered characters, skip over them.
+        final long buffered = bufcount - bufpos;
+        if (buffered >= n) {
+            bufpos += n;
+            return n;
         }
 
-        final long skipped = (avail < n) ? avail : n;
-        pos += skipped;
-        return skipped;
+        // Otherwise skip over the buffered characters and read the rest.
+        bufpos += buffered;
+        long remaining = n - buffered;
+        while (remaining > 0) {
+            final byte[] buf = new byte[(int)remaining];
+            final int read = read(buf, 0, buf.length);
+            if (read == -1) break;
+            remaining -= read;
+        }
+
+        // Return the number of characters skipped.
+        return n - remaining;
     }
 
-    /**
-     * Returns an estimate of the number of bytes that can be read (or
-     * skipped over) from this input stream without blocking by the next
-     * invocation of a method for this input stream. The next invocation might be
-     * the same thread or another thread.  A single read or skip of this
-     * many bytes will not block, but may read or skip fewer bytes.
-     * <p>
-     * This method returns the sum of the number of bytes remaining to be read in
-     * the buffer (<code>count&nbsp;- pos</code>) and the result of calling the
-     * {@link java.io.FilterInputStream#in in}.available().
-     *
-     * @return     an estimate of the number of bytes that can be read (or skipped
-     *             over) from this input stream without blocking.
-     * @exception  IOException  if this input stream has been closed by
-     *                          invoking its {@link #close()} method,
-     *                          or an I/O error occurs.
-     */
     @Override
     public int available() throws IOException {
-        final int n = count - pos;
-        final int avail = getInIfOpen().available();
-        return n > (Integer.MAX_VALUE - avail)
-                    ? Integer.MAX_VALUE
-                    : n + avail;
+        if (in == null)
+            throw new IOException("Stream is closed");
+        final int available = in.available();
+        return (bufcount + available < 0) ? Integer.MAX_VALUE : bufcount + available;
     }
 
-    /**
-     * See the general contract of the <code>mark</code>
-     * method of <code>InputStream</code>.
-     *
-     * @param   readlimit   the maximum limit of bytes that can be read before
-     *                      the mark position becomes invalid.
-     * @see     java.io.BufferedInputStream#reset()
-     */
     @Override
     public void mark(final int readlimit) {
-        marklimit = readlimit;
-        markpos = pos;
+        // Create the new buffer of the requested size.
+        final byte[] newbuf = new byte[readlimit];
+
+        // Copy any unread data that is currently buffered into the new buffer.
+        final int tocopy = (buf != null) ? bufcount - bufpos : 0;
+        if (tocopy > 0)
+            System.arraycopy(buf, bufpos, newbuf, 0, tocopy);
+
+        // Set the buffer.
+        buf = newbuf;
+        bufpos = 0;
+        bufcount = tocopy;
     }
 
-    /**
-     * See the general contract of the <code>reset</code>
-     * method of <code>InputStream</code>.
-     * <p>
-     * If <code>markpos</code> is <code>-1</code>
-     * (no mark has been set or the mark has been
-     * invalidated), an <code>IOException</code>
-     * is thrown. Otherwise, <code>pos</code> is
-     * set equal to <code>markpos</code>.
-     *
-     * @exception  IOException  if this stream has not been marked or,
-     *                  if the mark has been invalidated, or the stream
-     *                  has been closed by invoking its {@link #close()}
-     *                  method, or an I/O error occurs.
-     * @see        java.io.BufferedInputStream#mark(int)
-     */
     @Override
     public void reset() throws IOException {
-        getBufIfOpen(); // Cause exception if closed
-        if (markpos < 0)
-            throw new IOException("Resetting to invalid mark");
-        pos = markpos;
+        if (in == null)
+            throw new IOException("Stream is closed");
+        bufpos = 0;
     }
 
-    /**
-     * Tests if this input stream supports the <code>mark</code>
-     * and <code>reset</code> methods. The <code>markSupported</code>
-     * method of <code>BufferedInputStream</code> returns
-     * <code>true</code>.
-     *
-     * @return  a <code>boolean</code> indicating if this stream type supports
-     *          the <code>mark</code> and <code>reset</code> methods.
-     * @see     java.io.InputStream#mark(int)
-     * @see     java.io.InputStream#reset()
-     */
     @Override
     public boolean markSupported() {
         return true;
     }
 
-    /**
-     * Closes this input stream and releases any system resources
-     * associated with the stream.
-     * Once the stream has been closed, further read(), available(), reset(),
-     * or skip() invocations will throw an IOException.
-     * Closing a previously closed stream has no effect.
-     *
-     * @exception  IOException  if an I/O error occurs.
-     */
     @Override
     public void close() throws IOException {
-        byte[] buffer;
-        while ( (buffer = buf) != null) {
-            if (bufUpdater.compareAndSet(this, buffer, null)) {
-                final InputStream input = in;
-                in = null;
-                if (input != null)
-                    input.close();
-                return;
-            }
-            // Else retry in case a new buf was CASed in fill()
+        if (in != null) {
+            in.close();
+            in = null;
         }
     }
 }

--- a/core/src/main/javascript/package.json
+++ b/core/src/main/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msl-core",
-  "version": "1.1221.1",
+  "version": "1.1221.2",
   "description": "Message Security Layer",
   "keywords": [
     "msl",

--- a/integ-tests/src/test/javascript/package.json
+++ b/integ-tests/src/test/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msl-integ-tests-exec",
-  "version": "1.1221.1",
+  "version": "1.1221.2",
   "description": "Message Security Layer Integration Tests Execution",
   "keywords": [
     "msl",
@@ -21,8 +21,8 @@
     "lint": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs jshint --verbose"
   },
   "dependencies": {
-    "msl-core": "file:../../../../core/src/main/javascript/msl-core-1.1221.1.tgz",
-    "msl-tests": "file:../../../../tests/src/main/javascript/msl-tests-1.1221.1.tgz"
+    "msl-core": "^1.1221.2",
+    "msl-tests": "^1.1221.2"
   },
   "devDependencies": {
     "ec-key": "0.0.2",

--- a/tests/src/main/javascript/package.json
+++ b/tests/src/main/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msl-tests",
-  "version": "1.1221.1",
+  "version": "1.1221.2",
   "description": "Message Security Layer Tests",
   "keywords": [
     "msl",
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "msl-core": "^1.1221.1"
+    "msl-core": "^1.1221.2"
   },
   "devDependencies": {
     "ec-key": "0.0.2",

--- a/tests/src/test/javascript/package.json
+++ b/tests/src/test/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msl-tests-exec",
-  "version": "1.1221.1",
+  "version": "1.1221.2",
   "description": "Message Security Layer Tests Execution",
   "keywords": [
     "msl",
@@ -20,8 +20,8 @@
     "test": "find . -type f -name '*.js' ! -regex '.*/node_modules/.*' | xargs -n1 jasmine-node --matchall --forceexit --captureExceptions ./node_modules/msl-tests/lib/jasmine/msl-helpers.js"
   },
   "dependencies": {
-    "msl-core": "file:../../../../core/src/main/javascript/msl-core-1.1221.1.tgz",
-    "msl-tests": "file:../../main/javascript/msl-tests-1.1221.1.tgz"
+    "msl-core": "^1.1221.2",
+    "msl-tests": "^1.1221.2"
   },
   "devDependencies": {
     "ec-key": "0.0.2",


### PR DESCRIPTION
Fixes #269. Remove use of BufferedInputStream and BufferedReader which are thread-safe and acquire locks that will be super expensive when reading data one byte at a time.

ThriftyUtf8Reader now supports mark/reset if the backing input stream supports them by passing the calls through. skip() is implemented by directly reading characters.