### PR TITLE
Initialize cyclic dependencies once instead of every time.

### DIFF
--- a/core/src/main/javascript/io/JsonMslArray.js
+++ b/core/src/main/javascript/io/JsonMslArray.js
@@ -32,6 +32,9 @@
 	var MslException = require('../MslException.js');
 	var Base64 = require('../util/Base64.js');
 	var AsyncExecutor = require('../util/AsyncExecutor.js');
+
+    // Cyclic dependency declarations.
+	var JsonMslObject;
 	
 	var JsonMslArray = module.exports = MslArray.extend({
         /**
@@ -49,6 +52,9 @@
          */
         init: function init(encoder, source) {
             init.base.call(this);
+            
+            // Cyclic dependency assignments.
+            if (!JsonMslObject) JsonMslObject = require('../io/JsonMslObject.js');
             
             // Set properties.
             var props = {
@@ -90,8 +96,6 @@
         
         /** @inheritDoc */
         put: function put(index, value) {
-            var JsonMslObject = require('../io/JsonMslObject.js');
-            
             var o;
             try {
                 // Convert JSONObject to MslObject.

--- a/core/src/main/javascript/io/JsonMslObject.js
+++ b/core/src/main/javascript/io/JsonMslObject.js
@@ -33,6 +33,10 @@
 	var Base64 = require('../util/Base64.js');
 	var AsyncExecutor = require('../util/AsyncExecutor.js');
     
+    // Cyclic dependency declarations.
+    var MslEncoderFactory,
+        JsonMslArray;
+    
     /**
      * Encode the provided MSL object into JSON.
      * 
@@ -75,6 +79,10 @@
          */
         init: function init(encoder, source) {
             init.base.call(this);
+
+            // Cyclic dependency assignments.
+            if (!MslEncoderFactory) MslEncoderFactory = require('../io/MslEncoderFactory.js');
+            if (!JsonMslArray) JsonMslArray = require('../io/JsonMslArray.js');
             
             // Set properties.
             var props = {
@@ -126,8 +134,6 @@
         
         /** @inheritDoc */
         put: function put(key, value) {
-            var JsonMslArray = require('../io/JsonMslArray.js');
-
             var o;
             try {
                 // Convert Object to MslObject.
@@ -149,8 +155,6 @@
 
         /** @inheritDoc */
         getBytes: function getBytes(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             // When a JsonMslObject is decoded, there's no way for us to know if a
             // value is supposed to be a String to byte[]. Therefore interpret
             // Strings as Base64-encoded data consistent with the toJSONString()

--- a/core/src/main/javascript/io/MslArray.js
+++ b/core/src/main/javascript/io/MslArray.js
@@ -37,6 +37,11 @@
 	var Class = require('../util/Class.js');
 	var MslEncoderException = require('../io/MslEncoderException.js');
 	var MslEncodable = require('../io/MslEncodable.js');
+    
+    // Cyclic dependency declarations.
+    var MslEncoderFactory,
+        MslObject,
+        MslEncoderUtils;
 
     /**
      * @interface
@@ -50,6 +55,11 @@
          *         unsupported type.
          */
         init: function init(array) {
+            // Cyclic dependency assignments.
+            if (!MslEncoderFactory) MslEncoderFactory = require('../io/MslEncoderFactory.js');
+            if (!MslObject) MslObject = require('../io/MslObject.js');
+            if (!MslEncoderUtils) MslEncoderUtils = require('../io/MslEncoderUtils.js');
+            
             // The properties.
             var props = {
                 /**
@@ -78,8 +88,6 @@
          *         type.
          */
         get: function get(index) {
-            var MslObject = require('../io/MslObject.js');
-            
             if (index < 0 || index >= this.list.length)
                 throw new RangeError("MslArray[" + index + "] is negative or exceeds array length.");
             var o = this.list[index];
@@ -198,8 +206,6 @@
          *         type.
          */
         getMslObject: function getMslObject(index, encoder) {
-            var MslObject = require('../io/MslObject.js');
-            
             var o = this.get(index);
             if (o instanceof MslObject)
                 return o;
@@ -294,8 +300,6 @@
          *         exceeds the number of elements in the array.
          */
         opt: function opt(index) {
-            var MslObject = require('../io/MslObject.js');
-            
             if (index < 0 || index >= this.list.length)
                 throw new RangeError("MslArray[" + index + "] is negative or exceeds array length.");
             var o = this.list[index];
@@ -429,8 +433,6 @@
          *         exceeds the number of elements in the array.
          */
         optMslObject: function optMslObject(index, encoder) {
-            var MslObject = require('../io/MslObject.js');
-            
             var o = this.opt(index);
             if (o instanceof MslObject)
                 return o;
@@ -521,8 +523,6 @@
          * @throws TypeError if the value is of an unsupported type.
          */
         put: function put(index, value) {
-            var MslObject = require('../io/MslObject.js');
-            
             if (index < -1)
                 throw new RangeError("MslArray[" + index + "] is negative.");
             
@@ -755,8 +755,6 @@
          *         with the same elements in the same order.
          */
         equals: function equals(that) {
-            var MslEncoderUtils = require('../io/MslEncoderUtils.js');
-            
         	if (this == that) return true;
         	if (!(that instanceof MslArray)) return false;
         	try {
@@ -769,8 +767,6 @@
         
         /** @inheritDoc */
         toString: function toString() {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
         	return MslEncoderFactory.stringify(this.list);
         },
     });

--- a/core/src/main/javascript/io/MslObject.js
+++ b/core/src/main/javascript/io/MslObject.js
@@ -40,6 +40,11 @@
 	var Class = require('../util/Class.js');
 	var MslEncoderException = require('../io/MslEncoderException.js');
 	var MslEncodable = require('../io/MslEncodable.js');
+	
+    // Cyclic dependency declarations.
+	var MslEncoderFactory,
+	    MslArray,
+	    MslEncoderUtils;
 
     /**
      * @interface
@@ -54,6 +59,11 @@
          *         unsupported type.
          */
         init: function init(map) {
+            // Cyclic dependency assignments.
+            if (!MslEncoderFactory) MslEncoderFactory = require('../io/MslEncoderFactory.js');
+            if (!MslArray) MslArray = require('../io/MslArray.js');
+            if (!MslEncoderUtils) MslEncoderUtils = require('../io/MslEncoderUtils.js');
+            
             // The properties.
             var props = {
                 /**
@@ -85,9 +95,6 @@
          *         type or the value is {@code null}.
          */
         get: function get(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            var MslArray = require('../io/MslArray.js');
-            
             if (key instanceof String)
                 key = key.valueOf();
             if (typeof key !== 'string')
@@ -112,8 +119,6 @@
          *         proper type or the value is {@code null}.
          */
         getBoolean: function getBoolean(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             if (o instanceof Boolean)
                 return o.valueOf();
@@ -132,8 +137,6 @@
          *         proper type or the value is {@code null}.
          */
         getBytes: function getBytes(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             if (o instanceof Uint8Array)
                 return o;
@@ -150,8 +153,6 @@
          *         proper type or the value is {@code null}.
          */
         getDouble: function getDouble(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             if (o instanceof Number)
                 return o.valueOf();
@@ -170,8 +171,6 @@
          *         proper type or the value is {@code null}.
          */
         getInt: function getInt(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             // The << 0 operation converts to a signed 32-bit integer.
             if (o instanceof Number)
@@ -191,9 +190,6 @@
          *         proper type or the value is {@code null}.
          */
         getMslArray: function getMslArray(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            var MslArray = require('../io/MslArray.js');
-            
             var o = this.get(key);
             if (o instanceof MslArray)
                 return o;
@@ -213,8 +209,6 @@
          *         proper type or the value is {@code null}.
          */
         getMslObject: function getMslObject(key, encoder) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             if (o instanceof MslObject)
                 return o;
@@ -246,8 +240,6 @@
          *         proper type or the value is {@code null}.
          */
         getLong: function getLong(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             // I don't know of a better way than using parseInt().
             if (o instanceof Number)
@@ -267,8 +259,6 @@
          *         proper type or the value is {@code null}.
          */
         getString: function getString(key) {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
             var o = this.get(key);
             if (o instanceof String)
                 return o.valueOf();
@@ -298,8 +288,6 @@
          * @throws TypeError if the key is not a string.
          */
         opt: function opt(key) {
-            var MslArray = require('../io/MslArray.js');
-            
             if (key instanceof String)
                 key = key.valueOf();
             if (typeof key !== 'string')
@@ -416,8 +404,6 @@
          * @throws TypeError if the key is not a string.
          */
         optMslArray: function optMslArray(key) {
-            var MslArray = require('../io/MslArray.js');
-            
             var o = this.opt(key);
             if (o instanceof MslArray)
                 return o;
@@ -520,8 +506,6 @@
          *         value is of an unsupported type.
          */
         put: function put(key, value) {
-            var MslArray = require('../io/MslArray.js');
-            
             if (key instanceof String)
                 key = key.valueOf();
             if (typeof key !== 'string')
@@ -757,8 +741,6 @@
          *         with the same keys and values.
          */
         equals: function equals(that) {
-            var MslEncoderUtils = require('../io/MslEncoderUtils.js');
-            
         	if (this == that) return true;
         	if (!(that instanceof MslObject)) return false;
         	try {
@@ -771,8 +753,6 @@
         
         /** @inheritDoc */
         toString: function toString() {
-            var MslEncoderFactory = require('../io/MslEncoderFactory.js');
-            
         	return MslEncoderFactory.stringify(this.map);
         },
     });

--- a/core/src/main/javascript/msg/Header.js
+++ b/core/src/main/javascript/msg/Header.js
@@ -63,6 +63,10 @@
 	var MslMessageException = require('../MslMessageException.js');
 	var MslError = require('../MslError.js');
 	
+	// Cyclic dependency declarations.
+	var MessageHeader,
+	    ErrorHeader;
+	
 	/**
 	 * Common header keys.
 	 * @const
@@ -185,8 +189,8 @@
         
         function processHeaders(entityAuthData, masterToken, signature) {
             AsyncExecutor(callback, function() {
-                var MessageHeader = require('../msg/MessageHeader.js');
-                var ErrorHeader = require('../msg/ErrorHeader.js');
+                if (!MessageHeader) MessageHeader = require('../msg/MessageHeader.js');
+                if (!ErrorHeader) ErrorHeader = require('../msg/ErrorHeader.js');
                 
                 try {
                     // Process message headers.


### PR DESCRIPTION
Initialize cyclic dependencies early (but lazily) and once at module scope instead of every time in function scope, for a performance improvement.