### PR TITLE
Properly encode MslEncodable in MslEncoderUtils.createArray()

### DIFF
--- a/core/src/main/java/com/netflix/msl/io/MslEncoderUtils.java
+++ b/core/src/main/java/com/netflix/msl/io/MslEncoderUtils.java
@@ -110,12 +110,14 @@ public class MslEncoderUtils {
      * <code>String</code>, <code>null</code>, or turn any
      * <code>MslEncodable</code> into a <code>MslObject</code>.
      * 
+     * @param ctx MSL context.
+     * @param format MSL encoder format.
      * @param c a collection of MSL encoding-compatible objects.
      * @return the constructed MSL array.
      * @throws MslEncoderException if a <code>MslEncodable</code> cannot be
      *         encoded properly or an unsupported object is encountered.
      */
-    public static MslArray createArray(final MslContext ctx, final Collection<?> c) throws MslEncoderException {
+    public static MslArray createArray(final MslContext ctx, final MslEncoderFormat format, final Collection<?> c) throws MslEncoderException {
         final MslEncoderFactory encoder = ctx.getMslEncoderFactory();
         final MslArray array = encoder.createArray();
         for (final Object o : c) {
@@ -134,7 +136,7 @@ public class MslEncoderUtils {
                 array.put(-1, o);
             } else if (o instanceof MslEncodable) {
                 final MslEncodable me = (MslEncodable)o;
-                final byte[] encode = me.toMslEncoding(encoder, encoder.getPreferredFormat(null));
+                final byte[] encode = me.toMslEncoding(encoder, format);
                 final MslObject mo = encoder.parseObject(encode);
                 array.put(-1, mo);
             } else {

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -356,6 +356,8 @@ public class MessageHeader extends Header {
         // Construct the header data.
         try {
             final MslEncoderFactory encoder = ctx.getMslEncoderFactory();
+            final Set<MslEncoderFormat> formats = (capabilities != null) ? capabilities.getEncoderFormats() : null;
+            final MslEncoderFormat format = encoder.getPreferredFormat(formats);
             headerdata = encoder.createObject();
             if (sender != null) headerdata.put(KEY_SENDER, sender);
             headerdata.put(KEY_TIMESTAMP, this.timestamp);
@@ -365,14 +367,14 @@ public class MessageHeader extends Header {
             headerdata.put(KEY_RENEWABLE, this.renewable);
             headerdata.put(KEY_HANDSHAKE, this.handshake);
             if (this.capabilities != null) headerdata.put(KEY_CAPABILITIES, this.capabilities);
-            if (this.keyRequestData.size() > 0) headerdata.put(KEY_KEY_REQUEST_DATA, MslEncoderUtils.createArray(ctx, this.keyRequestData));
+            if (this.keyRequestData.size() > 0) headerdata.put(KEY_KEY_REQUEST_DATA, MslEncoderUtils.createArray(ctx, format, this.keyRequestData));
             if (this.keyResponseData != null) headerdata.put(KEY_KEY_RESPONSE_DATA, this.keyResponseData);
             if (this.userAuthData != null) headerdata.put(KEY_USER_AUTHENTICATION_DATA, this.userAuthData);
             if (this.userIdToken != null) headerdata.put(KEY_USER_ID_TOKEN, this.userIdToken);
-            if (this.serviceTokens.size() > 0) headerdata.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(ctx, this.serviceTokens));
+            if (this.serviceTokens.size() > 0) headerdata.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(ctx, format, this.serviceTokens));
             if (this.peerMasterToken != null) headerdata.put(KEY_PEER_MASTER_TOKEN, this.peerMasterToken);
             if (this.peerUserIdToken != null) headerdata.put(KEY_PEER_USER_ID_TOKEN, this.peerUserIdToken);
-            if (this.peerServiceTokens.size() > 0) headerdata.put(KEY_PEER_SERVICE_TOKENS, MslEncoderUtils.createArray(ctx, this.peerServiceTokens));
+            if (this.peerServiceTokens.size() > 0) headerdata.put(KEY_PEER_SERVICE_TOKENS, MslEncoderUtils.createArray(ctx, format, this.peerServiceTokens));
         } catch (final MslEncoderException e) {
             throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
                 .setMasterToken(this.masterToken)

--- a/core/src/main/javascript/io/MslEncoderUtils.js
+++ b/core/src/main/javascript/io/MslEncoderUtils.js
@@ -30,6 +30,8 @@
      * <code>String</code>, <code>null</code>, or turn any
      * <code>MslEncodable</code> into a <code>MslObject</code>.
      * 
+     * @param {MslContext} ctx MSL context.
+     * @param {MslEncoderFormat} format MSL encoder format.
      * @param {Array<*>} c a collection of MSL encoding-compatible objects.
      * @param {{result: function(MslArray), error: function(Error)}} callback
      *        the callback that will receive the constructed MSL array or any
@@ -37,7 +39,7 @@
      * @throws MslEncoderException if a <code>MslEncodable</code> cannot be
      *         encoded properly or an unsupported object is encountered.
      */
-    var MslEncoderUtils$createArray = function MslEncoderUtils$createArray(ctx, c, callback) {
+    var MslEncoderUtils$createArray = function MslEncoderUtils$createArray(ctx, format, c, callback) {
     	function add(encoder, array, i, callback) {
 	    	AsyncExecutor(callback, function() {
 	    		if (i >= c.length) return array;
@@ -59,7 +61,7 @@
 	    			add(encoder, array, i+1, callback);
 	    		} else if (o instanceof MslEncodable) {
 	    			var me = o;
-	    			me.toMslEncoding(encoder, encoder.getPreferredFormat(null), {
+	    			me.toMslEncoding(encoder, format, {
 	    				result: function(encode) {
 	    					AsyncExecutor(callback, function() {
 	    						var mo = encoder.parseObject(encode);

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -522,7 +522,7 @@
             AsyncExecutor(callback, function() {
                 if (creationData) {
                     // Ignore the sender.
-                    construct(null);
+                    prepare(null);
                 } else {
                     // Older MSL stacks expect the sender if a master token is being used.
                     //
@@ -536,18 +536,18 @@
                                 AsyncExecutor(callback, function() {
                                     var localIdentity = ead.getIdentity();
                                     var sender = (localIdentity) ? localIdentity : "";
-                                    construct(sender);
+                                    prepare(sender);
                                 }, self);
                             },
                             error: callback.error,
                         });
                     } else {
-                        construct(null);
+                        prepare(null);
                     }
                 }
             }, self);
 
-            function construct(sender) {
+            function prepare(sender) {
                 AsyncExecutor(callback, function() {
                     // Message ID must be within range.
                     if (headerData.messageId < 0 || headerData.messageId > MslConstants.MAX_LONG_VALUE)
@@ -629,79 +629,141 @@
                         if (peerServiceToken.isUserIdTokenBound() && (!peerUserIdToken || !peerServiceToken.isBoundTo(peerUserIdToken)))
                             throw new MslInternalException("User ID token bound peer service tokens must be bound to the provided peer user ID token.");
                     }, this);
-    
-                    // Create the header data.
-                    var user, timestampSeconds, headerdata, messageCryptoContext;
-                    if (!creationData) {
-                        // Grab the user.
-                        user = (userIdToken) ? userIdToken.user : null;
-                        
-                        // Set the creation timestamp.
-                        timestampSeconds = parseInt(ctx.getTime() / MILLISECONDS_PER_SECOND);
-    
-                        // Construct the header data.
-                        try {
-                            var encoder = ctx.getMslEncoderFactory();
-                            headerdata = encoder.createObject();
-                            if (typeof sender === 'string') headerdata.put(KEY_SENDER, sender);
-                            headerdata.put(KEY_TIMESTAMP, timestampSeconds);
-                            headerdata.put(KEY_MESSAGE_ID, messageId);
-                            headerdata.put(KEY_NON_REPLAYABLE, (typeof nonReplayableId === 'number'));
-                            if (typeof nonReplayableId === 'number') headerdata.put(KEY_NON_REPLAYABLE_ID, nonReplayableId);
-                            headerdata.put(KEY_RENEWABLE, renewable);
-                            headerdata.put(KEY_HANDSHAKE, handshake);
-                            if (capabilities) headerdata.put(KEY_CAPABILITIES, capabilities);
-                            if (keyRequestData.length > 0) headerdata.put(KEY_KEY_REQUEST_DATA, keyRequestData);
-                            if (keyResponseData) headerdata.put(KEY_KEY_RESPONSE_DATA, keyResponseData);
-                            if (userAuthData) headerdata.put(KEY_USER_AUTHENTICATION_DATA, userAuthData);
-                            if (userIdToken) headerdata.put(KEY_USER_ID_TOKEN, userIdToken);
-                            if (serviceTokens.length > 0) headerdata.put(KEY_SERVICE_TOKENS, serviceTokens);
-                            if (peerMasterToken) headerdata.put(KEY_PEER_MASTER_TOKEN, peerMasterToken);
-                            if (peerUserIdToken) headerdata.put(KEY_PEER_USER_ID_TOKEN, peerUserIdToken);
-                            if (peerServiceTokens.length > 0) headerdata.put(KEY_PEER_SERVICE_TOKENS, peerServiceTokens);
-                        } catch (e) {
-                            if (e instanceof MslEncoderException) {
-                                throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
-                                    .setMasterToken(masterToken)
-                                    .setEntityAuthenticationData(entityAuthData)
-                                    .setUserIdToken(peerUserIdToken)
-                                    .setUserAuthenticationData(userAuthData)
-                                    .setMessageId(messageId);
-                            }
-                            throw e;
+
+                    var encoder = ctx.getMslEncoderFactory();
+                    var formats = (capabilities) ? capabilities.encoderFormats : null;
+                    var format = encoder.getPreferredFormat(formats);
+                    MslEncoderUtils.createArray(ctx, format, keyRequestData, {
+                        result: function(maKeyRequestData) {
+                            MslEncoderUtils.createArray(ctx, format, serviceTokens, {
+                                result: function(maServiceTokens) {
+                                    MslEncoderUtils.createArray(ctx, format, peerServiceTokens, {
+                                        result: function(maPeerServiceTokens) {
+                                            construct(maKeyRequestData, maServiceTokens, maPeerServiceTokens);
+                                        },
+                                        error: function(e) {
+                                            AsyncExecutor(callback, function() {
+                                                if (e instanceof MslEncoderException) {
+                                                    throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
+                                                        .setMasterToken(masterToken)
+                                                        .setEntityAuthenticationData(entityAuthData)
+                                                        .setUserIdToken(peerUserIdToken)
+                                                        .setUserAuthenticationData(userAuthData)
+                                                        .setMessageId(messageId);
+                                                }
+                                                throw e;
+                                            }, self);
+                                        }
+                                    });
+                                },
+                                error: function(e) {
+                                    AsyncExecutor(callback, function() {
+                                        if (e instanceof MslEncoderException) {
+                                            throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
+                                                .setMasterToken(masterToken)
+                                                .setEntityAuthenticationData(entityAuthData)
+                                                .setUserIdToken(peerUserIdToken)
+                                                .setUserAuthenticationData(userAuthData)
+                                                .setMessageId(messageId);
+                                        }
+                                        throw e;
+                                    }, self);
+                                }
+                            });
+                        },
+                        error: function(e) {
+                            AsyncExecutor(callback, function() {
+                                if (e instanceof MslEncoderException) {
+                                    throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
+                                        .setMasterToken(masterToken)
+                                        .setEntityAuthenticationData(entityAuthData)
+                                        .setUserIdToken(peerUserIdToken)
+                                        .setUserAuthenticationData(userAuthData)
+                                        .setMessageId(messageId);
+                                }
+                                throw e;
+                            }, self);
                         }
-    
-                        // Get the correct crypto context.
-                        try {
-                            messageCryptoContext = getMessageCryptoContext(ctx, entityAuthData, masterToken);
-                        } catch (e) {
-                            if (e instanceof MslException) {
-                                e.setMasterToken(masterToken);
-                                e.setEntityAuthenticationData(entityAuthData);
-                                e.setUserIdToken(userIdToken);
-                                e.setUserAuthenticationData(userAuthData);
-                                e.setMessageId(messageId);
+                    });
+                
+                    function construct(maKeyRequestData, maServiceTokens, maPeerServiceTokens) {
+                        AsyncExecutor(callback, function() {
+                            // Create the header data.
+                            var user, timestampSeconds, headerdata, messageCryptoContext;
+                            if (!creationData) {
+                                // Grab the user.
+                                user = (userIdToken) ? userIdToken.user : null;
+                                
+                                // Set the creation timestamp.
+                                timestampSeconds = parseInt(ctx.getTime() / MILLISECONDS_PER_SECOND);
+            
+                                // Construct the header data.
+                                try {
+                                    headerdata = encoder.createObject();
+                                    if (typeof sender === 'string') headerdata.put(KEY_SENDER, sender);
+                                    headerdata.put(KEY_TIMESTAMP, timestampSeconds);
+                                    headerdata.put(KEY_MESSAGE_ID, messageId);
+                                    headerdata.put(KEY_NON_REPLAYABLE, (typeof nonReplayableId === 'number'));
+                                    if (typeof nonReplayableId === 'number') headerdata.put(KEY_NON_REPLAYABLE_ID, nonReplayableId);
+                                    headerdata.put(KEY_RENEWABLE, renewable);
+                                    headerdata.put(KEY_HANDSHAKE, handshake);
+                                    if (capabilities) headerdata.put(KEY_CAPABILITIES, capabilities);
+                                    // FIXME
+                                    if (keyRequestData.length > 0) headerdata.put(KEY_KEY_REQUEST_DATA, maKeyRequestData);
+                                    if (keyResponseData) headerdata.put(KEY_KEY_RESPONSE_DATA, keyResponseData);
+                                    if (userAuthData) headerdata.put(KEY_USER_AUTHENTICATION_DATA, userAuthData);
+                                    if (userIdToken) headerdata.put(KEY_USER_ID_TOKEN, userIdToken);
+                                    // FIXME
+                                    if (serviceTokens.length > 0) headerdata.put(KEY_SERVICE_TOKENS, maServiceTokens);
+                                    if (peerMasterToken) headerdata.put(KEY_PEER_MASTER_TOKEN, peerMasterToken);
+                                    if (peerUserIdToken) headerdata.put(KEY_PEER_USER_ID_TOKEN, peerUserIdToken);
+                                    // FIXME
+                                    if (peerServiceTokens.length > 0) headerdata.put(KEY_PEER_SERVICE_TOKENS, maPeerServiceTokens);
+                                } catch (e) {
+                                    if (e instanceof MslEncoderException) {
+                                        throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
+                                            .setMasterToken(masterToken)
+                                            .setEntityAuthenticationData(entityAuthData)
+                                            .setUserIdToken(peerUserIdToken)
+                                            .setUserAuthenticationData(userAuthData)
+                                            .setMessageId(messageId);
+                                    }
+                                    throw e;
+                                }
+            
+                                // Get the correct crypto context.
+                                try {
+                                    messageCryptoContext = getMessageCryptoContext(ctx, entityAuthData, masterToken);
+                                } catch (e) {
+                                    if (e instanceof MslException) {
+                                        e.setMasterToken(masterToken);
+                                        e.setEntityAuthenticationData(entityAuthData);
+                                        e.setUserIdToken(userIdToken);
+                                        e.setUserAuthenticationData(userAuthData);
+                                        e.setMessageId(messageId);
+                                    }
+                                    throw e;
+                                }
+                            } else {
+                                user = creationData.user;
+                                timestampSeconds = creationData.timestampSeconds;
+                                headerdata = creationData.headerdata;
+                                messageCryptoContext = creationData.messageCryptoContext;
                             }
-                            throw e;
-                        }
-                    } else {
-                        user = creationData.user;
-                        timestampSeconds = creationData.timestampSeconds;
-                        headerdata = creationData.headerdata;
-                        messageCryptoContext = creationData.messageCryptoContext;
+                            
+                            // The properties.
+                            var props = buildProperties(ctx, entityAuthData, masterToken, headerdata,
+                                timestampSeconds, messageId, nonReplayableId,
+                                renewable, handshake,
+                                capabilities, keyRequestData, keyResponseData,
+                                userAuthData, userIdToken,
+                                serviceTokens,
+                                peerMasterToken, peerUserIdToken, peerServiceTokens,
+                                user, messageCryptoContext);
+                            Object.defineProperties(this, props);
+                            return this;
+                        }, self);
                     }
-                    
-                    // The properties.
-                    var props = buildProperties(ctx, entityAuthData, masterToken, headerdata,
-                        timestampSeconds, messageId, nonReplayableId,
-                        renewable, handshake,
-                        capabilities, keyRequestData, keyResponseData,
-                        userAuthData, userIdToken,
-                        serviceTokens,
-                        peerMasterToken, peerUserIdToken, peerServiceTokens,
-                        user, messageCryptoContext);
-                    Object.defineProperties(this, props);
-                    return this;
                 }, self);
             }
         },

--- a/examples/burp/src/main/java/burp/MSLHttpListener.java
+++ b/examples/burp/src/main/java/burp/MSLHttpListener.java
@@ -33,6 +33,7 @@ import com.netflix.msl.entityauth.EntityAuthenticationFactory;
 import com.netflix.msl.entityauth.EntityAuthenticationScheme;
 import com.netflix.msl.io.MslEncoderException;
 import com.netflix.msl.io.MslEncoderFactory;
+import com.netflix.msl.io.MslEncoderFormat;
 import com.netflix.msl.io.MslEncoderUtils;
 import com.netflix.msl.io.MslObject;
 import com.netflix.msl.msg.ErrorHeader;
@@ -210,6 +211,7 @@ public class MSLHttpListener implements IHttpListener {
 
     protected String processMslMessage(final String body) throws WiretapException {
         final MslEncoderFactory encoder = ctx.getMslEncoderFactory();
+        final MslEncoderFormat format = encoder.getPreferredFormat(null);
         final StringBuilder retData = new StringBuilder("");
 
         WiretapMessageInputStream mis;
@@ -298,7 +300,7 @@ public class MSLHttpListener implements IHttpListener {
                 headerdataMo.put(KEY_HANDSHAKE, messageHeader.isHandshake());
                 headerdataMo.put(KEY_CAPABILITIES, messageHeader.getMessageCapabilities());
                 if(!messageHeader.getKeyRequestData().isEmpty())
-                    headerdataMo.put(KEY_KEY_REQUEST_DATA, MslEncoderUtils.createArray(ctx, messageHeader.getKeyRequestData()));
+                    headerdataMo.put(KEY_KEY_REQUEST_DATA, MslEncoderUtils.createArray(ctx, format, messageHeader.getKeyRequestData()));
                 if(messageHeader.getKeyResponseData() != null) {
                     final MslObject keyResponseDataMo = MslTestUtils.toMslObject(encoder, messageHeader.getKeyResponseData());
                     if(messageHeader.getKeyResponseData().getMasterToken() != null) {
@@ -315,7 +317,7 @@ public class MSLHttpListener implements IHttpListener {
                     headerdataMo.put(KEY_USER_ID_TOKEN, parseUserIdToken(messageHeader.getUserIdToken(), masterToken));
                 }
                 if(!messageHeader.getServiceTokens().isEmpty())
-                    headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(ctx, messageHeader.getServiceTokens()));
+                    headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(ctx, format, messageHeader.getServiceTokens()));
 
                 // Add headerdata in clear
                 msgHeaderMo.put(KEY_HEADERDATA, headerdataMo);

--- a/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
@@ -438,7 +438,7 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
@@ -446,7 +446,7 @@ public class MessageHeaderTest {
         assertFalse(headerdata.has(KEY_PEER_SERVICE_TOKENS));
         assertFalse(headerdata.has(KEY_PEER_USER_ID_TOKEN));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -482,7 +482,7 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
@@ -490,7 +490,7 @@ public class MessageHeaderTest {
         assertFalse(headerdata.has(KEY_PEER_SERVICE_TOKENS));
         assertFalse(headerdata.has(KEY_PEER_USER_ID_TOKEN));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -599,15 +599,15 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_MASTER_TOKEN), headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_USER_ID_TOKEN), headerdata.getMslObject(KEY_PEER_USER_ID_TOKEN, encoder)));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertFalse(headerdata.has(KEY_USER_ID_TOKEN));
     }
@@ -644,15 +644,15 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_MASTER_TOKEN), headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_USER_ID_TOKEN), headerdata.getMslObject(KEY_PEER_USER_ID_TOKEN, encoder)));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertFalse(headerdata.has(KEY_USER_ID_TOKEN));
     }
@@ -720,7 +720,7 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
@@ -728,7 +728,7 @@ public class MessageHeaderTest {
         assertFalse(headerdata.has(KEY_PEER_SERVICE_TOKENS));
         assertFalse(headerdata.has(KEY_PEER_USER_ID_TOKEN));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -804,15 +804,15 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_MASTER_TOKEN), headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_USER_ID_TOKEN), headerdata.getMslObject(KEY_PEER_USER_ID_TOKEN, encoder)));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -2113,7 +2113,7 @@ public class MessageHeaderTest {
         // After modifying the header data we need to encrypt it.
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
         serviceTokens.addAll(MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, null));
-        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, serviceTokens));
+        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens));
         final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
@@ -2147,7 +2147,7 @@ public class MessageHeaderTest {
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
         serviceTokens.addAll(MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, userIdToken));
-        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, serviceTokens));
+        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens));
         final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         

