### PR TITLE
Add new error to distinguish the reason for expired message.

### DIFF
--- a/core/src/main/java/com/netflix/msl/MslError.java
+++ b/core/src/main/java/com/netflix/msl/MslError.java
@@ -240,6 +240,8 @@ public class MslError {
     public static final MslError UNEXPECTED_LOCAL_MESSAGE_SENDER = new MslError(6041, ResponseCode.FAIL, "Message sender is equal to the local entity.");
     public static final MslError UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA = new MslError(6042, ResponseCode.FAIL, "User authentication data included in unencrypted message header.");
     public static final MslError MESSAGE_SENDER_MISMATCH = new MslError(6043, ResponseCode.FAIL, "Message sender entity identity does not match expected identity.");
+    public static final MslError MESSAGE_EXPIRED_NOT_RENEWABLE = new MslError(6044, ResponseCode.EXPIRED, "Message expired and not renewable. Rejected.");
+    public static final MslError MESSAGE_EXPIRED_NO_KEYREQUEST_DATA = new MslError(6045, ResponseCode.EXPIRED, "Message expired and missing key request data. Rejected.");
 
     // 7 Key Exchange
     public static final MslError UNIDENTIFIED_KEYX_SCHEME = new MslError(7000, ResponseCode.FAIL, "Unable to identify key exchange scheme.");

--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -277,8 +277,13 @@ public class MessageInputStream extends InputStream {
                 if (masterToken.isExpired(null)) {
                     // If the message is not renewable or does not contain key
                     // request data then reject the message.
-                    if (!messageHeader.isRenewable() || messageHeader.getKeyRequestData().isEmpty())
-                        throw new MslMessageException(MslError.MESSAGE_EXPIRED, messageHeader.toString());
+                    if (!messageHeader.isRenewable()) {
+                        throw new MslMessageException(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE, messageHeader.toString());
+                    }
+                    else if (messageHeader.getKeyRequestData().isEmpty()) {
+                        throw new MslMessageException(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA, messageHeader.toString());
+                    }
+
 
                     // If the master token will not be renewed by the token
                     // factory then reject the message.

--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -277,13 +277,10 @@ public class MessageInputStream extends InputStream {
                 if (masterToken.isExpired(null)) {
                     // If the message is not renewable or does not contain key
                     // request data then reject the message.
-                    if (!messageHeader.isRenewable()) {
+                    if (!messageHeader.isRenewable())
                         throw new MslMessageException(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE, messageHeader.toString());
-                    }
-                    else if (messageHeader.getKeyRequestData().isEmpty()) {
+                    else if (messageHeader.getKeyRequestData().isEmpty())
                         throw new MslMessageException(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA, messageHeader.toString());
-                    }
-
 
                     // If the master token will not be renewed by the token
                     // factory then reject the message.

--- a/core/src/main/javascript/MslError.js
+++ b/core/src/main/javascript/MslError.js
@@ -269,6 +269,8 @@
 	    UNEXPECTED_LOCAL_MESSAGE_SENDER : new MslError(6041, MslConstants.ResponseCode.FAIL, "Message sender is equal to the local entity."),
 	    UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA : new MslError(6042, MslConstants.ResponseCode.FAIL, "User authentication data included in unencrypted message header."),
 	    MESSAGE_SENDER_MISMATCH : new MslError(6043, MslConstants.ResponseCode.FAIL, "Message sender entity identity does not match expected identity."),
+        MESSAGE_EXPIRED_NOT_RENEWABLE : new MslError(6044, MslConstants.ResponseCode.EXPIRED, "Message expired and not renewable. Rejected."),
+        MESSAGE_EXPIRED_NO_KEYREQUEST_DATA : new MslError(6045, MslConstants.ResponseCode.EXPIRED, "Message expired and missing key request data. Rejected."),
 
 	    // 7 Key Exchange
 	    UNIDENTIFIED_KEYX_SCHEME : new MslError(7000, MslConstants.ResponseCode.FAIL, "Unable to identify key exchange scheme."),

--- a/core/src/main/javascript/MslError.js
+++ b/core/src/main/javascript/MslError.js
@@ -269,8 +269,8 @@
 	    UNEXPECTED_LOCAL_MESSAGE_SENDER : new MslError(6041, MslConstants.ResponseCode.FAIL, "Message sender is equal to the local entity."),
 	    UNENCRYPTED_MESSAGE_WITH_USERAUTHDATA : new MslError(6042, MslConstants.ResponseCode.FAIL, "User authentication data included in unencrypted message header."),
 	    MESSAGE_SENDER_MISMATCH : new MslError(6043, MslConstants.ResponseCode.FAIL, "Message sender entity identity does not match expected identity."),
-        MESSAGE_EXPIRED_NOT_RENEWABLE : new MslError(6044, MslConstants.ResponseCode.EXPIRED, "Message expired and not renewable. Rejected."),
-        MESSAGE_EXPIRED_NO_KEYREQUEST_DATA : new MslError(6045, MslConstants.ResponseCode.EXPIRED, "Message expired and missing key request data. Rejected."),
+	    MESSAGE_EXPIRED_NOT_RENEWABLE : new MslError(6044, MslConstants.ResponseCode.EXPIRED, "Message expired and not renewable. Rejected."),
+	    MESSAGE_EXPIRED_NO_KEYREQUEST_DATA : new MslError(6045, MslConstants.ResponseCode.EXPIRED, "Message expired and missing key request data. Rejected."),
 
 	    // 7 Key Exchange
 	    UNIDENTIFIED_KEYX_SCHEME : new MslError(7000, MslConstants.ResponseCode.FAIL, "Unable to identify key exchange scheme."),

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -533,8 +533,17 @@
                     if (masterToken.isExpired(null)) {
                         // If the message is not renewable or does not contain key
                         // request data then reject the message.
-                        if (!messageHeader.isRenewable() || messageHeader.keyRequestData.length == 0) {
-                            self._errored = new MslMessageException(MslError.MESSAGE_EXPIRED, messageHeader)
+                        if (!messageHeader.isRenewable()) {
+                            self._errored = new MslMessageException(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE, messageHeader)
+                            .setMasterToken(masterToken)
+                            .setUserIdToken(messageHeader.userIdToken)
+                            .setUserAuthenticationData(messageHeader.userAuthenticationData)
+                            .setMessageId(messageHeader.messageId);
+                            ready();
+                            return;
+                        }
+                        else if (messageHeader.keyRequestData.length == 0) {
+                            self._errored = new MslMessageException(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA, messageHeader)
                             .setMasterToken(masterToken)
                             .setUserIdToken(messageHeader.userIdToken)
                             .setUserAuthenticationData(messageHeader.userAuthenticationData)

--- a/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageInputStreamTest.java
@@ -638,7 +638,7 @@ public class MessageInputStreamTest {
     @Test
     public void expiredNotRenewableClientMessage() throws IOException, MslUserAuthException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
-        thrown.expectMslError(MslError.MESSAGE_EXPIRED);
+        thrown.expectMslError(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE);
         thrown.expectMessageId(MSG_ID);
 
         // Expired messages received by a trusted network server should be
@@ -658,7 +658,7 @@ public class MessageInputStreamTest {
     @Test
     public void expiredNoKeyRequestDataClientMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
-        thrown.expectMslError(MslError.MESSAGE_EXPIRED);
+        thrown.expectMslError(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA);
         thrown.expectMessageId(MSG_ID);
 
         // Expired renewable messages received by a trusted network server
@@ -709,7 +709,7 @@ public class MessageInputStreamTest {
     @Test
     public void expiredNoKeyRequestDataPeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
-        thrown.expectMslError(MslError.MESSAGE_EXPIRED);
+        thrown.expectMslError(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA);
         thrown.expectMessageId(MSG_ID);
 
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);
@@ -727,7 +727,7 @@ public class MessageInputStreamTest {
     @Test
     public void expiredNotRenewablePeerMessage() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslUserAuthException, MslKeyExchangeException, IOException, MslException, MslEncoderException {
         thrown.expect(MslMessageException.class);
-        thrown.expectMslError(MslError.MESSAGE_EXPIRED);
+        thrown.expectMslError(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE);
         thrown.expectMessageId(MSG_ID);
 
         final Date renewalWindow = new Date(System.currentTimeMillis() - 20000);

--- a/tests/src/test/javascript/msg/MessageInputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageInputStreamTest.js
@@ -1827,7 +1827,7 @@ describe("MessageInputStream", function() {
 
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED), MSG_ID);
+            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE), MSG_ID);
         });
     });
 
@@ -1887,7 +1887,7 @@ describe("MessageInputStream", function() {
 
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED), MSG_ID);
+            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA), MSG_ID);
         });
     });
 
@@ -2031,7 +2031,7 @@ describe("MessageInputStream", function() {
 
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED), MSG_ID);
+            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED_NO_KEYREQUEST_DATA), MSG_ID);
         });
     });
 
@@ -2089,7 +2089,7 @@ describe("MessageInputStream", function() {
 
         runs(function() {
             var f = function() { throw exception; };
-            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED), MSG_ID);
+            expect(f).toThrow(new MslMessageException(MslError.MESSAGE_EXPIRED_NOT_RENEWABLE), MSG_ID);
         });
     });
 


### PR DESCRIPTION
Add two internal codes MESSAGE_EXPIRED_NOT_RENEWABLE and MESSAGE_EXPIRED_NO_KEYREQUEST_DATA to indicate more specific reason for expired message failure.  This fixes issue #289.