### PR TITLE
Attach user ID token instead of peer user ID token when message header parsing fails.

### DIFF
--- a/core/src/main/cpp/msg/MessageHeader.cpp
+++ b/core/src/main/cpp/msg/MessageHeader.cpp
@@ -284,7 +284,7 @@ MessageHeader::MessageHeader(shared_ptr<MslContext> ctx, shared_ptr<EntityAuthen
         throw MslEncodingException(MslError::MSL_ENCODE_ERROR, "headerdata", e)
             .setMasterToken(masterToken)
             .setEntityAuthenticationData(entityAuthData)
-            .setUserIdToken(peerUserIdToken)
+            .setUserIdToken(userIdToken)
             .setUserAuthenticationData(userAuthData)
             .setMessageId(messageId);
     }

--- a/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageHeader.java
@@ -377,7 +377,7 @@ public class MessageHeader extends Header {
             throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
                 .setMasterToken(this.masterToken)
                 .setEntityAuthenticationData(this.entityAuthData)
-                .setUserIdToken(this.peerUserIdToken)
+                .setUserIdToken(this.userIdToken)
                 .setUserAuthenticationData(this.userAuthData)
                 .setMessageId(this.messageId);
         }

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -664,7 +664,7 @@
                                 throw new MslEncodingException(MslError.MSL_ENCODE_ERROR, "headerdata", e)
                                     .setMasterToken(masterToken)
                                     .setEntityAuthenticationData(entityAuthData)
-                                    .setUserIdToken(peerUserIdToken)
+                                    .setUserIdToken(userIdToken)
                                     .setUserAuthenticationData(userAuthData)
                                     .setMessageId(messageId);
                             }


### PR DESCRIPTION
Fixes #278.