### PR TITLE
JavaScript dependency fixes and update to jshint v2.9.6 and jsrsasign v8.0.15.

### DIFF
--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@
 	var SessionCryptoContext = require('../crypto/SessionCryptoContext.js');
 	var MslEntityAuthException = require('../MslEntityAuthException.js');
 	var MslEncodable = require('../io/MslEncodable.js');
+	var MslEncoderUtils = require('../io/MslEncoderUtils.js');
 	var AsyncExecutor = require('../util/AsyncExecutor.js');
 	var MslConstants = require('../MslConstants.js');
 	var MslInternalException = require('../MslInternalException.js');

--- a/core/src/main/javascript/package.json
+++ b/core/src/main/javascript/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "jshint": "^2.9.6",
-    "jsrsasign": "^7.2.2"
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15"
   }
 }

--- a/examples/simple/src/main/javascript/client/package.json
+++ b/examples/simple/src/main/javascript/client/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "clarinet": "^0.11.0",
-    "jsrsasign": "^7.2.2",
-    "jshint": "^2.9.5"
+    "jsrsasign": "^8.0.15",
+    "jshint": "^2.11.1"
   }
 }

--- a/integ-tests/src/test/javascript/package.json
+++ b/integ-tests/src/test/javascript/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "ec-key": "0.0.2",
     "elliptic": "^6.4.0",
-    "jshint": "^2.9.5",
-    "jsrsasign": "^7.2.2",
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15",
     "ursa": "^0.9.4"
   }
 }

