### PR TITLE
Add payload security properties to MessageInputStream and MessageOutputStream.

### DIFF
--- a/core/src/main/cpp/msg/MessageInputStream.cpp
+++ b/core/src/main/cpp/msg/MessageInputStream.cpp
@@ -460,6 +460,61 @@ shared_ptr<MslUser> MessageInputStream::getUser()
 	return messageHeader->getUser();
 }
 
+bool MessageInputStream::encryptsPayloads()
+{
+    // Return false for error messages.
+    shared_ptr<MessageHeader> messageHeader = getMessageHeader();
+    if (!messageHeader)
+        return false;
+
+    // If the message uses entity authentication data for an entity
+    // authentication scheme that provides encryption, return true.
+    shared_ptr<EntityAuthenticationData> entityAuthData = messageHeader->getEntityAuthenticationData();
+    if (entityAuthData && entityAuthData->getScheme().encrypts())
+        return true;
+
+    // If the message uses a master token, return true.
+    shared_ptr<MasterToken> masterToken = messageHeader->getMasterToken();
+    if (masterToken)
+        return true;
+
+    // If the message includes key response data, return true.
+    shared_ptr<KeyResponseData> keyResponseData = messageHeader->getKeyResponseData();
+    if (keyResponseData)
+        return true;
+
+    // Otherwise return false.
+    return false;
+}
+
+bool MessageInputStream::protectsPayloadIntegrity()
+{
+    // Return false for error messages.
+    shared_ptr<MessageHeader> messageHeader = getMessageHeader();
+    if (!messageHeader)
+        return false;
+
+    // If the message uses entity authentication data for an entity
+    // authentication scheme that provides integrity protection, return
+    // true.
+    shared_ptr<EntityAuthenticationData> entityAuthData = messageHeader->getEntityAuthenticationData();
+    if (entityAuthData && entityAuthData->getScheme().protectsIntegrity())
+        return true;
+
+    // If the message uses a master token, return true.
+    shared_ptr<MasterToken> masterToken = messageHeader->getMasterToken();
+    if (masterToken)
+        return true;
+
+    // If the message includes key response data, return true.
+    shared_ptr<KeyResponseData> keyResponseData = messageHeader->getKeyResponseData();
+    if (keyResponseData)
+        return true;
+
+    // Otherwise return false.
+    return false;
+}
+
 void MessageInputStream::abort()
 {
 	aborted_ = true;

--- a/core/src/main/cpp/msg/MessageInputStream.h
+++ b/core/src/main/cpp/msg/MessageInputStream.h
@@ -156,6 +156,28 @@ public:
     virtual std::shared_ptr<crypto::ICryptoContext> getKeyExchangeCryptoContext() { return keyxCryptoContext_; }
 
     /**
+     * Returns true if the payload application data is encrypted. This will be
+     * true if the entity authentication scheme provides encryption or if
+     * session keys were used. Returns false for error messages which do not
+     * have any payload chunks.
+     *
+     * @return true if the payload application data is encrypted. Will be false
+     *         for error messages.
+     */
+    virtual bool encryptsPayloads();
+
+    /**
+     * Returns true if the payload application data is integrity protected.
+     * This will be true if the entity authentication scheme provides integrity
+     * protection or if session keys were used. Returns false for error
+     * messages which do not have any payload chunks.
+     *
+     * @return true if the payload application data is integrity protected.
+     *         Will be false for error messages.
+     */
+    virtual bool protectsPayloadIntegrity();
+
+    /**
      * By default the source input stream is not closed when this message input
      * stream is closed. If it should be closed then this method can be used to
      * dictate the desired behavior.

--- a/core/src/main/cpp/msg/MessageOutputStream.h
+++ b/core/src/main/cpp/msg/MessageOutputStream.h
@@ -111,17 +111,39 @@ public:
      * @throws MslInternalException if writing an error message.
      * @see #flush()
      */
-    bool setCompressionAlgorithm(const MslConstants::CompressionAlgorithm& compressionAlgo);
+    virtual bool setCompressionAlgorithm(const MslConstants::CompressionAlgorithm& compressionAlgo);
 
     /**
      * @return the message header. Will be null for error messages.
      */
-    std::shared_ptr<MessageHeader> getMessageHeader();
+    virtual std::shared_ptr<MessageHeader> getMessageHeader();
 
     /**
      * @return the error header. Will be null except for error messages.
      */
-    std::shared_ptr<ErrorHeader> getErrorHeader();
+    virtual std::shared_ptr<ErrorHeader> getErrorHeader();
+
+    /**
+     * Returns true if the payload application data is encrypted. This will be
+     * true if the entity authentication scheme provides encryption or if
+     * session keys were used. Returns false for error messages which do not
+     * have any payload chunks.
+     *
+     * @return true if the payload application data is encrypted. Will be false
+     *         for error messages.
+     */
+    virtual bool encryptsPayloads();
+
+    /**
+     * Returns true if the payload application data is integrity protected.
+     * This will be true if the entity authentication scheme provides integrity
+     * protection or if session keys were used. Returns false for error
+     * messages which do not have any payload chunks.
+     *
+     * @return true if the payload application data is integrity protected.
+     *         Will be false for error messages.
+     */
+    virtual bool protectsPayloadIntegrity();
 
     /**
      * Returns the payloads sent so far. Once payload caching is turned off
@@ -129,12 +151,12 @@ public:
      *
      * @return an immutable ordered list of the payloads sent so far.
      */
-    std::vector<std::shared_ptr<PayloadChunk>> getPayloads() { return payloads_; }
+    virtual std::vector<std::shared_ptr<PayloadChunk>> getPayloads() { return payloads_; }
 
     /**
      * Turns off caching of any message data (e.g. payloads).
      */
-    void stopCaching();
+    virtual void stopCaching();
 
     /**
      * By default the destination output stream is not closed when this message
@@ -144,7 +166,7 @@ public:
      * @param close true if the destination output stream should be closed,
      *        false if it should not.
      */
-    void closeDestination(bool close) { closeDestination_ = close; }
+    virtual void closeDestination(bool close) { closeDestination_ = close; }
 
     /** @inheritDoc */
     virtual void abort();

--- a/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageInputStream.java
@@ -565,6 +565,77 @@ public class MessageInputStream extends InputStream {
     public ICryptoContext getKeyExchangeCryptoContext() {
         return keyxCryptoContext;
     }
+    
+    /**
+     * Returns true if the payload application data is encrypted. This will be
+     * true if the entity authentication scheme provides encryption or if
+     * session keys were used. Returns false for error messages which do not
+     * have any payload chunks.
+     * 
+     * @return true if the payload application data is encrypted. Will be false
+     *         for error messages.
+     */
+    public boolean encryptsPayloads() {
+        // Return false for error messages.
+        final MessageHeader messageHeader = getMessageHeader();
+        if (messageHeader == null)
+            return false;
+        
+        // If the message uses entity authentication data for an entity
+        // authentication scheme that provides encryption, return true.
+        final EntityAuthenticationData entityAuthData = messageHeader.getEntityAuthenticationData();
+        if (entityAuthData != null && entityAuthData.getScheme().encrypts())
+            return true;
+        
+        // If the message uses a master token, return true.
+        final MasterToken masterToken = messageHeader.getMasterToken();
+        if (masterToken != null)
+            return true;
+        
+        // If the message includes key response data, return true.
+        final KeyResponseData keyResponseData = messageHeader.getKeyResponseData();
+        if (keyResponseData != null)
+            return true;
+        
+        // Otherwise return false.
+        return false;
+    }
+    
+    /**
+     * Returns true if the payload application data is integrity protected.
+     * This will be true if the entity authentication scheme provides integrity
+     * protection or if session keys were used. Returns false for error
+     * messages which do not have any payload chunks.
+     * 
+     * @return true if the payload application data is integrity protected.
+     *         Will be false for error messages.
+     */
+    public boolean protectsPayloadIntegrity() {
+        // Return false for error messages.
+        final MessageHeader messageHeader = getMessageHeader();
+        if (messageHeader == null)
+            return false;
+        
+        // If the message uses entity authentication data for an entity
+        // authentication scheme that provides integrity protection, return
+        // true.
+        final EntityAuthenticationData entityAuthData = messageHeader.getEntityAuthenticationData();
+        if (entityAuthData != null && entityAuthData.getScheme().protectsIntegrity())
+            return true;
+        
+        // If the message uses a master token, return true.
+        final MasterToken masterToken = messageHeader.getMasterToken();
+        if (masterToken != null)
+            return true;
+        
+        // If the message includes key response data, return true.
+        final KeyResponseData keyResponseData = messageHeader.getKeyResponseData();
+        if (keyResponseData != null)
+            return true;
+        
+        // Otherwise return false.
+        return false;
+    }
 
     /* (non-Javadoc)
      * @see java.io.InputStream#available()

--- a/core/src/main/javascript/msg/MessageInputStream.js
+++ b/core/src/main/javascript/msg/MessageInputStream.js
@@ -1007,6 +1007,77 @@
         getKeyExchangeCryptoContext: function getKeyExchangeCryptoContext() {
             return this._keyxCryptoContext;
         },
+        
+        /**
+         * Returns true if the payload application data is encrypted. This will be
+         * true if the entity authentication scheme provides encryption or if
+         * session keys were used. Returns false for error messages which do not
+         * have any payload chunks.
+         * 
+         * @return {boolean} true if the payload application data is encrypted. Will be false
+         *         for error messages.
+         */
+        encryptsPayloads: function encryptsPayloads() {
+            // Return false for error messages.
+            var messageHeader = this.getMessageHeader();
+            if (!messageHeader)
+                return false;
+            
+            // If the message uses entity authentication data for an entity
+            // authentication scheme that provides encryption, return true.
+            var entityAuthData = messageHeader.entityAuthenticationData;
+            if (entityAuthData && entityAuthData.scheme.encrypts)
+                return true;
+            
+            // If the message uses a master token, return true.
+            var masterToken = messageHeader.masterToken;
+            if (masterToken)
+                return true;
+            
+            // If the message includes key response data, return true.
+            var keyResponseData = messageHeader.keyResponseData;
+            if (keyResponseData)
+                return true;
+            
+            // Otherwise return false.
+            return false;
+        },
+        
+        /**
+         * Returns true if the payload application data is integrity protected.
+         * This will be true if the entity authentication scheme provides integrity
+         * protection or if session keys were used. Returns false for error
+         * messages which do not have any payload chunks.
+         * 
+         * @return {boolean} true if the payload application data is integrity protected.
+         *         Will be false for error messages.
+         */
+        protectsPayloadIntegrity: function protectsPayloadIntegrity() {
+            // Return false for error messages.
+            var messageHeader = this.getMessageHeader();
+            if (!messageHeader)
+                return false;
+            
+            // If the message uses entity authentication data for an entity
+            // authentication scheme that provides integrity protection, return
+            // true.
+            var entityAuthData = messageHeader.entityAuthenticationData;
+            if (entityAuthData && entityAuthData.scheme.protectsIntegrity)
+                return true;
+            
+            // If the message uses a master token, return true.
+            var masterToken = messageHeader.masterToken;
+            if (masterToken)
+                return true;
+            
+            // If the message includes key response data, return true.
+            var keyResponseData = messageHeader.keyResponseData;
+            if (keyResponseData)
+                return true;
+            
+            // Otherwise return false.
+            return false;
+        },
 
         /**
          * By default the source input stream is not closed when this message input

--- a/core/src/main/javascript/msg/MessageOutputStream.js
+++ b/core/src/main/javascript/msg/MessageOutputStream.js
@@ -342,10 +342,81 @@
         /**
          * @return {ErrorHeader} the error header. Will be null except for error messages.
          */
-        getErrorMessage: function getErrorHeader() {
+        getErrorHeader: function getErrorHeader() {
             if (this._header instanceof ErrorHeader)
                 return this._header;
             return null;
+        },
+        
+        /**
+         * Returns true if the payload application data is encrypted. This will be
+         * true if the entity authentication scheme provides encryption or if
+         * session keys were used. Returns false for error messages which do not
+         * have any payload chunks.
+         * 
+         * @return {boolean} true if the payload application data is encrypted. Will be false
+         *         for error messages.
+         */
+        encryptsPayloads: function encryptsPayloads() {
+            // Return false for error messages.
+            var messageHeader = this.getMessageHeader();
+            if (!messageHeader)
+                return false;
+            
+            // If the message uses entity authentication data for an entity
+            // authentication scheme that provides encryption, return true.
+            var entityAuthData = messageHeader.entityAuthenticationData;
+            if (entityAuthData && entityAuthData.scheme.encrypts)
+                return true;
+            
+            // If the message uses a master token, return true.
+            var masterToken = messageHeader.masterToken;
+            if (masterToken)
+                return true;
+            
+            // If the message includes key response data, return true.
+            var keyResponseData = messageHeader.keyResponseData;
+            if (keyResponseData)
+                return true;
+            
+            // Otherwise return false.
+            return false;
+        },
+        
+        /**
+         * Returns true if the payload application data is integrity protected.
+         * This will be true if the entity authentication scheme provides integrity
+         * protection or if session keys were used. Returns false for error
+         * messages which do not have any payload chunks.
+         * 
+         * @return {boolean} true if the payload application data is integrity protected.
+         *         Will be false for error messages.
+         */
+        protectsPayloadIntegrity: function protectsPayloadIntegrity() {
+            // Return false for error messages.
+            var messageHeader = this.getMessageHeader();
+            if (!messageHeader)
+                return false;
+            
+            // If the message uses entity authentication data for an entity
+            // authentication scheme that provides integrity protection, return
+            // true.
+            var entityAuthData = messageHeader.entityAuthenticationData;
+            if (entityAuthData && entityAuthData.scheme.protectsIntegrity)
+                return true;
+            
+            // If the message uses a master token, return true.
+            var masterToken = messageHeader.masterToken;
+            if (masterToken)
+                return true;
+            
+            // If the message includes key response data, return true.
+            var keyResponseData = messageHeader.keyResponseData;
+            if (keyResponseData)
+                return true;
+            
+            // Otherwise return false.
+            return false;
         },
 
         /**


### PR DESCRIPTION
Resolves #279. Add encryptsPayloads() and protectsPayloadIntegrity() functions to MessageInputStream and MessageOutputStream.