### PR TITLE
Fix deep MSL object build in MslEncoderUtilsTest

### DIFF
--- a/tests/src/test/java/com/netflix/msl/io/MslEncoderUtilsTest.java
+++ b/tests/src/test/java/com/netflix/msl/io/MslEncoderUtilsTest.java
@@ -59,7 +59,6 @@ public class MslEncoderUtilsTest {
     private static final String KEY_BOOLEAN = "boolean";
     private static final String KEY_NUMBER = "number";
     private static final String KEY_STRING = "string";
-    private static final String KEY_NULL = "null";
     private static final String KEY_OBJECT = "object";
     private static final String KEY_ARRAY = "array";
     
@@ -84,7 +83,7 @@ public class MslEncoderUtilsTest {
     private static MslObject createFlatMslObject(final Random random) throws MslEncoderException {
         final MslObject mo = new MslObject();
         for (int i = 1 + random.nextInt(MAX_ELEMENTS - 1); i > 0; --i) {
-            switch (random.nextInt(4)) {
+            switch (random.nextInt(3)) {
                 case 0:
                     mo.put(KEY_BOOLEAN + i, random.nextBoolean());
                     break;
@@ -93,9 +92,6 @@ public class MslEncoderUtilsTest {
                     break;
                 case 2:
                     mo.put(KEY_STRING + i, randomString(random));
-                    break;
-                case 3:
-                    mo.put(KEY_NULL + i, null);
                     break;
             }
         }
@@ -112,7 +108,7 @@ public class MslEncoderUtilsTest {
     private static MslObject createDeepMslObject(final Random random, final int depth) throws MslEncoderException {
         final MslObject mo = new MslObject();
         for (int i = 1 + random.nextInt(MAX_ELEMENTS - 1); i > 0; --i) {
-            switch (random.nextInt(6)) {
+            switch (random.nextInt(5)) {
                 case 0:
                     mo.put(KEY_BOOLEAN + i, random.nextBoolean());
                     break;
@@ -121,9 +117,6 @@ public class MslEncoderUtilsTest {
                     break;
                 case 2:
                     mo.put(KEY_STRING + i, randomString(random));
-                    break;
-                case 3:
-                    mo.put(KEY_NULL + i, null);
                     break;
                 case 4:
                     mo.put(KEY_OBJECT + i, (depth > 1) ? createDeepMslObject(random, depth - 1) : createFlatMslObject(random));

--- a/tests/src/test/javascript/io/MslEncoderUtilsTest.js
+++ b/tests/src/test/javascript/io/MslEncoderUtilsTest.js
@@ -23,7 +23,6 @@ describe("MslEncoderUtils", function() {
     var KEY_BOOLEAN = "boolean";
     var KEY_NUMBER = "number";
     var KEY_STRING = "string";
-    var KEY_NULL = "null";
     var KEY_OBJECT = "object";
     var KEY_ARRAY = "array";
     
@@ -48,7 +47,7 @@ describe("MslEncoderUtils", function() {
     function createFlatMslObject(random) {
         var mo = new MslObject();
         for (var i = 1 + random.nextInt(MAX_ELEMENTS - 1); i > 0; --i) {
-            switch (random.nextInt(4)) {
+            switch (random.nextInt(3)) {
                 case 0:
                     mo.put(KEY_BOOLEAN + i, random.nextBoolean());
                     break;
@@ -57,9 +56,6 @@ describe("MslEncoderUtils", function() {
                     break;
                 case 2:
                     mo.put(KEY_STRING + i, randomString(random));
-                    break;
-                case 3:
-                    mo.put(KEY_NULL + i, null);
                     break;
             }
         }
@@ -75,7 +71,7 @@ describe("MslEncoderUtils", function() {
     function createDeepMslObject(random, depth) {
         var mo = new MslObject();
         for (var i = 1 + random.nextInt(MAX_ELEMENTS - 1); i > 0; --i) {
-            switch (random.nextInt(6)) {
+            switch (random.nextInt(5)) {
 	            case 0:
 	                mo.put(KEY_BOOLEAN + i, random.nextBoolean());
 	                break;
@@ -84,9 +80,6 @@ describe("MslEncoderUtils", function() {
 	                break;
 	            case 2:
 	                mo.put(KEY_STRING + i, randomString(random));
-	                break;
-	            case 3:
-	                mo.put(KEY_NULL + i, null);
 	                break;
 	            case 4:
 	                mo.put(KEY_OBJECT + i, (depth > 1) ? createDeepMslObject(random, depth - 1) : createFlatMslObject(random));


### PR DESCRIPTION
Do not try to add null values to the deep MslObject as that deletes the key/value pair.