--- a/tests/src/main/cpp/util/MslTestUtils.cpp
+++ b/tests/src/main/cpp/util/MslTestUtils.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -273,9 +273,12 @@ set<shared_ptr<ServiceToken>> getMasterBoundServiceTokens(shared_ptr<MslContext>
 	shared_ptr<ICryptoContext> cryptoContext = make_shared<NullCryptoContext>();
 	set<shared_ptr<ServiceToken>> tokens;
 	for (int count = random->nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+        stringstream ss;
+        ss << SERVICE_TOKEN_NAME << random->nextInt();
+        const string name = ss.str();
 		shared_ptr<ByteArray> data = make_shared<ByteArray>(8);
 		random->nextBytes(*data);
-		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, "masterbound" + to_string(count), data, masterToken, shared_ptr<UserIdToken>(), false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
+		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, name, data, masterToken, shared_ptr<UserIdToken>(), false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
 		tokens.insert(token);
 	}
 	return tokens;
@@ -288,9 +291,12 @@ set<shared_ptr<ServiceToken>> getUserBoundServiceTokens(shared_ptr<MslContext> c
 	shared_ptr<ICryptoContext> cryptoContext = make_shared<NullCryptoContext>();
 	set<shared_ptr<ServiceToken>> tokens;
 	for (int count = random->nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+        stringstream ss;
+        ss << SERVICE_TOKEN_NAME << random->nextInt();
+        const string name = ss.str();
 		shared_ptr<ByteArray> data = make_shared<ByteArray>(8);
 		random->nextBytes(*data);
-		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, "masterbound" + to_string(count), data, masterToken, userIdToken, false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
+		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, name, data, masterToken, userIdToken, false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
 		tokens.insert(token);
 	}
 	return tokens;

--- a/tests/src/main/java/com/netflix/msl/util/MslTestUtils.java
+++ b/tests/src/main/java/com/netflix/msl/util/MslTestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,9 +238,10 @@ public class MslTestUtils {
         final ICryptoContext cryptoContext = new NullCryptoContext();
         final Set<ServiceToken> tokens = new HashSet<ServiceToken>();
         for (int count = random.nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+            final String name = SERVICE_TOKEN_NAME + random.nextInt();
             final byte[] data = new byte[8];
             random.nextBytes(data);
-            final ServiceToken token = new ServiceToken(ctx, "masterbound" + count, data, masterToken, null, false, null, cryptoContext);
+            final ServiceToken token = new ServiceToken(ctx, name, data, masterToken, null, false, null, cryptoContext);
             tokens.add(token);
         }
         return tokens;
@@ -262,9 +263,10 @@ public class MslTestUtils {
         final ICryptoContext cryptoContext = new NullCryptoContext();
         final Set<ServiceToken> tokens = new HashSet<ServiceToken>();
         for (int count = random.nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+            final String name = SERVICE_TOKEN_NAME + random.nextInt();
             final byte[] data = new byte[8];
             random.nextBytes(data);
-            final ServiceToken token = new ServiceToken(ctx, "userbound" + count, data, masterToken, userIdToken, false, null, cryptoContext);
+            final ServiceToken token = new ServiceToken(ctx, name, data, masterToken, userIdToken, false, null, cryptoContext);
             tokens.add(token);
         }
         return tokens;

--- a/tests/src/main/javascript/package.json
+++ b/tests/src/main/javascript/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "ec-key": "0.0.2",
     "elliptic": "^6.4.1",
-    "jshint": "^2.9.6",
-    "jsrsasign": "^7.2.2",
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15",
     "ursa": "^0.9.4"
   }
 }

--- a/tests/src/main/javascript/util/MslTestUtils.js
+++ b/tests/src/main/javascript/util/MslTestUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -374,10 +374,11 @@
 	    			callback.result(tokens);
 	    			return;
 	    		}
-	    		
+
+                var name = SERVICE_TOKEN_NAME + random.nextInt();
 	    		var data = new Uint8Array(8);
 	            random.nextBytes(data);
-	            ServiceToken.create(ctx, "masterbound" + count, data, masterToken, null, false, null, cryptoContext, {
+	            ServiceToken.create(ctx, name, data, masterToken, null, false, null, cryptoContext, {
 	            	result: function(token) {
 	            		tokens.push(token);
 	            		--count;
@@ -414,10 +415,11 @@
 	    			callback.result(tokens);
 	    			return;
 	    		}
-	    		
+
+                var name = SERVICE_TOKEN_NAME + random.nextInt();
 	    		var data = new Uint8Array(8);
 	            random.nextBytes(data);
-	            ServiceToken.create(ctx, "userbound" + count, data, masterToken, userIdToken, false, null, cryptoContext, {
+	            ServiceToken.create(ctx, name, data, masterToken, userIdToken, false, null, cryptoContext, {
 	            	result: function(token) {
 	            		tokens.push(token);
 	            		--count;

--- a/tests/src/test/javascript/msg/MessageOutputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageOutputStreamTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ describe("MessageOutputStream", function() {
     var MessageHeader = require('msl-core/msg/MessageHeader.js');
     var MslConstants = require('msl-core/MslConstants.js');
     var EntityAuthenticationScheme = require('msl-core/entityauth/EntityAuthenticationScheme.js');
+    var UnauthenticatedAuthenticationData = require('msl-core/entityauth/UnauthenticatedAuthenticationData.js');
+    var PresharedAuthenticationData = require('msl-core/entityauth/PresharedAuthenticationData.js');
+    var RsaAuthenticationData = require('msl-core/entityauth/RsaAuthenticationData.js');
     var ErrorHeader = require('msl-core/msg/ErrorHeader.js');
     var MessageOutputStream = require('msl-core/msg/MessageOutputStream.js');
     var ByteArrayInputStream = require('msl-core/io/ByteArrayInputStream.js');
@@ -44,9 +47,13 @@ describe("MessageOutputStream", function() {
     var MslError = require('msl-core/MslError.js');
     var MslIoException = require('msl-core/MslIoException.js');
     var TextEncoding = require('msl-core/util/TextEncoding.js');
+    var SymmetricWrappedExchange = require('msl-core/keyx/SymmetricWrappedExchange.js');
 
     var MslTestConstants = require('msl-tests/MslTestConstants.js');
+    var MockRsaAuthenticationFactory = require('msl-tests/entityauth/MockRsaAuthenticationFactory.js');
+    var MockPresharedAuthenticationFactory = require('msl-tests/entityauth/MockPresharedAuthenticationFactory.js');
     var MockMslContext = require('msl-tests/util/MockMslContext.js');
+    var MslTestUtils = require('msl-tests/util/MslTestUtils.js');
 
     /** MSL encoder format. */
     var ENCODER_FORMAT = MslEncoderFormat.JSON;

--- a/tests/src/test/javascript/package.json
+++ b/tests/src/test/javascript/package.json
@@ -26,8 +26,8 @@
   "devDependencies": {
     "ec-key": "0.0.2",
     "elliptic": "^6.4.0",
-    "jshint": "^2.9.5",
-    "jsrsasign": "^7.2.2",
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15",
     "ursa": "^0.9.4"
   }
 }


### PR DESCRIPTION
* Add missing requires.
* Update to jshint v2.9.6 and jsrsasign v8.0.15 to address reported vulnerabilities.
* Use random names for service tokens generated by `MslTestUtils`.