### PR TITLE
Correct (hopefully) master token lock cleanup in MslControl.

### DIFF
--- a/core/src/main/javascript/util/Semaphore.js
+++ b/core/src/main/javascript/util/Semaphore.js
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>A semaphore.</p>
+ */
+(function(require, module) {
+    "use strict";
+    
+    var Class = require('../util/Class.js');
+    var MslConstants = require('../MslConstants.js');
+    var InterruptibleExecutor = require('../util/InterruptibleExecutor.js');
+
+    /**
+     * @param {number} the ticket number.
+     * @return the next larger ticket number, wrapped around.
+     */
+    function incrementTicket(number) {
+        return (number == MslConstants.MAX_LONG_VALUE) ? 1 : number + 1;
+    }
+
+    /**
+     * Return the provided semaphore's next waiter ticket number.
+     *
+     * @param {Semaphore} sem the sempahore.
+     * @return {number} the next waiter ticket number.
+     */
+    function nextWaiter(sem) {
+        // If there are no more waiters then we're done.
+        if (Object.keys(sem._waiters).length === 0) {
+            return 0;
+        }
+
+        // Otherwise update the next waiter number.
+        var next = incrementTicket(sem._nextWaiter);
+        while (!sem._waiters[next])
+            next = incrementTicket(next);
+        return next;
+    }
+    
+    var Semaphore = module.exports = Class.create({
+        /**
+         * Create a new sempahore.
+         * 
+         * @param {number} count the initial number of available resources.
+         */
+        init: function init(count) {
+            // The properties.
+            var props = {
+                /**
+                 * Current number of available resources.
+                 * @type {number}
+                 */
+                _available: { value: count, writable: true, enumerable: false, configurable: false },
+                /**
+                 * Maximum number of available resources.
+                 * @type {number}
+                 */
+                _maximum: { value: count, writable: false, enumerable: false, configurable: false },
+                /**
+                 * Queue of readers waiting for a resource.
+                 * @type {Object.<number,function()}
+                 */
+                _waiters: { value: {}, writable: false, enumerable: false, configurable: false },
+                /**
+                 * Next waiter number. [1,2^53] or 0 indicating no waiter.
+                 * @type {number}
+                 */
+                _nextWaiter: { value: 0, writable: true, enumerable: false, configurable: false },
+                /**
+                 * Last added waiter number. [1,2^53] or 0 indicating no waiter.
+                 * @type {number}
+                 */
+                _lastWaiter: { value: 0, writable: true, enumerable: false, configurable: false }
+            };
+            Object.defineProperties(this, props);
+        },
+        
+        /**
+         * Cancel a waiter identified by the given ticket.
+         * 
+         * @param {number} ticket the ticket identifying the operation to
+         *        cancel.
+         */
+        cancel: function cancel(ticket) {
+            // Do nothing if the waiter is no longer waiting.
+            if (!this._waiters[ticket]) return;
+
+            // Deliver false to the identified waiter.
+            this._waiters[ticket].call(this, false);
+            delete this._waiters[ticket];
+
+            // If this is the next waiter then update the next waiter number.
+            if (ticket == this._nextWaiter)
+                this._nextWaiter = nextWaiter(this);
+        },
+
+        /**
+         * Cancel all waiters.
+         */
+        cancelAll: function cancelAll() {
+            while (this._nextWaiter !== 0)
+                this.cancel(this._nextWaiter);
+        },
+
+        /**
+         * Wait until a resource is available.
+         *
+         * @param {number} timeout timeout in milliseconds or -1 for no
+         *        timeout.
+         * @param {{result: function(boolean), timeout: function(), error: function(Error)}}
+         *        callback the callback that will receive true if the resource
+         *        has been acquired or false if cancelled, be notified of
+         *        timeout, or receive any thrown exceptions.
+         * @return {number} a ticket with which the operation can be cancelled
+         *         or 0 if the resource was immediately acquired.
+         */
+        wait: function wait(timeout, callback) {
+            var self = this;
+            
+            // If a resource is available, allow immediate acquisition.
+            if (this._available > 0) {
+                --this._available;
+                // The actual delay will be clamped.
+                setTimeout(function() { callback.result(true); }, 0);
+                return 0;
+            }
+            
+            // Otherwise wait until a resource is available.
+            var number = incrementTicket(this._lastWaiter);
+            this._lastWaiter = number;
+
+            InterruptibleExecutor(callback, function() {
+                // Start the timeout and stick the waiter onto the waiter queue.
+                // The timeout cannot execute before we return so there is no
+                // chance of a race condition.
+                var timeoutId;
+                if (timeout != -1) {
+                    timeoutId = setTimeout(function() {
+                        // Trigger the timeout after we update the next waiter
+                        // in case the timeout triggers a callback to the
+                        // queue.
+                        delete self._waiters[number];
+                        if (number == self._nextWaiter)
+                            self._nextWaiter = nextWaiter(self);
+                        callback.timeout();
+                    }, timeout);
+                }
+                this._waiters[number] = function(elem) {
+                    clearTimeout(timeoutId);
+                    
+                    // If not being cancelled, acquire one of the resources.
+                    if (elem) {
+                        // Make sure a resource is available.
+                        if (this._available <= 0) {
+                            // The actual delay will be clamped.
+                            setTimeout(function() { callback.error(new MslInternalException("Semaphore waiter signaled without any available resources.")); }, 0);
+                            return;
+                        }
+                        
+                        --this._available;
+                    }
+                    
+                    // The actual delay will be clamped.
+                    setTimeout(function() { callback.result(elem); }, 0);
+                };
+                if (!this._nextWaiter)
+                    this._nextWaiter = number;
+            }, self);
+            
+            // Return the cancellation ticket.
+            return number;
+        },
+        
+        /**
+         * Release a resource.
+         */
+        signal: function signal(ticket) {
+            // Make sure signal hasn't been called too many times.
+            if (this._available == this._maximum)
+                throw new MslInternalException("Sempahore signaled despite all resources being already available.");
+            
+            // Increment the number of available resources.
+            ++this._available;
+            
+            // If there is a waiter signal it.
+            if (this._nextWaiter) {
+                // Grab the signaling function but do not execute it until
+                // after updating the next waiter number in case signaling
+                // triggers a callback to the queue.
+                var signaling = this._waiters[this._nextWaiter];
+                delete this._waiters[this._nextWaiter];
+                this._nextWaiter = nextWaiter(this);
+                
+                // Signal the waiter.
+                signaling.call(this, true);
+                return;
+            }
+        },
+    });
+})(require, (typeof module !== 'undefined') ? module : mkmodule('Semaphore'));

