### PR TITLE
Add JMH benchmark LZW algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Release Library/
 *.ipr
 *.iws
 .idea/
+out/
+classes/

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,10 @@
+plugins {
+    id "me.champeau.gradle.jmh" version "0.4.6"
+}
+
 apply plugin: 'java'
 apply plugin: 'eclipse-wtp'
+apply plugin: 'me.champeau.gradle.jmh'
 
 targetCompatibility = '1.7' // Android maximum supported language level
 sourceCompatibility = '1.7' // Android maximum supported language level
@@ -83,4 +88,14 @@ task javadoc_public(type: Javadoc) {
         "**/UserAuthenticationScheme.java",
         "**/UserIdToken.java"
     ]
+}
+
+jmh {
+    warmupIterations = 1
+    iterations = 1
+    profilers = ["gc"]
+}
+
+dependencies {
+    jmh "commons-io:commons-io:2.5"
 }

--- a/core/src/jmh/java/com/netflix/msl/crypto/LzwCompressionBenchmark.java
+++ b/core/src/jmh/java/com/netflix/msl/crypto/LzwCompressionBenchmark.java
@@ -1,0 +1,53 @@
+package com.netflix.msl.crypto;
+
+import com.netflix.msl.MslConstants;
+import com.netflix.msl.MslException;
+import com.netflix.msl.util.MslCompression;
+import org.apache.commons.io.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@State(Scope.Thread)
+public class LzwCompressionBenchmark {
+    private byte[] license;
+    private byte[] licenseCompressed;
+
+    @Setup
+    public void prepare() throws IOException, MslException {
+        InputStream inputStream = getClass().getResourceAsStream("/LICENSE.txt");
+        license  = IOUtils.toByteArray(inputStream);
+        licenseCompressed = MslCompression.compress(MslConstants.CompressionAlgorithm.LZW, license);
+    }
+
+    @Benchmark
+    public byte[] measureCompressThroughput() throws MslException {
+        return MslCompression.compress(MslConstants.CompressionAlgorithm.LZW, license);
+    }
+
+    @Benchmark
+    public byte[] measureUncompressThroughput() throws MslException {
+        return MslCompression.uncompress(MslConstants.CompressionAlgorithm.LZW, licenseCompressed);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + LzwCompressionBenchmark.class.getSimpleName() + ".*")
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .forks(4)
+                .addProfiler( GCProfiler.class )
+                .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
This can be used as a base to know if changes to LZW are improved performance-wise, as well as GC wise. We could keep it as a branch used just during testing of alternative LZW implementations, but I think it would be helpful to have around in general. We could add encoding benchmarks for when we go to a binary format, for example.

Baseline: 
```
Benchmark                                                                              Mode  Cnt       Score       Error   Units
LzwCompressionBenchmark.measureCompressThroughput                                     thrpt    5    3417.926 ±   190.332   ops/s
LzwCompressionBenchmark.measureCompressThroughput:·gc.alloc.rate                      thrpt    5     748.716 ±    41.979  MB/sec
LzwCompressionBenchmark.measureCompressThroughput:·gc.alloc.rate.norm                 thrpt    5  241248.014 ±     0.002    B/op
LzwCompressionBenchmark.measureCompressThroughput:·gc.churn.PS_Eden_Space             thrpt    5     700.957 ±     4.011  MB/sec
LzwCompressionBenchmark.measureCompressThroughput:·gc.churn.PS_Eden_Space.norm        thrpt    5  225900.269 ± 13551.567    B/op
LzwCompressionBenchmark.measureCompressThroughput:·gc.churn.PS_Survivor_Space         thrpt    5      12.404 ±     0.840  MB/sec
LzwCompressionBenchmark.measureCompressThroughput:·gc.churn.PS_Survivor_Space.norm    thrpt    5    3996.654 ±   177.041    B/op
LzwCompressionBenchmark.measureCompressThroughput:·gc.count                           thrpt    5      30.000              counts
LzwCompressionBenchmark.measureCompressThroughput:·gc.time                            thrpt    5   32204.000                  ms
LzwCompressionBenchmark.measureUncompressThroughput                                   thrpt    5    5167.581 ±   515.675   ops/s
LzwCompressionBenchmark.measureUncompressThroughput:·gc.alloc.rate                    thrpt    5     684.608 ±    68.677  MB/sec
LzwCompressionBenchmark.measureUncompressThroughput:·gc.alloc.rate.norm               thrpt    5  145896.011 ±     0.001    B/op
LzwCompressionBenchmark.measureUncompressThroughput:·gc.churn.PS_Eden_Space           thrpt    5     662.171 ±     8.921  MB/sec
LzwCompressionBenchmark.measureUncompressThroughput:·gc.churn.PS_Eden_Space.norm      thrpt    5  141188.005 ± 13687.078    B/op
LzwCompressionBenchmark.measureUncompressThroughput:·gc.churn.PS_Survivor_Space       thrpt    5      22.185 ±     0.512  MB/sec
LzwCompressionBenchmark.measureUncompressThroughput:·gc.churn.PS_Survivor_Space.norm  thrpt    5    4730.867 ±   556.624    B/op
LzwCompressionBenchmark.measureUncompressThroughput:·gc.count                         thrpt    5      35.000              counts
LzwCompressionBenchmark.measureUncompressThroughput:·gc.time                          thrpt    5   29217.000                  ms
```