--- a/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageHeaderTest.java
@@ -90,9 +90,6 @@ import com.netflix.msl.util.MslTestUtils;
  * @author Wesley Miaw <wmiaw@netflix.com>
  */
 public class MessageHeaderTest {
-	/** MSL encoder format. */
-	private static final MslEncoderFormat ENCODER_FORMAT = MslEncoderFormat.JSON;
-
     /** Milliseconds per second. */
     private static final long MILLISECONDS_PER_SECOND = 1000;
     
@@ -187,6 +184,8 @@ public class MessageHeaderTest {
     private static MslContext p2pCtx;
     /** MSL encoder factory. */
     private static MslEncoderFactory encoder;
+    /** MSL encoder format. */
+    private static MslEncoderFormat format;
     
     /**
      * A helper class for building message header data.
@@ -300,12 +299,13 @@ public class MessageHeaderTest {
         ALGOS.add(CompressionAlgorithm.LZW);
         FORMATS.add(MslEncoderFormat.JSON);
         CAPABILITIES = new MessageCapabilities(ALGOS, LANGUAGES, FORMATS);
+        format = encoder.getPreferredFormat(CAPABILITIES.getEncoderFormats());
         
         MASTER_TOKEN = MslTestUtils.getMasterToken(trustedNetCtx, 1, 1);
         
         final KeyRequestData keyRequestData = new SymmetricWrappedExchange.RequestData(KeyId.PSK);
         final KeyExchangeFactory factory = trustedNetCtx.getKeyExchangeFactory(keyRequestData.getKeyExchangeScheme());
-        final KeyExchangeData keyxData = factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequestData, MASTER_TOKEN);
+        final KeyExchangeData keyxData = factory.generateResponse(trustedNetCtx, format, keyRequestData, MASTER_TOKEN);
         KEY_REQUEST_DATA.add(keyRequestData);
         KEY_RESPONSE_DATA = keyxData.keyResponseData;
         
@@ -317,13 +317,14 @@ public class MessageHeaderTest {
         
         final KeyRequestData peerKeyRequestData = new SymmetricWrappedExchange.RequestData(KeyId.PSK);
         final KeyExchangeFactory peerFactory = p2pCtx.getKeyExchangeFactory(peerKeyRequestData.getKeyExchangeScheme());
-        final KeyExchangeData peerKeyxData = peerFactory.generateResponse(p2pCtx, ENCODER_FORMAT, peerKeyRequestData, PEER_MASTER_TOKEN);
+        final KeyExchangeData peerKeyxData = peerFactory.generateResponse(p2pCtx, format, peerKeyRequestData, PEER_MASTER_TOKEN);
         PEER_KEY_REQUEST_DATA.add(peerKeyRequestData);
         PEER_KEY_RESPONSE_DATA = peerKeyxData.keyResponseData;
     }
     
     @AfterClass
     public static void teardown() {
+        format = null;
         encoder = null;
         p2pCtx = null;
         trustedNetCtx = null;
@@ -438,7 +439,7 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, format, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
@@ -446,7 +447,7 @@ public class MessageHeaderTest {
         assertFalse(headerdata.has(KEY_PEER_SERVICE_TOKENS));
         assertFalse(headerdata.has(KEY_PEER_USER_ID_TOKEN));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -482,7 +483,7 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, format, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
@@ -490,7 +491,7 @@ public class MessageHeaderTest {
         assertFalse(headerdata.has(KEY_PEER_SERVICE_TOKENS));
         assertFalse(headerdata.has(KEY_PEER_USER_ID_TOKEN));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -599,15 +600,15 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_MASTER_TOKEN), headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_USER_ID_TOKEN), headerdata.getMslObject(KEY_PEER_USER_ID_TOKEN, encoder)));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertFalse(headerdata.has(KEY_USER_ID_TOKEN));
     }
@@ -644,15 +645,15 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_MASTER_TOKEN), headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_USER_ID_TOKEN), headerdata.getMslObject(KEY_PEER_USER_ID_TOKEN, encoder)));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertFalse(headerdata.has(KEY_USER_ID_TOKEN));
     }
@@ -720,7 +721,7 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, format, KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
@@ -728,7 +729,7 @@ public class MessageHeaderTest {
         assertFalse(headerdata.has(KEY_PEER_SERVICE_TOKENS));
         assertFalse(headerdata.has(KEY_PEER_USER_ID_TOKEN));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -804,15 +805,15 @@ public class MessageHeaderTest {
         assertEquals(RENEWABLE, headerdata.getBoolean(KEY_RENEWABLE));
         assertEquals(HANDSHAKE, headerdata.getBoolean(KEY_HANDSHAKE));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, CAPABILITIES), headerdata.getMslObject(KEY_CAPABILITIES, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, PEER_KEY_REQUEST_DATA), headerdata.getMslArray(KEY_KEY_REQUEST_DATA)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_KEY_RESPONSE_DATA), headerdata.getMslObject(KEY_KEY_RESPONSE_DATA, encoder)));
         assertTrue(isAboutNowSeconds(headerdata.getLong(KEY_TIMESTAMP)));
         assertEquals(MESSAGE_ID, headerdata.getLong(KEY_MESSAGE_ID));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_MASTER_TOKEN), headerdata.getMslObject(KEY_PEER_MASTER_TOKEN, encoder)));
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, peerServiceTokens), headerdata.getMslArray(KEY_PEER_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, PEER_USER_ID_TOKEN), headerdata.getMslObject(KEY_PEER_USER_ID_TOKEN, encoder)));
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
-        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
+        assertTrue(MslEncoderUtils.equalArrays(MslEncoderUtils.createArray(p2pCtx, format, serviceTokens), headerdata.getMslArray(KEY_SERVICE_TOKENS)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_AUTH_DATA), headerdata.getMslObject(KEY_USER_AUTHENTICATION_DATA, encoder)));
         assertTrue(MslEncoderUtils.equalObjects(MslTestUtils.toMslObject(encoder, USER_ID_TOKEN), headerdata.getMslObject(KEY_USER_ID_TOKEN, encoder)));
     }
@@ -1785,11 +1786,11 @@ public class MessageHeaderTest {
         headerdataMo.put(KEY_KEY_REQUEST_DATA, encoder.createArray());
         headerdataMo.put(KEY_SERVICE_TOKENS, encoder.createArray());
         headerdataMo.put(KEY_PEER_SERVICE_TOKENS, encoder.createArray());
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         final Header header = Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -1886,11 +1887,11 @@ public class MessageHeaderTest {
         headerdataMo.put(KEY_KEY_REQUEST_DATA, encoder.createArray());
         headerdataMo.put(KEY_SERVICE_TOKENS, encoder.createArray());
         headerdataMo.put(KEY_PEER_SERVICE_TOKENS, encoder.createArray());
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         final Header header = Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -1954,11 +1955,11 @@ public class MessageHeaderTest {
         // After modifying the header data we need to encrypt it.
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER);
         headerdataMo.put(KEY_USER_ID_TOKEN, userIdToken);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -1986,11 +1987,11 @@ public class MessageHeaderTest {
         // After modifying the header data we need to encrypt it.
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, PEER_MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER);
         headerdataMo.put(KEY_USER_ID_TOKEN, userIdToken);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2020,11 +2021,11 @@ public class MessageHeaderTest {
         // After modifying the header data we need to encrypt it.
         final UserAuthenticationData userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL_2, MockEmailPasswordAuthenticationFactory.PASSWORD_2);
         headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, userAuthData);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2052,11 +2053,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataMo.remove(KEY_PEER_MASTER_TOKEN));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2081,11 +2082,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_PEER_MASTER_TOKEN, MASTER_TOKEN);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2113,12 +2114,12 @@ public class MessageHeaderTest {
         // After modifying the header data we need to encrypt it.
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
         serviceTokens.addAll(MslTestUtils.getServiceTokens(trustedNetCtx, PEER_MASTER_TOKEN, null));
-        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens));
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2147,12 +2148,12 @@ public class MessageHeaderTest {
         final Set<ServiceToken> serviceTokens = builder.getServiceTokens();
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
         serviceTokens.addAll(MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, userIdToken));
-        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        headerdataMo.put(KEY_SERVICE_TOKENS, MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens));
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2180,11 +2181,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataMo.remove(KEY_PEER_MASTER_TOKEN));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2212,11 +2213,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_PEER_MASTER_TOKEN, MASTER_TOKEN);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2245,11 +2246,11 @@ public class MessageHeaderTest {
         // After modifying the header data we need to encrypt it.
         final UserIdToken userIdToken = MslTestUtils.getUserIdToken(p2pCtx, PEER_MASTER_TOKEN, 2, MockEmailPasswordAuthenticationFactory.USER);
         headerdataMo.put(KEY_PEER_USER_ID_TOKEN, userIdToken);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2274,11 +2275,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataMo.remove(KEY_TIMESTAMP));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2306,11 +2307,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_TIMESTAMP, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2338,11 +2339,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataMo.remove(KEY_MESSAGE_ID));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2370,11 +2371,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_MESSAGE_ID, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2424,11 +2425,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_MESSAGE_ID, -1);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2456,11 +2457,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_MESSAGE_ID, MslConstants.MAX_LONG_VALUE + 1);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2489,11 +2490,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_NON_REPLAYABLE_ID, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2522,11 +2523,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataMo.remove(KEY_RENEWABLE));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2555,11 +2556,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_RENEWABLE, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2590,11 +2591,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         assertNotNull(headerdataMo.remove(KEY_HANDSHAKE));
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         // FIXME For now a missing handshake flag will result in a false value.
@@ -2627,11 +2628,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_HANDSHAKE, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2660,11 +2661,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_CAPABILITIES, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2692,11 +2693,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_KEY_REQUEST_DATA, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2726,11 +2727,11 @@ public class MessageHeaderTest {
         final MslArray a = encoder.createArray();
         a.put(-1, "x");
         headerdataMo.put(KEY_PEER_SERVICE_TOKENS, a);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2758,11 +2759,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_SERVICE_TOKENS, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2792,11 +2793,11 @@ public class MessageHeaderTest {
         final MslArray a = encoder.createArray();
         a.put(-1, "x");
         headerdataMo.put(KEY_SERVICE_TOKENS, a);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2824,11 +2825,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_PEER_SERVICE_TOKENS, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2858,11 +2859,11 @@ public class MessageHeaderTest {
         final MslArray a = encoder.createArray();
         a.put(-1, "x");
         headerdataMo.put(KEY_PEER_SERVICE_TOKENS, a);
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2890,11 +2891,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_PEER_MASTER_TOKEN, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2922,11 +2923,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_PEER_USER_ID_TOKEN, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2954,11 +2955,11 @@ public class MessageHeaderTest {
         
         // After modifying the header data we need to encrypt it.
         headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, "x");
-        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, ENCODER_FORMAT), encoder, ENCODER_FORMAT);
+        final byte[] headerdata = cryptoContext.encrypt(encoder.encodeObject(headerdataMo, format), encoder, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -2995,13 +2996,13 @@ public class MessageHeaderTest {
         final byte[] plaintext = messageHeaderMo.getBytes(KEY_HEADERDATA);
         final MslObject headerdataMo = encoder.parseObject(plaintext);
         headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, USER_AUTH_DATA);
-        final byte[] headerdata = encoder.encodeObject(headerdataMo, ENCODER_FORMAT);
+        final byte[] headerdata = encoder.encodeObject(headerdataMo, format);
         messageHeaderMo.put(KEY_HEADERDATA, headerdata);
         
         // The header data must be signed or it will not be processed.
         final EntityAuthenticationFactory factory = x509Ctx.getEntityAuthenticationFactory(entityAuthData.getScheme());
         final ICryptoContext cryptoContext = factory.getCryptoContext(x509Ctx, entityAuthData);
-        final byte[] signature = cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT);
+        final byte[] signature = cryptoContext.sign(headerdata, encoder, format);
         messageHeaderMo.put(KEY_SIGNATURE, signature);
         
         Header.parseHeader(x509Ctx, messageHeaderMo, CRYPTO_CONTEXTS);
@@ -3286,9 +3287,9 @@ public class MessageHeaderTest {
         final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final KeyRequestData keyRequestData = KEY_REQUEST_DATA.toArray(new KeyRequestData[0])[0];
         final KeyExchangeFactory factory = trustedNetCtx.getKeyExchangeFactory(keyRequestData.getKeyExchangeScheme());
-        final KeyExchangeData keyxDataA = factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequestData, MASTER_TOKEN);
+        final KeyExchangeData keyxDataA = factory.generateResponse(trustedNetCtx, format, keyRequestData, MASTER_TOKEN);
         final KeyResponseData keyResponseDataA = keyxDataA.keyResponseData;
-        final KeyExchangeData keyxDataB = factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequestData, MASTER_TOKEN);
+        final KeyExchangeData keyxDataB = factory.generateResponse(trustedNetCtx, format, keyRequestData, MASTER_TOKEN);
         final KeyResponseData keyResponseDataB = keyxDataB.keyResponseData;
         final HeaderData headerDataA = new HeaderDataBuilder(trustedNetCtx, USER_ID_TOKEN, serviceTokens).set(KEY_KEY_RESPONSE_DATA, keyResponseDataA).build();
         final HeaderData headerDataB = new HeaderDataBuilder(trustedNetCtx, USER_ID_TOKEN, serviceTokens).set(KEY_KEY_RESPONSE_DATA, keyResponseDataB).build();

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -397,7 +397,7 @@ describe("MessageHeader", function() {
 					result: function(x) { PEER_USER_ID_TOKEN_MO = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
-				MslEncoderUtils.createArray(trustedNetCtx, KEY_REQUEST_DATA, {
+				MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA, {
 					result: function(x) { KEY_REQUEST_DATA_MA = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -405,7 +405,7 @@ describe("MessageHeader", function() {
 					result: function(x) { KEY_RESPONSE_DATA_MO = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
-				MslEncoderUtils.createArray(p2pCtx, PEER_KEY_REQUEST_DATA, {
+				MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA, {
 					result: function(x) { PEER_KEY_REQUEST_DATA_MA = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -614,7 +614,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -713,7 +713,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -924,11 +924,11 @@ describe("MessageHeader", function() {
 		var serviceTokensMa, peerServiceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
-			MslEncoderUtils.createArray(p2pCtx, peerServiceTokens, {
+			MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens, {
 				result: function(x) { peerServiceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1029,11 +1029,11 @@ describe("MessageHeader", function() {
 		var serviceTokensMa, peerServiceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
-			MslEncoderUtils.createArray(p2pCtx, peerServiceTokens, {
+			MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens, {
 				result: function(x) { peerServiceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1177,7 +1177,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1329,7 +1329,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1338,7 +1338,7 @@ describe("MessageHeader", function() {
 		
 		var peerServiceTokensMa;
 		runs(function() {
-			MslEncoderUtils.createArray(trustedNetCtx, peerServiceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, peerServiceTokens, {
 				result: function(x) { peerServiceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});

--- a/tests/src/test/javascript/msg/MessageHeaderTest.js
+++ b/tests/src/test/javascript/msg/MessageHeaderTest.js
@@ -52,9 +52,6 @@ describe("MessageHeader", function() {
     var MockMslContext = require('msl-tests/util/MockMslContext.js');
     var MockPresharedAuthenticationFactory = require('msl-tests/entityauth/MockPresharedAuthenticationFactory.js');
     var MockEmailPasswordAuthenticationFactory = require('msl-tests/userauth/MockEmailPasswordAuthenticationFactory.js');
-    
-	/** MSL encoder format. */
-	var ENCODER_FORMAT = MslEncoderFormat.JSON;
 	
     /** Milliseconds per second. */
     var MILLISECONDS_PER_SECOND = 1000;
@@ -130,6 +127,8 @@ describe("MessageHeader", function() {
 	var p2pCtx;
     /** MSL encoder factory. */
     var encoder;
+    /** MSL encoder format. */
+    var format;
 
 	var USER_AUTH_DATA = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL, MockEmailPasswordAuthenticationFactory.PASSWORD);
 	var USER_AUTH_DATA_MO;
@@ -330,6 +329,8 @@ describe("MessageHeader", function() {
 			waitsFor(function() { return MASTER_TOKEN && PEER_MASTER_TOKEN && ENTITY_AUTH_DATA && PEER_ENTITY_AUTH_DATA; }, "master tokens and entity authentication data not received", MslTestConstants.TIMEOUT);
 
 			runs(function() {
+			    format = encoder.getPreferredFormat(CAPABILITIES.encoderFormats);
+			    
 				MslTestUtils.getUserIdToken(trustedNetCtx, MASTER_TOKEN, 1, MockEmailPasswordAuthenticationFactory.USER, {
 					result: function(token) { USER_ID_TOKEN = token; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
@@ -341,7 +342,7 @@ describe("MessageHeader", function() {
 
 				var keyRequestData = new SymmetricWrappedExchange.RequestData(SymmetricWrappedExchange.KeyId.PSK);
 				var factory = trustedNetCtx.getKeyExchangeFactory(keyRequestData.keyExchangeScheme);
-				factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequestData, MASTER_TOKEN, {
+				factory.generateResponse(trustedNetCtx, format, keyRequestData, MASTER_TOKEN, {
 					result: function(keyxData) {
 						KEY_REQUEST_DATA.push(keyRequestData);
 						KEY_RESPONSE_DATA = keyxData.keyResponseData;
@@ -351,7 +352,7 @@ describe("MessageHeader", function() {
 
 				var peerKeyRequestData = new SymmetricWrappedExchange.RequestData(SymmetricWrappedExchange.KeyId.PSK);
 				var peerFactory = p2pCtx.getKeyExchangeFactory(peerKeyRequestData.keyExchangeScheme);
-				peerFactory.generateResponse(p2pCtx, ENCODER_FORMAT, peerKeyRequestData, PEER_MASTER_TOKEN, {
+				peerFactory.generateResponse(p2pCtx, format, peerKeyRequestData, PEER_MASTER_TOKEN, {
 					result: function(peerKeyxData) {
 						PEER_KEY_REQUEST_DATA.push(peerKeyRequestData);
 						PEER_KEY_RESPONSE_DATA = peerKeyxData.keyResponseData;
@@ -397,7 +398,7 @@ describe("MessageHeader", function() {
 					result: function(x) { PEER_USER_ID_TOKEN_MO = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
-				MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, KEY_REQUEST_DATA, {
+				MslEncoderUtils.createArray(trustedNetCtx, format, KEY_REQUEST_DATA, {
 					result: function(x) { KEY_REQUEST_DATA_MA = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -405,7 +406,7 @@ describe("MessageHeader", function() {
 					result: function(x) { KEY_RESPONSE_DATA_MO = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
-				MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, PEER_KEY_REQUEST_DATA, {
+				MslEncoderUtils.createArray(p2pCtx, format, PEER_KEY_REQUEST_DATA, {
 					result: function(x) { PEER_KEY_REQUEST_DATA_MA = x; },
 					error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 				});
@@ -614,7 +615,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -713,7 +714,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -924,11 +925,11 @@ describe("MessageHeader", function() {
 		var serviceTokensMa, peerServiceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
-			MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens, {
+			MslEncoderUtils.createArray(p2pCtx, format, peerServiceTokens, {
 				result: function(x) { peerServiceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1029,11 +1030,11 @@ describe("MessageHeader", function() {
 		var serviceTokensMa, peerServiceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
-			MslEncoderUtils.createArray(p2pCtx, ENCODER_FORMAT, peerServiceTokens, {
+			MslEncoderUtils.createArray(p2pCtx, format, peerServiceTokens, {
 				result: function(x) { peerServiceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1177,7 +1178,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1329,7 +1330,7 @@ describe("MessageHeader", function() {
 		var serviceTokensMa;
 		runs(function() {
 			var serviceTokens = builder.getServiceTokens();
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, serviceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, serviceTokens, {
 				result: function(x) { serviceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -1338,7 +1339,7 @@ describe("MessageHeader", function() {
 		
 		var peerServiceTokensMa;
 		runs(function() {
-			MslEncoderUtils.createArray(trustedNetCtx, ENCODER_FORMAT, peerServiceTokens, {
+			MslEncoderUtils.createArray(trustedNetCtx, format, peerServiceTokens, {
 				result: function(x) { peerServiceTokensMa = x; },
 		        error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
@@ -3399,14 +3400,14 @@ describe("MessageHeader", function() {
                     headerdataMo.put(KEY_KEY_REQUEST_DATA, encoder.createArray());
                     headerdataMo.put(KEY_SERVICE_TOKENS, encoder.createArray());
                     headerdataMo.put(KEY_PEER_SERVICE_TOKENS, encoder.createArray());
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -3576,14 +3577,14 @@ describe("MessageHeader", function() {
                     headerdataMo.put(KEY_KEY_REQUEST_DATA, encoder.createArray());
                     headerdataMo.put(KEY_SERVICE_TOKENS, encoder.createArray());
                     headerdataMo.put(KEY_PEER_SERVICE_TOKENS, encoder.createArray());
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -3701,14 +3702,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_USER_ID_TOKEN, userIdToken);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -3786,14 +3787,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_USER_ID_TOKEN, userIdToken);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -3873,14 +3874,14 @@ describe("MessageHeader", function() {
                     // After modifying the header data we need to encrypt it.
                     var userAuthData = new EmailPasswordAuthenticationData(MockEmailPasswordAuthenticationFactory.EMAIL_2, MockEmailPasswordAuthenticationFactory.PASSWORD_2);
                     headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, userAuthData);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -3954,14 +3955,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.remove(KEY_PEER_MASTER_TOKEN);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4035,14 +4036,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_PEER_MASTER_TOKEN, MASTER_TOKEN);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4120,14 +4121,14 @@ describe("MessageHeader", function() {
                         serviceTokens.push(mismatchedToken);
                     }, this);
                     headerdataMo.put(KEY_SERVICE_TOKENS, serviceTokens);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4214,14 +4215,14 @@ describe("MessageHeader", function() {
                         serviceTokens.push(mismatchedToken);
                     }, this);
                     headerdataMo.put(KEY_SERVICE_TOKENS, serviceTokens);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4295,14 +4296,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.remove(KEY_PEER_MASTER_TOKEN);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-                    		cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+                    		cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4376,14 +4377,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_PEER_MASTER_TOKEN, MASTER_TOKEN);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4466,14 +4467,14 @@ describe("MessageHeader", function() {
 
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_PEER_USER_ID_TOKEN, userIdToken);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4544,14 +4545,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.remove(KEY_TIMESTAMP);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(trustedNetCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4618,14 +4619,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_TIMESTAMP, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4699,14 +4700,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.remove(KEY_MESSAGE_ID);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4780,14 +4781,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_MESSAGE_ID, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -4919,14 +4920,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_MESSAGE_ID, -1);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5000,14 +5001,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_MESSAGE_ID, MslConstants.MAX_LONG_VALUE + 2);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5081,14 +5082,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_NON_REPLAYABLE_ID, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5162,14 +5163,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.remove(KEY_RENEWABLE);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5243,14 +5244,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_RENEWABLE, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5326,14 +5327,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.remove(KEY_HANDSHAKE);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5410,14 +5411,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_HANDSHAKE, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5491,14 +5492,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_CAPABILITIES, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5572,14 +5573,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_KEY_REQUEST_DATA, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5655,14 +5656,14 @@ describe("MessageHeader", function() {
                     var a = encoder.createArray();
                     a.put(-1, "x");
                     headerdataMo.put(KEY_PEER_SERVICE_TOKENS, a);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5736,14 +5737,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_SERVICE_TOKENS, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5819,14 +5820,14 @@ describe("MessageHeader", function() {
                     var a = encoder.createArray();
                     a.put(-1, "x");
                     headerdataMo.put(KEY_SERVICE_TOKENS, a);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5900,14 +5901,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_PEER_SERVICE_TOKENS, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -5983,14 +5984,14 @@ describe("MessageHeader", function() {
                     var a = encoder.createArray();
                     a.put(-1, "x");
                     headerdataMo.put(KEY_PEER_SERVICE_TOKENS, a);
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -6063,14 +6064,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_PEER_MASTER_TOKEN, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-                    		cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+                    		cryptoContext.encrypt(plaintext, encoder, format, {
                     			result: function(headerdata) {
                     				messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 
                     				// The header data must be signed or it will not be processed.
-                    				cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+                    				cryptoContext.sign(headerdata, encoder, format, {
                     					result: function(signature) {
                     						messageHeaderMo.put(KEY_SIGNATURE, signature);
                     						Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -6144,14 +6145,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_PEER_USER_ID_TOKEN, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -6225,14 +6226,14 @@ describe("MessageHeader", function() {
         
                     // After modifying the header data we need to encrypt it.
                     headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, "x");
-                    encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+                    encoder.encodeObject(headerdataMo, format, {
                     	result: function(plaintext) {
-		                    cryptoContext.encrypt(plaintext, encoder, ENCODER_FORMAT, {
+		                    cryptoContext.encrypt(plaintext, encoder, format, {
 		                        result: function(headerdata) {
 		                            messageHeaderMo.put(KEY_HEADERDATA, headerdata);
 		                    
 		                            // The header data must be signed or it will not be processed.
-		                            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+		                            cryptoContext.sign(headerdata, encoder, format, {
 		                                result: function(signature) {
 		                                    messageHeaderMo.put(KEY_SIGNATURE, signature);
 		                                    Header.parseHeader(p2pCtx, messageHeaderMo, CRYPTO_CONTEXTS, {
@@ -6359,7 +6360,7 @@ describe("MessageHeader", function() {
             var plaintext = messageHeaderMo.getBytes(KEY_HEADERDATA);
             var headerdataMo = encoder.parseObject(plaintext);
             headerdataMo.put(KEY_USER_AUTHENTICATION_DATA, USER_AUTH_DATA);
-            encoder.encodeObject(headerdataMo, ENCODER_FORMAT, {
+            encoder.encodeObject(headerdataMo, format, {
                 result: function(x) { headerdata = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -6373,7 +6374,7 @@ describe("MessageHeader", function() {
             // The header data must be signed or it will not be processed.
             var factory = rsaCtx.getEntityAuthenticationFactory(entityAuthData.scheme);
             var cryptoContext = factory.getCryptoContext(rsaCtx, entityAuthData);
-            cryptoContext.sign(headerdata, encoder, ENCODER_FORMAT, {
+            cryptoContext.sign(headerdata, encoder, format, {
                 result: function(x) { signature = x; },
                 error: function(e) { expect(function() { throw e; }).not.toThrow(); }
             });
@@ -7023,11 +7024,11 @@ describe("MessageHeader", function() {
 		runs(function() {
             var keyRequestData = KEY_REQUEST_DATA[0];
             var factory = trustedNetCtx.getKeyExchangeFactory(keyRequestData.getKeyExchangeScheme());		
-			factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequestData, MASTER_TOKEN, {
+			factory.generateResponse(trustedNetCtx, format, keyRequestData, MASTER_TOKEN, {
 				result: function(x) { keyxDataA = x; },
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});
-			factory.generateResponse(trustedNetCtx, ENCODER_FORMAT, keyRequestData, MASTER_TOKEN, {
+			factory.generateResponse(trustedNetCtx, format, keyRequestData, MASTER_TOKEN, {
 				result: function(x) { keyxDataB = x; },
 				error: function(e) { expect(function() { throw e; }).not.toThrow(); }
 			});


### PR DESCRIPTION
Fixes #297. Add encoder format parameter to `MslEncoderUtils.createArray()` to ensure `MslEncodable` types are encoded in a format compatible with the final MSL message.