--- a/core/src/main/javascript/util/Semaphore.js
+++ b/core/src/main/javascript/util/Semaphore.js
@@ -23,6 +23,7 @@
     var Class = require('../util/Class.js');
     var MslConstants = require('../MslConstants.js');
     var InterruptibleExecutor = require('../util/InterruptibleExecutor.js');
+    var MslInternalException = require('../MslInternalException.js');
 
     /**
      * @param {number} the ticket number.

--- a/examples/simple/src/main/javascript/client/SimpleClient.html
+++ b/examples/simple/src/main/javascript/client/SimpleClient.html
@@ -41,13 +41,6 @@
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/WebCryptoNamedCurve.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/crypto/WebCryptoUsage.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslConstants.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/AsyncExecutor.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/InterruptibleExecutor.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/BlockingQueue.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Random.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
-<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Semaphore.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslError.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslException.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslCryptoException.js"></script>
@@ -62,6 +55,13 @@
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslMessageException.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslUserAuthException.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslUserIdTokenException.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/AsyncExecutor.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/InterruptibleExecutor.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/BlockingQueue.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Random.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Semaphore.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/io/InputStream.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/io/OutputStream.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/io/ByteArrayInputStream.js"></script>

--- a/examples/simple/src/main/javascript/client/SimpleClient.html
+++ b/examples/simple/src/main/javascript/client/SimpleClient.html
@@ -47,6 +47,7 @@
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Random.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
+<script type="text/javascript" src="../../../../../../core/src/main/javascript/util/Semaphore.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslError.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslException.js"></script>
 <script type="text/javascript" src="../../../../../../core/src/main/javascript/MslCryptoException.js"></script>

--- a/tests/src/test/javascript/msltests.html
+++ b/tests/src/test/javascript/msltests.html
@@ -38,6 +38,7 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/Random.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/Semaphore.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslError.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslException.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslCryptoException.js"></script>
@@ -283,6 +284,7 @@
 <script type="text/javascript" src="util/BlockingQueueTest.js"></script>
 <script type="text/javascript" src="util/ConditionVariableTest.js"></script>
 <script type="text/javascript" src="util/ReadWriteLockTest.js"></script>
+<script type="text/javascript" src="util/SemaphoreTest.js"></script>
 <script type="text/javascript" src="util/SimpleMslStoreTest.js"></script>
 <script type="text/javascript" src="util/NullMslStoreTest.js"></script>
 </head>

--- a/tests/src/test/javascript/msltests.html
+++ b/tests/src/test/javascript/msltests.html
@@ -32,13 +32,6 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/WebCryptoNamedCurve.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/crypto/WebCryptoUsage.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslConstants.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/AsyncExecutor.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/InterruptibleExecutor.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/BlockingQueue.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/Random.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
-<script type="text/javascript" src="../../../../core/src/main/javascript/util/Semaphore.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslError.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslException.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslCryptoException.js"></script>
@@ -53,6 +46,13 @@
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslMessageException.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslUserAuthException.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/MslUserIdTokenException.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/AsyncExecutor.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/InterruptibleExecutor.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/BlockingQueue.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/ConditionVariable.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/Random.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/ReadWriteLock.js"></script>
+<script type="text/javascript" src="../../../../core/src/main/javascript/util/Semaphore.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/io/InputStream.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/io/OutputStream.js"></script>
 <script type="text/javascript" src="../../../../core/src/main/javascript/io/ByteArrayInputStream.js"></script>

--- a/tests/src/test/javascript/util/SemaphoreTest.js
+++ b/tests/src/test/javascript/util/SemaphoreTest.js
@@ -17,6 +17,7 @@
 describe("Semaphore", function() {
     var Semaphore = require('msl-core/util/Semaphore.js');
     var Random = require('msl-core/util/Random.js');
+    var MslInternalException = require('msl-core/MslInternalException.js');
     
     var RESOURCE_COUNT = 3;
     var TIMEOUT = 150;

--- a/tests/src/test/javascript/util/SemaphoreTest.js
+++ b/tests/src/test/javascript/util/SemaphoreTest.js
@@ -1,0 +1,359 @@
+/**
+ * Copyright (c) 2018 Netflix, Inc.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Semaphore", function() {
+    var Semaphore = require('msl-core/util/Semaphore.js');
+    var Random = require('msl-core/util/Random.js');
+    
+    var RESOURCE_COUNT = 3;
+    var TIMEOUT = 150;
+    var WAIT = 200;
+    var DELAY = 1;
+    var NAME = "name";
+    
+    /**
+     * Create a new acquisition counter.
+     * 
+     * The number of acquisitions will be counted in the acquired property. The
+     * number of cancellations will be counted in the cancelled property.
+     * 
+     * The lastName property will be set when a specific resource is acquired
+     * or cancelled.
+     * 
+     * A new Semaphore.wait() callback with the specified name can be created
+     * by calling the getCallback() function.
+     */
+    function SemaphoreCounter() {
+        var self = this;
+        this.acquired = 0;
+        this.cancelled = 0;
+        this.lastName = undefined;
+        this.getCallback = function getCallback(name) {
+            return {
+                result: function(acquired) {
+                    self.lastName = name;
+                    if (acquired) ++self.acquired;
+                    else ++self.cancelled;
+                },
+                timeout: function() {
+                    expect(function() { throw new Error(name + " timedout"); }).not.toThrow();
+                },
+                error: function(e) {
+                    expect(function() { throw e; }).not.toThrow();
+                }
+            };
+        };
+    }
+    
+    var random = new Random();
+    var nameCount = 0;
+    var sem, counter;
+    
+    /** Return the next signal name. */
+    function nextName() {
+        return NAME + nameCount++;
+    }
+    
+    beforeEach(function() {
+        sem = new Semaphore(RESOURCE_COUNT);
+        counter = new SemaphoreCounter();
+        nameCount = 0;
+    });
+    
+    it("acquire immediately", function() {
+        runs(function() {
+            var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+            expect(t).toEqual(0);
+            expect(counter.acquired).toEqual(0);
+        });
+        waitsFor(function() { return counter.acquired == 1; }, "acquired", WAIT);
+    });
+    
+    it("acquire maximum", function() {
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i) {
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+                expect(t).toEqual(0);
+                expect(counter.acquired).toEqual(0);
+            }
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+    });
+    
+    it("wait one and signal", function() {
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i) {
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+                expect(t).toEqual(0);
+                expect(counter.acquired).toEqual(0);
+            }
+            var tw = sem.wait(TIMEOUT, counter.getCallback(NAME));
+            expect(tw).toBeTruthy();
+            expect(counter.acquired).toEqual(0);
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+        
+        runs(function() {
+            setTimeout(function() { sem.signal(); }, DELAY);
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT + 1; }, "signaled", WAIT);
+    });
+    
+    it("wait one and signal all", function() {
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i) {
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+                expect(t).toEqual(0);
+                expect(counter.acquired).toEqual(0);
+            }
+            var tw = sem.wait(TIMEOUT, counter.getCallback(NAME));
+            expect(tw).toBeTruthy();
+            expect(counter.acquired).toEqual(0);
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+        
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i)
+                setTimeout(function() { sem.signal(); }, DELAY);
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT + 1; }, "signaled", WAIT);
+    });
+    
+    it("signal prematurely", function() {
+        expect(function() {
+            sem.signal();
+        }).toThrow(new MslInternalException());
+    });
+    
+    it("signal excessively", function() {
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT + 1; ++i)
+                sem.wait(TIMEOUT, counter.getCallback(NAME));
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+        
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT + 1; ++i)
+                setTimeout(function() { sem.signal(); }, DELAY);
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT + 1; }, "signaled", WAIT);
+        
+        runs(function() {
+            expect(function() {
+                sem.signal();
+            }).toThrow(new MslInternalException());
+        });
+    });
+    
+    it("multiple wait and signal", function() {
+        var names = [];
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i) {
+                var name = nextName();
+                names.push(name);
+                var t = sem.wait(TIMEOUT, counter.getCallback(name));
+                expect(t).toEqual(0);
+            }
+            expect(counter.acquired).toEqual(0);
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+    
+        runs(function() {
+            var expectedName = names.pop();
+            expect(counter.lastName).toEqual(expectedName);
+            names = [];
+            
+            for (var i = 0; i < RESOURCE_COUNT; ++i) {
+                var name = nextName();
+                names.push(name);
+                var t = sem.wait(TIMEOUT, counter.getCallback(name));
+                expect(t).toBeTruthy();
+            }
+            expect(counter.acquired).toEqual(RESOURCE_COUNT);
+        });
+        waitsFor(function() { return names.length == RESOURCE_COUNT; }, "waiting", WAIT);
+        
+        runs(function() {
+            var expectedAcquisitions = RESOURCE_COUNT;
+            function next() {
+                if (names.length == 0)
+                    return;
+                
+                var expectedName = names.shift();
+                expect(counter.lastName).toEqual(expectedName);
+                expect(counter.acquired).toEqual(expectedAcquisitions);
+                sem.signal();
+                ++expectedAcquisitions;
+                setTimeout(next, 0);
+            }
+            sem.signal();
+            ++expectedAcquisitions;
+            setTimeout(next, 0);
+        });
+        waitsFor(function() { return names.length == 0; }, "signaling", WAIT);
+        
+        runs(function() {
+            expect(counter.acquired).toEqual(2 * RESOURCE_COUNT);
+        });
+    });
+    
+    it("wait forever", function() {
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i) {
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+                expect(t).toEqual(0);
+                expect(counter.acquired).toEqual(0);
+            }
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+        
+        var passed = false;
+        runs(function() {
+            var signaled = false;
+            sem.wait(-1, {
+                result: function(x) { signaled = x; },
+                timeout: function() { expect(function() { throw Error("timedout"); }).not.toThrow(); },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+            setTimeout(function() {
+                expect(signaled).toBeFalsy();
+                passed = true;
+            }, DELAY);
+        });
+        waitsFor(function() { return passed; }, "passed", WAIT);
+    });
+    
+    it("cancel zero", function() {
+        sem.cancel(0);
+
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT + 1; ++i)
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+        
+        runs(function() {
+            sem.cancel(0);
+            expect(counter.acquired).toEqual(RESOURCE_COUNT);
+            sem.signal();
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT + 1; }, "acquired", WAIT);
+    });
+    
+    it("cancel", function() {
+        var ticket;
+        runs(function() {
+            for (var i = 0; i < RESOURCE_COUNT; ++i)
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+            ticket = sem.wait(TIMEOUT, counter.getCallback(NAME));
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT && ticket !== undefined; }, "acquired", WAIT);
+        
+        runs(function() {
+            sem.cancel(ticket);
+            expect(counter.acquired).toEqual(RESOURCE_COUNT);
+            for (var i = 0; i < RESOURCE_COUNT; ++i)
+                sem.signal();
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT && counter.cancelled == 1; }, "cancelled", WAIT);
+    });
+    
+    it("cancel all", function() {
+        runs(function() {
+            for (var i = 0; i < 2 * RESOURCE_COUNT; ++i)
+                var t = sem.wait(TIMEOUT, counter.getCallback(NAME));
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT; }, "acquired", WAIT);
+        
+        runs(function() {
+            sem.cancelAll();
+        });
+        waitsFor(function() { return counter.acquired == RESOURCE_COUNT && counter.cancelled == RESOURCE_COUNT; }, "cancelled", WAIT);
+    });
+    
+    it("stress", function() {
+        var tickets = [];
+        var numWaiters = 0;
+        var expectedAcquired = 0;
+        var expectedCancelled = 0;
+        var MAX_WAITERS = 100;
+        
+        function addOperation() {
+            if (numWaiters == MAX_WAITERS) {
+                expectedCancelled += tickets.length;
+                tickets = [];
+                sem.cancelAll();
+                return;
+            }
+            
+            var r = random.nextInt(10);
+            switch (r) {
+                case 0:
+                {
+                    setTimeout(function() { addOperation(); }, 10 * DELAY);
+                    return;
+                }
+                case 1:
+                {
+                    var ticket1 = tickets.shift();
+                    if (ticket1)
+                        ++expectedAcquired;
+                    sem.signal();
+                    break;
+                }
+                case 2:
+                {
+                    var ticket2 = tickets.shift();
+                    if (ticket2) {
+                        ++expectedCancelled;
+                        sem.cancel(ticket2);
+                    }
+                    break;
+                }
+                case 3:
+                {
+                    expectedCancelled += tickets.length;
+                    tickets = [];
+                    sem.cancelAll();
+                    break;
+                }
+                default:
+                {
+                    var name = nextName();
+                    var ticketDefault = sem.wait(TIMEOUT, counter.getCallback(name));
+                    if (ticketDefault != 0) {
+                        tickets.push(ticketDefault);
+                        ++numWaiters;
+                    } else {
+                        ++expectedAcquired;
+                    }
+                    break;
+                }
+            }
+            addOperation();
+        }
+        
+        runs(function() {
+            addOperation();
+        });
+        waitsFor(function() { return numWaiters == MAX_WAITERS; }, "complete", 5 * WAIT);
+        
+        runs(function() {
+            expect(counter.acquired).toEqual(expectedAcquired);
+            expect(counter.cancelled).toEqual(expectedCancelled);
+        });
+    });
+});

--- a/tests/src/test/javascript/util/SemaphoreTest.js
+++ b/tests/src/test/javascript/util/SemaphoreTest.js
@@ -310,9 +310,10 @@ describe("Semaphore", function() {
                 case 1:
                 {
                     var ticket1 = tickets.shift();
-                    if (ticket1)
+                    if (ticket1) {
                         ++expectedAcquired;
-                    sem.signal();
+                        sem.signal();
+                    }
                     break;
                 }
                 case 2:


### PR DESCRIPTION
Possibly fixes #208: Do not release the master token (an extra time) in RequestService.execute() after the recursive call is made, but make sure to release it in all other cases.

Also make sure to release the master token if an exception is thrown while retrieving the user ID token in buildRequest(), buildResponse().