### PR TITLE
configure javadoc task properly

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile 'org.json:json:20140107'
 }
 
-task javadoc(type: Javadoc, overwrite: true) {
+javadoc {
     options.overview = "overview.html"
     options.links = [
         "http://docs.oracle.com/javase/7/docs/api/",


### PR DESCRIPTION
New versions of gradle will fail this build because replacing existing tasks is not supported anymore: https://stash.corp.netflix.com/projects/SPE/repos/msl-core/compare/commits?sourceBranch=refs/heads/fix-javadoc-task

Error message:

```
Caused by: java.lang.IllegalStateException: Replacing an existing task that may have already been used by other plugins is not supported.  Use a different name for this task ('javadoc').
``` 

Solution is to configure `javadoc` task instead