### PR TITLE
Properly support multiple service tokens with the same name

### DIFF
--- a/core/.cproject
+++ b/core/.cproject
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
 	<storageModule moduleId="org.eclipse.cdt.core.settings">
-		<cconfiguration id="cdt.managedbuild.config.gnu.cross.so.debug.1261219416">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.so.debug.1261219416" moduleId="org.eclipse.cdt.core.settings" name="Debug">
+		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245" moduleId="org.eclipse.cdt.core.settings" name="Debug">
 				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
@@ -19,53 +19,60 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.so.debug.1261219416" name="Debug" parent="cdt.managedbuild.config.gnu.cross.so.debug.1261219416">
-					<folderInfo id="cdt.managedbuild.config.gnu.cross.so.debug.1261219416." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.1509381860" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.1545236221" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder buildPath="${workspace_loc:/msl-core}/Debug" id="cdt.managedbuild.target.gnu.builder.macosx.base.1571561825" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.507331917" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1472061821" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base"/>
-							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.1814914243" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1310765810" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245" name="Debug" parent="cdt.managedbuild.config.gnu.cross.exe.debug" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245." name="/" resourcePath="">
+						<toolChain errorParsers="" id="cdt.managedbuild.toolchain.gnu.macosx.base.1383669104" name="MacOSX GCC" nonInternalBuilderId="cdt.managedbuild.builder.gnu.cross" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.439436129" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
+							<builder buildPath="${workspace_loc:/msl-core}/Debug" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.builder.gnu.cross.2004559693" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.575684029" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
+							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1855195074" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base"/>
+							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.1968779818" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1573204453" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1375916378" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="/usr/local/bin/g++-7" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.458508960" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
-								<option id="gnu.cpp.compiler.option.include.paths.2016204762" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+							<tool command="ar" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="" id="cdt.managedbuild.tool.gnu.archiver.macosx.base.102444448" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.2071770013" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+								<option id="gnu.cpp.compiler.option.include.paths.682364181" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.1122826244" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option id="gnu.cpp.compiler.option.preprocessor.def.1840885606" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
 									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
 									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.1875088536" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.89084273" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.1076832623" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.default" valueType="enumerated"/>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.511782228" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+								<option id="gnu.cpp.compiler.option.optimization.level.1952647787" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.1618084455" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.485256826" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.759579935" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.145763403" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
-								<option id="gnu.c.compiler.option.include.paths.1305836267" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+							<tool command="/usr/local/bin/gcc-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1176226158" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+								<option id="gnu.c.compiler.option.include.paths.15704130" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.349824378" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.1041658437" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.38550529" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1347910571" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.106542641" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+								</option>
+								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.1817484847" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.2096512286" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.1667377217" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1867512074" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/main/cpp"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
-		<cconfiguration id="cdt.managedbuild.config.gnu.cross.so.release.1284340631">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.so.release.1284340631" moduleId="org.eclipse.cdt.core.settings" name="Release">
+		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659" moduleId="org.eclipse.cdt.core.settings" name="Release">
 				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
@@ -82,53 +89,61 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.so.release.1284340631" name="Release" parent="cdt.managedbuild.config.gnu.cross.so.release.1284340631">
-					<folderInfo id="cdt.managedbuild.config.gnu.cross.so.release.1284340631." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.2051073119" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.10637246" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder buildPath="${workspace_loc:/msl-core}/Release" id="cdt.managedbuild.target.gnu.builder.macosx.base.2115596878" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.864474851" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.552096915" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.891263051" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1540364342" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659" name="Release" parent="cdt.managedbuild.config.gnu.cross.exe.release" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659." name="/" resourcePath="">
+						<toolChain errorParsers="" id="cdt.managedbuild.toolchain.gnu.macosx.base.440047286" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.486771602" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
+							<builder buildPath="${workspace_loc:/msl-core}/Release" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.target.gnu.builder.macosx.base.1142674050" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
+							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.780739361" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
+							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1179594792" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base"/>
+							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.2131443798" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.828932783" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.2133422945" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="/usr/local/bin/g++-7" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1119489500" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
-								<option id="gnu.cpp.compiler.option.include.paths.1221189470" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+							<tool command="ar" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="" id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1422978416" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.585589160" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+								<option id="gnu.cpp.compiler.option.include.paths.594456184" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.1724244947" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option id="gnu.cpp.compiler.option.preprocessor.def.578659221" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.optimization.level.2091881550" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.1012424629" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.1725855378" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.1996849848" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1589424196" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.1212295418" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.125317467" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1928762903" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool command="/usr/local/bin/gcc-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1953264969" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+								<option id="gnu.c.compiler.option.include.paths.1658347758" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
+								</option>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.1420430963" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
 									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
 									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.1462561464" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.272641924" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.1880281542" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.default" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.other.350650808" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.warnings.extrawarn.137319089" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.toerrors.677687723" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.222076141" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.1263909706" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.wconversion.1994651281" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.other.other.388119371" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0" valueType="string"/>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.2023418286" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
-							</tool>
-							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.953879823" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
-								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.193423605" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.1590413777" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.1707864846" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.include.paths.1644780074" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
-								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1011007670" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.544636181" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.most" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.1184770750" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.741070673" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.148001690" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.1509173346" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.809298230" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.1144677001" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1982198313" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/main/cpp"/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/core/src/main/cpp/crypto/opensslImpl/diffieHellman.cpp
+++ b/core/src/main/cpp/crypto/opensslImpl/diffieHellman.cpp
@@ -52,24 +52,47 @@ void dhGenKeyPair(const ByteArray& p, const ByteArray& g, ByteArray& pubKey, Byt
     BigNum gbn(BN_bin2bn(&g[0], CheckedNumeric<int>::cast(gSize).ValueOrDie(), NULL));
     if (!gbn.get())
         throw MslInternalException("dhGenKeyPair: BN_bin2bn() error making bignum g");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!(dh.get()->p = BN_dup(pbn.get())))
         throw MslInternalException("dhGenKeyPair: BN_dup() unable to duplicate DH prime");
     if (!(dh.get()->g = BN_dup(gbn.get())))
         throw MslInternalException("dhGenKeyPair: BN_dup() unable to duplicate DH generator");
+#else
+    BIGNUM * dupP = BN_dup(pbn.get());
+    if (!dupP)
+        throw MslInternalException("dhGenKeyPair: BN_dup() unable to duplicate DH prime");
+    BIGNUM * dupG = BN_dup(pbn.get());
+    if (!dupG)
+        throw MslInternalException("dhGenKeyPair: BN_dup() unable to duplicate DH generator");
+    if (!DH_set0_pqg(dh.get(), dupP, NULL, dupG))
+        throw MslInternalException("dhGenKeyPair: unable to set DH prime and generator");
+#endif
 
     // Generate the public/private key pair
     if (!DH_generate_key(dh.get()))
         throw MslInternalException("dhGenKeyPair: DH_generate_key() unable to generate key pair");
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     const BIGNUM * const pubBn = dh.get()->pub_key;
+#else
+    const BIGNUM * const pubBn = DH_get0_pub_key(dh.get());
+#endif
     const int pubSizeBytes = BN_num_bytes(pubBn);
+    if (pubSizeBytes == 0)
+        throw MslInternalException("dhGenKeyPair: DH_generate_key() generated zero-length public key");
     ByteArray pubBuf(static_cast<const size_t>(pubSizeBytes), 0);
     int sizeResult = BN_bn2bin(pubBn, &pubBuf[0]); (void) sizeResult;
     if (sizeResult != pubSizeBytes)
         throw MslInternalException("dhGenKeyPair: BN_bn2bin() error converting public key");
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     const BIGNUM * const privBn = dh.get()->priv_key;
+#else
+    const BIGNUM * const privBn = DH_get0_priv_key(dh.get());
+#endif
     const int privSizeBytes = BN_num_bytes(privBn);
+    if (privSizeBytes == 0)
+        throw MslInternalException("dhGenKeyPair: DH_generate_key() generated zero-length private key");
     ByteArray privBuf(static_cast<const size_t>(privSizeBytes), 0);
     sizeResult = BN_bn2bin(privBn, &privBuf[0]); (void) sizeResult;
     if (sizeResult != privSizeBytes)
@@ -98,14 +121,34 @@ void dhComputeSharedSecret(const ByteArray& remotePublicKey, const ByteArray& p,
     BigNum pbn(BN_bin2bn(&p[0], CheckedNumeric<int>::cast(pSize).ValueOrDie(), NULL));
     if (!pbn.get())
         throw MslInternalException("computeSharedSecret: BN_bin2bn() error making bignum from p");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!(dh.get()->p = BN_dup(pbn.get())))
         throw MslInternalException("computeSharedSecret: BN_dup() unable to duplicate DH prime");
+#else
+    BIGNUM * dupN = BN_dup(pbn.get());
+    if (!dupN)
+        throw MslInternalException("computeSharedSecret: BN_dup() unable to duplicate DH prime");
+    const BIGNUM * g = DH_get0_g(dh.get());
+    BIGNUM * dupG = (g != NULL) ? BN_dup(g) : NULL;
+    if (!dupG)
+        throw MslInternalException("computeSharedSecret: BN_dup() unable to duplicate DH generator");
+    if (!DH_set0_pqg(dh.get(), dupN, NULL, dupG))
+        throw MslInternalException("dhGenKeyPair: unable to set DH prime and generator");
+#endif
     CheckedNumeric<size_t> localPrivateKeySize(localPrivateKey.size());
     BigNum localPrivateKeyBn(BN_bin2bn(&localPrivateKey[0], CheckedNumeric<int>::cast(localPrivateKeySize).ValueOrDie(), NULL));
     if (!localPrivateKeyBn.get())
         throw MslInternalException("computeSharedSecret: BN_bin2bn() error making bignum from private key");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!(dh.get()->priv_key = BN_dup(localPrivateKeyBn.get())))
         throw MslInternalException("computeSharedSecret: BN_dup() unable to duplicate DH private key");
+#else
+    BIGNUM * dupPrivKey = BN_dup(localPrivateKeyBn.get());
+    if (!dupPrivKey)
+        throw MslInternalException("computeSharedSecret: BN_dup() unable to duplicate DH private key");
+    if (!DH_set0_key(dh.get(), NULL, dupPrivKey))
+        throw MslInternalException("computeSharedSecret: unable to set DH private key");
+#endif
 
     // make remotePublicKey into a BIGNUM
     CheckedNumeric<size_t> remotePublicKeySize(remotePublicKey.size());

--- a/core/src/main/cpp/crypto/opensslImpl/digest.cpp
+++ b/core/src/main/cpp/crypto/opensslImpl/digest.cpp
@@ -19,6 +19,7 @@
 #include <MslInternalException.h>
 #include <numerics/safe_math.h>
 #include <openssl/evp.h>
+#include <openssl/opensslv.h>
 #include <util/ScopedDisposer.h>
 
 using namespace std;
@@ -34,7 +35,11 @@ void digest(const string& spec, const ByteArray& data, ByteArray& md)
 {
     OpenSslErrStackTracer errTracer;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ScopedDisposer<EVP_MD_CTX, void, EVP_MD_CTX_destroy> evpMd(EVP_MD_CTX_create());
+#else
+    ScopedDisposer<EVP_MD_CTX, void, EVP_MD_CTX_free> evpMd(EVP_MD_CTX_new());
+#endif
     if (!evpMd.get())
         throw MslInternalException("digest: EVP_MD_CTX_create unable to create EVP_MD_CTX");
 

--- a/core/src/main/cpp/crypto/opensslImpl/rsa.cpp
+++ b/core/src/main/cpp/crypto/opensslImpl/rsa.cpp
@@ -29,6 +29,7 @@
 #include <openssl/evp.h>
 
 #include <openssl/x509.h>
+#include <openssl/opensslv.h>
 #include <stdint.h>
 #include <util/ScopedDisposer.h>
 #include <vector>
@@ -114,7 +115,11 @@ void sign(EVP_PKEY* pkey, const ByteArray& data, ByteArray& signature)
     if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
         throw MslCryptoException(MslError::INVALID_PRIVATE_KEY);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ScopedDisposer<EVP_MD_CTX, void, EVP_MD_CTX_destroy> ctx(EVP_MD_CTX_create());
+#else
+    ScopedDisposer<EVP_MD_CTX, void, EVP_MD_CTX_free> ctx(EVP_MD_CTX_new());
+#endif
     if (ctx.isEmpty())
         throw MslInternalException("EVP_MD_CTX_new failed.");
     EVP_PKEY_CTX* pctx = NULL;  // Owned by |ctx|.
@@ -147,7 +152,11 @@ bool verify(EVP_PKEY* pkey, const ByteArray& data, const ByteArray& signature)
     if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
         throw MslCryptoException(MslError::INVALID_PUBLIC_KEY);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ScopedDisposer<EVP_MD_CTX, void, EVP_MD_CTX_destroy> ctx(EVP_MD_CTX_create());
+#else
+    ScopedDisposer<EVP_MD_CTX, void, EVP_MD_CTX_free> ctx(EVP_MD_CTX_new());
+#endif
     if (ctx.isEmpty())
         throw MslInternalException("EVP_MD_CTX_new failed.");
     EVP_PKEY_CTX* pctx = NULL;  // Owned by |ctx|.

--- a/core/src/main/cpp/msg/MessageBuilder.cpp
+++ b/core/src/main/cpp/msg/MessageBuilder.cpp
@@ -460,6 +460,11 @@ shared_ptr<MessageBuilder> MessageBuilder::addServiceTokenIfAbsent(shared_ptr<Se
 	return shared_from_this();
 }
 
+shared_ptr<MessageBuilder> MessageBuilder::excludeServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return excludeServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
+}
+
 shared_ptr<MessageBuilder> MessageBuilder::excludeServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
     set<shared_ptr<ServiceToken>>::iterator tokens = serviceTokens_.begin();
@@ -475,6 +480,11 @@ shared_ptr<MessageBuilder> MessageBuilder::excludeServiceToken(const string& nam
         }
     }
 	return shared_from_this();
+}
+
+shared_ptr<MessageBuilder> MessageBuilder::deleteServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return deleteServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
 }
 
 shared_ptr<MessageBuilder> MessageBuilder::deleteServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
@@ -590,6 +600,11 @@ shared_ptr<MessageBuilder> MessageBuilder::addPeerServiceTokenIfAbsent(shared_pt
 	return shared_from_this();
 }
 
+shared_ptr<MessageBuilder> MessageBuilder::excludePeerServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return excludePeerServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
+}
+
 shared_ptr<MessageBuilder> MessageBuilder::excludePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
     set<shared_ptr<ServiceToken>>::iterator tokens = peerServiceTokens_.begin();
@@ -605,6 +620,11 @@ shared_ptr<MessageBuilder> MessageBuilder::excludePeerServiceToken(const string&
         }
     }
 	return shared_from_this();
+}
+
+shared_ptr<MessageBuilder> MessageBuilder::deletePeerServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return deletePeerServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
 }
 
 shared_ptr<MessageBuilder> MessageBuilder::deletePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)

--- a/core/src/main/cpp/msg/MessageBuilder.cpp
+++ b/core/src/main/cpp/msg/MessageBuilder.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,18 +152,26 @@ void MessageBuilder::initializeMessageBuilder(
 	// Set the initial service tokens based on the MSL store and provided
 	// service tokens.
 	set<shared_ptr<ServiceToken>> tokens = ctx_->getMslStore()->getServiceTokens(serviceMasterToken, userIdToken);
-	for (set<shared_ptr<ServiceToken>>::iterator token = tokens.begin();
-		 token != tokens.end();
-		 ++token)
-	{
-		serviceTokens_.insert(make_pair((*token)->getName(), *token));
-	}
+	serviceTokens_.insert(tokens.begin(), tokens.end());
 	for (set<shared_ptr<ServiceToken>>::iterator token = serviceTokens.begin();
 		 token != serviceTokens.end();
 		 ++token)
 	{
-		serviceTokens_.erase((*token)->getName());
-		serviceTokens_.insert(make_pair((*token)->getName(), *token));
+        // Make sure the service token is properly bound.
+        if ((*token)->isMasterTokenBound() && !(*token)->isBoundTo(serviceMasterToken)) {
+            stringstream ss;
+            ss << "st " << *token << "; mt " << serviceMasterToken;
+            throw MslMessageException(MslError::SERVICETOKEN_MASTERTOKEN_MISMATCH, ss.str()).setMasterToken(serviceMasterToken);
+        }
+        if ((*token)->isUserIdTokenBound() && !(*token)->isBoundTo(userIdToken)) {
+            stringstream ss;
+            ss << "st " << *token << "; uit " << userIdToken;
+            throw MslMessageException(MslError::SERVICETOKEN_USERIDTOKEN_MISMATCH, ss.str()).setMasterToken(serviceMasterToken).setUserIdToken(userIdToken);
+        }
+
+		// Add the service token.
+        serviceTokens_.erase(*token);
+		serviceTokens_.insert(*token);
 	}
 
 	// Set the peer-to-peer data.
@@ -182,18 +190,26 @@ void MessageBuilder::initializeMessageBuilder(
 		// Set the initial peer service tokens based on the MSL store and
 		// provided peer service tokens.
 		set<shared_ptr<ServiceToken>> peerTokens = ctx_->getMslStore()->getServiceTokens(peerServiceMasterToken, peerUserIdToken);
-		for (set<shared_ptr<ServiceToken>>::iterator peerToken = peerTokens.begin();
-				peerToken != peerTokens.end();
-				++peerToken)
-		{
-			peerServiceTokens_.insert(make_pair((*peerToken)->getName(), *peerToken));
-		}
+		peerServiceTokens_.insert(peerTokens.begin(), peerTokens.end());
 		for (set<shared_ptr<ServiceToken>>::iterator peerToken = peerServiceTokens.begin();
 			 peerToken != peerServiceTokens.end();
 			 ++peerToken)
 		{
-			peerServiceTokens_.erase((*peerToken)->getName());
-			peerServiceTokens_.insert(make_pair((*peerToken)->getName(), *peerToken));
+            // Make sure the service token is properly bound.
+            if ((*peerToken)->isMasterTokenBound() && !(*peerToken)->isBoundTo(peerMasterToken)) {
+                stringstream ss;
+                ss << "st " << *peerToken << "; mt " << peerMasterToken;
+                throw MslMessageException(MslError::SERVICETOKEN_MASTERTOKEN_MISMATCH, ss.str()).setMasterToken(peerMasterToken);
+            }
+            if ((*peerToken)->isUserIdTokenBound() && !(*peerToken)->isBoundTo(peerUserIdToken)) {
+                stringstream ss;
+                ss << "st " << *peerToken << "; uit " << peerUserIdToken;
+                throw MslMessageException(MslError::SERVICETOKEN_USERIDTOKEN_MISMATCH, ss.str()).setMasterToken(peerMasterToken).setUserIdToken(peerUserIdToken);
+            }
+
+            // Add the peer service token.
+            peerServiceTokens_.erase(*peerToken);
+			peerServiceTokens_.insert(*peerToken);
 		}
 	}
 }
@@ -229,13 +245,6 @@ shared_ptr<MessageHeader> MessageBuilder::getHeader()
 {
 	shared_ptr<KeyResponseData> response;
 	if (keyExchangeData_) response = keyExchangeData_->keyResponseData;
-	set<shared_ptr<ServiceToken>> tokens;
-	for (map<string,shared_ptr<ServiceToken>>::iterator token = serviceTokens_.begin();
-		 token != serviceTokens_.end();
-		 ++token)
-	{
-		tokens.insert(token->second);
-	}
 	int64_t nonReplayableId;
 	if (nonReplayable_) {
 		if (!masterToken_)
@@ -244,15 +253,8 @@ shared_ptr<MessageHeader> MessageBuilder::getHeader()
 	} else {
 		nonReplayableId = -1;
 	}
-	shared_ptr<HeaderData> headerData = make_shared<HeaderData>( messageId_, nonReplayableId, renewable_, handshake_, capabilities_, keyRequestData_, response, userAuthData_, userIdToken_, tokens);
-	set<shared_ptr<ServiceToken>> peerTokens;
-	for (map<string,shared_ptr<ServiceToken>>::iterator token = peerServiceTokens_.begin();
-		 token != peerServiceTokens_.end();
-		 ++token)
-	{
-		peerTokens.insert(token->second);
-	}
-	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(peerMasterToken_, peerUserIdToken_, peerTokens);
+	shared_ptr<HeaderData> headerData = make_shared<HeaderData>( messageId_, nonReplayableId, renewable_, handshake_, capabilities_, keyRequestData_, response, userAuthData_, userIdToken_, serviceTokens_);
+	shared_ptr<HeaderPeerData> peerData = make_shared<HeaderPeerData>(peerMasterToken_, peerUserIdToken_, peerServiceTokens_);
 
 	return createMessageHeader(ctx_, ctx_->getEntityAuthenticationData(), masterToken_, headerData, peerData);
 }
@@ -326,9 +328,9 @@ void MessageBuilder::setAuthTokens(shared_ptr<MasterToken> masterToken, shared_p
 	}
 
 	// Remove any service tokens that will no longer be bound.
-	map<string,shared_ptr<ServiceToken>>::iterator tokens = serviceTokens_.begin();
+	set<shared_ptr<ServiceToken>>::iterator tokens = serviceTokens_.begin();
 	while (tokens != serviceTokens_.end()) {
-		shared_ptr<ServiceToken> token = tokens->second;
+		shared_ptr<ServiceToken> token = *tokens;
 		if ((token->isUserIdTokenBound() && !token->isBoundTo(userIdToken)) ||
 			(token->isMasterTokenBound() && !token->isBoundTo(masterToken)))
 		{
@@ -346,8 +348,8 @@ void MessageBuilder::setAuthTokens(shared_ptr<MasterToken> masterToken, shared_p
 		 token != storedTokens.end();
 		 ++token)
 	{
-		serviceTokens_.erase((*token)->getName());
-		serviceTokens_.insert(make_pair((*token)->getName(), *token));
+	    excludeServiceToken((*token)->getName(), (*token)->isMasterTokenBound(), (*token)->isUserIdTokenBound());
+		serviceTokens_.insert(*token);
 	}
 
 	// Set the new authentication tokens.
@@ -432,39 +434,56 @@ shared_ptr<MessageBuilder> MessageBuilder::addServiceToken(shared_ptr<ServiceTok
 		throw MslMessageException(MslError::SERVICETOKEN_USERIDTOKEN_MISMATCH, ss.str()).setMasterToken(serviceMasterToken).setUserIdToken(userIdToken_);
 	}
 
+    // Remove any existing service token with the same name and bound state.
+    excludeServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
+
 	// Add the service token.
-	serviceTokens_.erase(serviceToken->getName());
-	serviceTokens_.insert(make_pair(serviceToken->getName(), serviceToken));
+	serviceTokens_.insert(serviceToken);
 	return shared_from_this();
 }
 
 shared_ptr<MessageBuilder> MessageBuilder::addServiceTokenIfAbsent(shared_ptr<ServiceToken> serviceToken)
 {
-	map<string,shared_ptr<ServiceToken>>::iterator it = serviceTokens_.find(serviceToken->getName());
-	if (it == serviceTokens_.end())
-		addServiceToken(serviceToken);
+    for (set<shared_ptr<ServiceToken>>::iterator tokens = serviceTokens_.begin();
+         tokens != serviceTokens_.end();
+         ++tokens)
+    {
+        shared_ptr<ServiceToken> token = (*tokens);
+        if (token->getName() == serviceToken->getName() &&
+            token->isMasterTokenBound() == serviceToken->isMasterTokenBound() &&
+            token->isUserIdTokenBound() == serviceToken->isUserIdTokenBound())
+        {
+            return shared_from_this();
+        }
+    }
+    addServiceToken(serviceToken);
 	return shared_from_this();
 }
 
-shared_ptr<MessageBuilder> MessageBuilder::excludeServiceToken(const string& name)
+shared_ptr<MessageBuilder> MessageBuilder::excludeServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
-	serviceTokens_.erase(name);
+    set<shared_ptr<ServiceToken>>::iterator tokens = serviceTokens_.begin();
+    while (tokens != serviceTokens_.end()) {
+        shared_ptr<ServiceToken> token = (*tokens);
+        if (token->getName() == name &&
+            token->isMasterTokenBound() == masterTokenBound &&
+            token->isUserIdTokenBound() == userIdTokenBound)
+        {
+            serviceTokens_.erase(tokens++);
+        } else {
+            ++tokens;
+        }
+    }
 	return shared_from_this();
 }
 
-shared_ptr<MessageBuilder> MessageBuilder::deleteServiceToken(const string& name)
+shared_ptr<MessageBuilder> MessageBuilder::deleteServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
-	// Do nothing if the original token does not exist.
-	map<string,shared_ptr<ServiceToken>>::iterator it = serviceTokens_.find(name);
-	if (it == serviceTokens_.end())
-		return shared_from_this();
-	shared_ptr<ServiceToken> originalToken = it->second;
-
 	// Rebuild the original token with empty service data.
 	shared_ptr<MasterToken> masterToken;
-	if (originalToken->isMasterTokenBound()) masterToken = masterToken_;
+	if (masterTokenBound) masterToken = masterToken_;
 	shared_ptr<UserIdToken> userIdToken;
-	if (originalToken->isUserIdTokenBound()) userIdToken = userIdToken_;
+	if (userIdTokenBound) userIdToken = userIdToken_;
 	try {
 		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx_, name, EMPTY_DATA, masterToken, userIdToken, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
 		return addServiceToken(token);
@@ -474,13 +493,7 @@ shared_ptr<MessageBuilder> MessageBuilder::deleteServiceToken(const string& name
 }
 
 set<shared_ptr<ServiceToken>> MessageBuilder::getServiceTokens() {
-	set<shared_ptr<ServiceToken>> tokens;
-	for (map<string,shared_ptr<ServiceToken>>::iterator serviceToken = serviceTokens_.begin();
-		 serviceToken != serviceTokens_.end();
-		 ++serviceToken)
-	{
-		tokens.insert(serviceToken->second);
-	}
+	set<shared_ptr<ServiceToken>> tokens(serviceTokens_);
 	return tokens;
 }
 
@@ -507,25 +520,16 @@ void MessageBuilder::setPeerAuthTokens(shared_ptr<MasterToken> masterToken, shar
 	}
 
 	// Remove any peer service tokens that will no longer be bound.
-	set<shared_ptr<ServiceToken>> tokens;
-	for (map<string,shared_ptr<ServiceToken>>::iterator token = peerServiceTokens_.begin();
-		 token != peerServiceTokens_.end();
-		 ++token)
-	{
-		tokens.insert(token->second);
-	}
-	for (set<shared_ptr<ServiceToken>>::iterator token = tokens.begin();
-		 token != tokens.end();
-		 ++token)
-	{
-		if ((*token)->isUserIdTokenBound() && !(*token)->isBoundTo(userIdToken)) {
-			peerServiceTokens_.erase((*token)->getName());
-			continue;
-		}
-		if ((*token)->isMasterTokenBound() && !(*token)->isBoundTo(masterToken)) {
-			peerServiceTokens_.erase((*token)->getName());
-			continue;
-		}
+	set<shared_ptr<ServiceToken>>::iterator tokens = peerServiceTokens_.begin();
+	while(tokens != peerServiceTokens_.end()) {
+	    shared_ptr<ServiceToken> token = *tokens;
+	    if ((token->isUserIdTokenBound() && !token->isBoundTo(userIdToken)) ||
+	        (token->isMasterTokenBound() && !token->isBoundTo(masterToken)))
+	    {
+	        peerServiceTokens_.erase(tokens++);
+	    } else {
+	        ++tokens;
+	    }
 	}
 
 	// Add any peer service tokens based on the MSL store if they are not
@@ -534,9 +538,8 @@ void MessageBuilder::setPeerAuthTokens(shared_ptr<MasterToken> masterToken, shar
 		 token != storedTokens.end();
 		 ++token)
 	{
-		map<string,shared_ptr<ServiceToken>>::iterator found = peerServiceTokens_.find((*token)->getName());
-		if (found == peerServiceTokens_.end())
-			peerServiceTokens_.insert(make_pair((*token)->getName(), (*token)));
+	    excludePeerServiceToken((*token)->getName(), (*token)->isMasterTokenBound(), (*token)->isUserIdTokenBound());
+	    peerServiceTokens_.insert(*token);
 	}
 
 	// Set the new peer authentication tokens.
@@ -546,8 +549,12 @@ void MessageBuilder::setPeerAuthTokens(shared_ptr<MasterToken> masterToken, shar
 
 shared_ptr<MessageBuilder> MessageBuilder::addPeerServiceToken(shared_ptr<ServiceToken> serviceToken)
 {
+    // If we are not in peer-to-peer mode then peer service tokens cannot
+    // be set.
 	if (!ctx_->isPeerToPeer())
 		throw MslInternalException("Cannot set peer service tokens when not in peer-to-peer mode.");
+
+    // Make sure the service token is properly bound.
 	if (serviceToken->isMasterTokenBound() && !serviceToken->isBoundTo(peerMasterToken_)) {
 		stringstream ss;
 		ss << "st " << serviceToken << "; mt " << peerMasterToken_;
@@ -559,39 +566,54 @@ shared_ptr<MessageBuilder> MessageBuilder::addPeerServiceToken(shared_ptr<Servic
 		throw MslMessageException(MslError::SERVICETOKEN_USERIDTOKEN_MISMATCH, ss.str()).setMasterToken(peerMasterToken_).setUserIdToken(peerUserIdToken_);
 	}
 
+    // Remove any existing service token with the same name and bound state.
+    excludePeerServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
+
 	// Add the peer service token.
-	peerServiceTokens_.erase(serviceToken->getName());
-	peerServiceTokens_.insert(make_pair(serviceToken->getName(), serviceToken));
+	peerServiceTokens_.insert(serviceToken);
 	return shared_from_this();
 }
 
 shared_ptr<MessageBuilder> MessageBuilder::addPeerServiceTokenIfAbsent(shared_ptr<ServiceToken> serviceToken)
 {
-	map<string,shared_ptr<ServiceToken>>::iterator it = peerServiceTokens_.find(serviceToken->getName());
-	if (it == peerServiceTokens_.end())
-		addPeerServiceToken(serviceToken);
+	set<shared_ptr<ServiceToken>>::iterator tokens = peerServiceTokens_.begin();
+	while (tokens != peerServiceTokens_.end()) {
+	    shared_ptr<ServiceToken> token = *tokens;
+	    if (token->getName() == serviceToken->getName() &&
+	        token->isMasterTokenBound() == serviceToken->isMasterTokenBound() &&
+	        token->isUserIdTokenBound() == serviceToken->isUserIdTokenBound())
+	    {
+	        return shared_from_this();
+	    }
+	}
+	addPeerServiceToken(serviceToken);
 	return shared_from_this();
 }
 
-shared_ptr<MessageBuilder> MessageBuilder::excludePeerServiceToken(const string& name)
+shared_ptr<MessageBuilder> MessageBuilder::excludePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
-	peerServiceTokens_.erase(name);
+    set<shared_ptr<ServiceToken>>::iterator tokens = peerServiceTokens_.begin();
+    while (tokens != peerServiceTokens_.end()) {
+        shared_ptr<ServiceToken> token = *tokens;
+        if (token->getName() == name &&
+            token->isMasterTokenBound() == masterTokenBound &&
+            token->isUserIdTokenBound() == userIdTokenBound)
+        {
+            peerServiceTokens_.erase(tokens++);
+        } else {
+            ++tokens;
+        }
+    }
 	return shared_from_this();
 }
 
-shared_ptr<MessageBuilder> MessageBuilder::deletePeerServiceToken(const string& name)
+shared_ptr<MessageBuilder> MessageBuilder::deletePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
-	// Do nothing if the original token does not exist.
-	map<string,shared_ptr<ServiceToken>>::iterator it = peerServiceTokens_.find(name);
-	if (it == peerServiceTokens_.end())
-		return shared_from_this();
-	shared_ptr<ServiceToken> originalToken = it->second;
-
 	// Rebuild the original token with empty service data.
 	shared_ptr<MasterToken> peerMasterToken;
-	if (originalToken->isMasterTokenBound()) peerMasterToken = peerMasterToken_;
+	if (masterTokenBound) peerMasterToken = peerMasterToken_;
 	shared_ptr<UserIdToken> peerUserIdToken;
-	if (originalToken->isUserIdTokenBound()) peerUserIdToken = peerUserIdToken_;
+	if (userIdTokenBound) peerUserIdToken = peerUserIdToken_;
 	try {
 		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx_, name, EMPTY_DATA, peerMasterToken, peerUserIdToken, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
 		return addPeerServiceToken(token);
@@ -600,16 +622,9 @@ shared_ptr<MessageBuilder> MessageBuilder::deletePeerServiceToken(const string& 
 	}
 }
 
-
 set<shared_ptr<ServiceToken>> MessageBuilder::getPeerServiceTokens()
 {
-	set<shared_ptr<ServiceToken>> tokens;
-	for (map<string,shared_ptr<ServiceToken>>::iterator serviceToken = peerServiceTokens_.begin();
-		 serviceToken != peerServiceTokens_.end();
-		 ++serviceToken)
-	{
-		tokens.insert(serviceToken->second);
-	}
+	set<shared_ptr<ServiceToken>> tokens(peerServiceTokens_);
 	return tokens;
 }
 

--- a/core/src/main/cpp/msg/MessageBuilder.h
+++ b/core/src/main/cpp/msg/MessageBuilder.h
@@ -314,34 +314,85 @@ public:
     std::shared_ptr<MessageBuilder> addServiceTokenIfAbsent(std::shared_ptr<tokens::ServiceToken> serviceToken);
 
     /**
+     * <p>Exclude a service token from the message. This matches the token name
+     * and whether or not it is bound to the master token or to a user ID
+     * token. It does not require the token to be bound to the exact same
+     * master token or user ID token that will be used in the message.</p>
+     *
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #excludeServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return this.
+     * @see #excludeServiceToken(String, boolean, boolean)
+     */
+    std::shared_ptr<MessageBuilder> excludeServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
+
+    /**
      * <p>Exclude a service token from the message matching all the specified
      * parameters. A false value for the master token bound or user ID token
      * bound parameters restricts exclusion to tokens that are not bound to a
      * master token or not bound to a user ID token respectively.</p>
      * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be excluded
+     * from the message. If a name is provided but both other parameters are
+     * false, then only an unbound service token with the same name will be
+     * excluded.</p>
+     *
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return this.
      */
     std::shared_ptr<MessageBuilder> excludeServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
     /**
+     * <p>Mark a service token for deletion.</p>
+     *
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #deleteServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return this.
+     */
+    std::shared_ptr<MessageBuilder> deleteServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
+
+    /**
      * <p>Mark a service token for deletion. A false value for the master token
-     * bound or user ID token bound parameters restricts exclusion to tokens
+     * bound or user ID token bound parameters restricts deletion to tokens
      * that are not bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be marked
+     * for deletion. If a name is provided but both other parameters are false,
+     * then only an unbound service token with the same name will be marked for
+     * deletion.</p>
+     *
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to delete a master token bound service token.
-     * @param userIdTokenBound true to delete a user ID token bound service token.
+     * @param masterTokenBound true to delete a master token bound service
+     *        token.
+     * @param userIdTokenBound true to delete a user ID token bound service
+     *        token.
      * @return this.
      */
     std::shared_ptr<MessageBuilder> deleteServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
@@ -411,35 +462,85 @@ public:
     std::shared_ptr<MessageBuilder> addPeerServiceTokenIfAbsent(std::shared_ptr<tokens::ServiceToken> serviceToken);
 
     /**
+     * <p>Exclude a peer service token from the message. This matches the token
+     * name and whether or not it is bound to the master token or to a user ID
+     * token. It does not require the token to be bound to the exact same
+     * master token or user ID token that will be used in the message.</p>
+     *
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #excludePeerServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return this.
+     */
+    std::shared_ptr<MessageBuilder> excludePeerServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
+
+    /**
      * <p>Exclude a peer service token from the message matching all the
      * specified parameters. A false value for the master token bound or user
      * ID token bound parameters restricts exclusion to tokens that are not
      * bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be excluded
+     * from the message. If a name is provided but both other parameters are
+     * false, then only an unbound service token with the same name will be
+     * excluded.</p>
+     *
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return this.
      */
     std::shared_ptr<MessageBuilder> excludePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
     /**
+     * <p>Mark a peer service token for deletion.</p>
+     *
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #deletePeerServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return this.
+     */
+    std::shared_ptr<MessageBuilder> deletePeerServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
+
+    /**
      * <p>Mark a peer service token for deletion. A false value for the master
-     * token bound or user ID token bound parameters restricts exclusion to
+     * token bound or user ID token bound parameters restricts deletion to
      * tokens that are not bound to a master token or not bound to a user ID
      * token respectively.</p>
      * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be marked
+     * for deletion. If a name is provided but both other parameters are false,
+     * then only an unbound service token with the same name will be marked for
+     * deletion.</p>
+     *
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to delete a master token bound service token.
-     * @param userIdTokenBound true to delete a user ID token bound service token.
+     * @param masterTokenBound true to delete a master token bound service
+     *        token.
+     * @param userIdTokenBound true to delete a user ID token bound service
+     *        token.
      * @return this.
      */
     std::shared_ptr<MessageBuilder> deletePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
@@ -457,7 +558,7 @@ protected:
      *
      * @param ctx MSL context.
      */
-    MessageBuilder(std::shared_ptr<util::MslContext> ctx) : ctx_(ctx) {}
+    MessageBuilder(std::shared_ptr<util::MslContext> ctx) : ctx_(ctx), messageId_(-1) {}
 
     /**
      * initialize a message builder with the provided tokens and key exchange

--- a/core/src/main/cpp/msg/MessageBuilder.h
+++ b/core/src/main/cpp/msg/MessageBuilder.h
@@ -390,7 +390,7 @@ public:
      * 
      * @param name service token name.
      * @param masterTokenBound true to delete a master token bound service
-     *        token.
+     *        token. Must be true if {@code userIdTokenBound} is true.
      * @param userIdTokenBound true to delete a user ID token bound service
      *        token.
      * @return this.
@@ -497,7 +497,7 @@ public:
      * 
      * @param name service token name.
      * @param masterTokenBound true to exclude a master token bound service
-     *        token.
+     *        token. Must be true if {@code userIdTokenBound} is true.
      * @param userIdTokenBound true to exclude a user ID token bound service
      *        token.
      * @return this.
@@ -538,7 +538,7 @@ public:
      * 
      * @param name service token name.
      * @param masterTokenBound true to delete a master token bound service
-     *        token.
+     *        token. Must be true if {@code userIdTokenBound} is true.
      * @param userIdTokenBound true to delete a user ID token bound service
      *        token.
      * @return this.

--- a/core/src/main/cpp/msg/MessageBuilder.h
+++ b/core/src/main/cpp/msg/MessageBuilder.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <MslError.h>
 #include <keyx/KeyExchangeFactory.h>
-#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -284,7 +283,8 @@ public:
 
     /**
      * <p>Add a service token to the message. This will overwrite any service
-     * token with the same name.</p>
+     * token with the same name that is also bound to the master token or user
+     * ID token in the same way as the new service token.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -299,7 +299,8 @@ public:
 
     /**
      * <p>Add a service token to the message if a service token with the same
-     * name does not already exist.</p>
+     * name that is also bound to the master token or user ID token in the same
+     * way as the new service token does not already exist.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -313,28 +314,37 @@ public:
     std::shared_ptr<MessageBuilder> addServiceTokenIfAbsent(std::shared_ptr<tokens::ServiceToken> serviceToken);
 
     /**
-     * <p>Exclude a service token from the message.</p>
+     * <p>Exclude a service token from the message matching all the specified
+     * parameters. A false value for the master token bound or user ID token
+     * bound parameters restricts exclusion to tokens that are not bound to a
+     * master token or not bound to a user ID token respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return this.
      */
-    std::shared_ptr<MessageBuilder> excludeServiceToken(const std::string& name);
+    std::shared_ptr<MessageBuilder> excludeServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
     /**
-     * <p>Mark a service token for deletion, if it exists. Otherwise this
-     * method does nothing.</p>
+     * <p>Mark a service token for deletion. A false value for the master token
+     * bound or user ID token bound parameters restricts exclusion to tokens
+     * that are not bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to delete a master token bound service token.
+     * @param userIdTokenBound true to delete a user ID token bound service token.
      * @return this.
      */
-    std::shared_ptr<MessageBuilder> deleteServiceToken(const std::string& name);
+    std::shared_ptr<MessageBuilder> deleteServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
     /**
      * @return the unmodifiable set of service tokens that will be included in
@@ -369,7 +379,8 @@ public:
 
     /**
      * <p>Add a peer service token to the message. This will overwrite any peer
-     * service token with the same name.</p>
+     * service token with the same name that is also bound to a peer master
+     * token or peer user ID token in the same way as the new service token.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -384,7 +395,9 @@ public:
 
     /**
      * <p>Add a peer service token to the message if a peer service token with
-     * the same name does not already exist.</p>
+     * the same name that is also bound to the peer master token or peer user
+     * ID token in the same way as the new service token does not already
+     * exist.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -398,28 +411,38 @@ public:
     std::shared_ptr<MessageBuilder> addPeerServiceTokenIfAbsent(std::shared_ptr<tokens::ServiceToken> serviceToken);
 
     /**
-     * <p>Exclude a peer service token from the message.</p>
+     * <p>Exclude a peer service token from the message matching all the
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return this.
      */
-    std::shared_ptr<MessageBuilder> excludePeerServiceToken(const std::string& name);
+    std::shared_ptr<MessageBuilder> excludePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
     /**
-     * <p>Mark a peer service token for deletion, if it exists. Otherwise this
-     * method does nothing.</p>
+     * <p>Mark a peer service token for deletion. A false value for the master
+     * token bound or user ID token bound parameters restricts exclusion to
+     * tokens that are not bound to a master token or not bound to a user ID
+     * token respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to delete a master token bound service token.
+     * @param userIdTokenBound true to delete a user ID token bound service token.
      * @return this.
      */
-    std::shared_ptr<MessageBuilder> deletePeerServiceToken(const std::string& name);
+    std::shared_ptr<MessageBuilder> deletePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
     /**
      * @return the unmodifiable set of peer service tokens that will be
@@ -523,15 +546,15 @@ protected:
     std::shared_ptr<userauth::UserAuthenticationData> userAuthData_;
     /** Header data user ID token. */
     std::shared_ptr<tokens::UserIdToken> userIdToken_;
-    /** Header data service tokens keyed off token name. */
-    std::map<std::string,std::shared_ptr<tokens::ServiceToken>> serviceTokens_;
+    /** Header data service tokens. */
+    std::set<std::shared_ptr<tokens::ServiceToken>> serviceTokens_;
 
     /** Header peer data master token. */
     std::shared_ptr<tokens::MasterToken> peerMasterToken_;
     /** Header peer data user ID token. */
     std::shared_ptr<tokens::UserIdToken> peerUserIdToken_;
-    /** Header peer data service tokens keyed off token name. */
-    std::map<std::string,std::shared_ptr<tokens::ServiceToken>> peerServiceTokens_;
+    /** Header peer data service tokens. */
+    std::set<std::shared_ptr<tokens::ServiceToken>> peerServiceTokens_;
 };
 
 }}} // namespace netflix::msl::msg

--- a/core/src/main/cpp/msg/MessageServiceTokenBuilder.cpp
+++ b/core/src/main/cpp/msg/MessageServiceTokenBuilder.cpp
@@ -277,6 +277,11 @@ bool MessageServiceTokenBuilder::addUserBoundPeerServiceToken(const string& name
 	return true;
 }
 
+bool MessageServiceTokenBuilder::excludePrimaryServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return excludePrimaryServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
+}
+
 bool MessageServiceTokenBuilder::excludePrimaryServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
 	// Exclude the service token if found.
@@ -296,6 +301,11 @@ bool MessageServiceTokenBuilder::excludePrimaryServiceToken(const string& name, 
 
 	// Not found.
 	return false;
+}
+
+bool MessageServiceTokenBuilder::excludePeerServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return excludePeerServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
 }
 
 bool MessageServiceTokenBuilder::excludePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
@@ -319,6 +329,11 @@ bool MessageServiceTokenBuilder::excludePeerServiceToken(const string& name, con
 	return false;
 }
 
+bool MessageServiceTokenBuilder::deletePrimaryServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return deletePrimaryServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
+}
+
 bool MessageServiceTokenBuilder::deletePrimaryServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
     // Mark the service token for deletion if found.
@@ -338,6 +353,11 @@ bool MessageServiceTokenBuilder::deletePrimaryServiceToken(const string& name, c
 
 	// Not found.
 	return false;
+}
+
+bool MessageServiceTokenBuilder::deletePeerServiceToken(shared_ptr<ServiceToken> serviceToken)
+{
+    return deletePeerServiceToken(serviceToken->getName(), serviceToken->isMasterTokenBound(), serviceToken->isUserIdTokenBound());
 }
 
 bool MessageServiceTokenBuilder::deletePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)

--- a/core/src/main/cpp/msg/MessageServiceTokenBuilder.cpp
+++ b/core/src/main/cpp/msg/MessageServiceTokenBuilder.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -277,7 +277,7 @@ bool MessageServiceTokenBuilder::addUserBoundPeerServiceToken(const string& name
 	return true;
 }
 
-bool MessageServiceTokenBuilder::excludePrimaryServiceToken(const string& name)
+bool MessageServiceTokenBuilder::excludePrimaryServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
 	// Exclude the service token if found.
 	set<shared_ptr<ServiceToken>> serviceTokens = builder_->getServiceTokens();
@@ -285,8 +285,11 @@ bool MessageServiceTokenBuilder::excludePrimaryServiceToken(const string& name)
 		 serviceToken != serviceTokens.end();
 		 ++serviceToken)
 	{
-		if ((*serviceToken)->getName() == name) {
-			builder_->excludeServiceToken(name);
+		if ((*serviceToken)->getName() == name &&
+		    (*serviceToken)->isMasterTokenBound() == masterTokenBound &&
+		    (*serviceToken)->isUserIdTokenBound() == userIdTokenBound)
+		{
+			builder_->excludeServiceToken(name, masterTokenBound, userIdTokenBound);
 			return true;
 		}
 	}
@@ -295,7 +298,7 @@ bool MessageServiceTokenBuilder::excludePrimaryServiceToken(const string& name)
 	return false;
 }
 
-bool MessageServiceTokenBuilder::excludePeerServiceToken(const string& name)
+bool MessageServiceTokenBuilder::excludePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
 	// Exclude the service token if found.
 	set<shared_ptr<ServiceToken>> serviceTokens = builder_->getPeerServiceTokens();
@@ -303,8 +306,11 @@ bool MessageServiceTokenBuilder::excludePeerServiceToken(const string& name)
 		 serviceToken != serviceTokens.end();
 		 ++serviceToken)
 	{
-		if ((*serviceToken)->getName() == name) {
-			builder_->excludePeerServiceToken(name);
+		if ((*serviceToken)->getName() == name &&
+	        (*serviceToken)->isMasterTokenBound() == masterTokenBound &&
+	        (*serviceToken)->isUserIdTokenBound() == userIdTokenBound)
+		{
+			builder_->excludePeerServiceToken(name, masterTokenBound, userIdTokenBound);
 			return true;
 		}
 	}
@@ -313,7 +319,7 @@ bool MessageServiceTokenBuilder::excludePeerServiceToken(const string& name)
 	return false;
 }
 
-bool MessageServiceTokenBuilder::deletePrimaryServiceToken(const string& name)
+bool MessageServiceTokenBuilder::deletePrimaryServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
     // Mark the service token for deletion if found.
 	set<shared_ptr<ServiceToken>> serviceTokens = builder_->getServiceTokens();
@@ -321,8 +327,11 @@ bool MessageServiceTokenBuilder::deletePrimaryServiceToken(const string& name)
 		 serviceToken != serviceTokens.end();
 		 ++serviceToken)
 	{
-		if ((*serviceToken)->getName() == name) {
-			builder_->deleteServiceToken(name);
+		if ((*serviceToken)->getName() == name &&
+	        (*serviceToken)->isMasterTokenBound() == masterTokenBound &&
+	        (*serviceToken)->isUserIdTokenBound() == userIdTokenBound)
+		{
+			builder_->deleteServiceToken(name, masterTokenBound, userIdTokenBound);
 			return true;
 		}
 	}
@@ -331,7 +340,7 @@ bool MessageServiceTokenBuilder::deletePrimaryServiceToken(const string& name)
 	return false;
 }
 
-bool MessageServiceTokenBuilder::deletePeerServiceToken(const string& name)
+bool MessageServiceTokenBuilder::deletePeerServiceToken(const string& name, const bool masterTokenBound, const bool userIdTokenBound)
 {
     // Mark the service token for deletion if found.
 	set<shared_ptr<ServiceToken>> serviceTokens = builder_->getPeerServiceTokens();
@@ -339,8 +348,11 @@ bool MessageServiceTokenBuilder::deletePeerServiceToken(const string& name)
 		 serviceToken != serviceTokens.end();
 		 ++serviceToken)
 	{
-		if ((*serviceToken)->getName() == name) {
-			builder_->deletePeerServiceToken(name);
+		if ((*serviceToken)->getName() == name &&
+	        (*serviceToken)->isMasterTokenBound() == masterTokenBound &&
+	        (*serviceToken)->isUserIdTokenBound() == userIdTokenBound)
+		{
+			builder_->deletePeerServiceToken(name, masterTokenBound, userIdTokenBound);
 			return true;
 		}
 	}

--- a/core/src/main/cpp/msg/MessageServiceTokenBuilder.h
+++ b/core/src/main/cpp/msg/MessageServiceTokenBuilder.h
@@ -299,8 +299,10 @@ public:
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the service token was found and therefore removed.
      */
     bool excludePrimaryServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
@@ -332,8 +334,10 @@ public:
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the peer service token was found and therefore removed.
      */
     bool excludePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
@@ -368,8 +372,10 @@ public:
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the service token exists and was marked for deletion.
      */
     bool deletePrimaryServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
@@ -404,8 +410,10 @@ public:
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the peer service token exists and was marked for
      *         deletion.
      */

--- a/core/src/main/cpp/msg/MessageServiceTokenBuilder.h
+++ b/core/src/main/cpp/msg/MessageServiceTokenBuilder.h
@@ -272,6 +272,23 @@ public:
     bool addUserBoundPeerServiceToken(const std::string& name, std::shared_ptr<ByteArray> data, bool encrypt, MslConstants::CompressionAlgorithm compressionAlgo);
     
     /**
+     * <p>Exclude a primary service token from the message. This matches the
+     * token name and whether or not it is bound to the master token or to a
+     * user ID token. It does not require the token to be bound to the exact
+     * same master token or user ID token that will be used in the message.</p>
+     *
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #excludePrimaryServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return true if the service token was found and therefore removed.
+     */
+    bool excludePrimaryServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
+
+    /**
      * <p>Exclude a primary service token from the message matching all
      * specified parameters. A false value for the master token bound or user
      * ID token bound parameters restricts exclusion to tokens that are not
@@ -287,6 +304,23 @@ public:
      * @return true if the service token was found and therefore removed.
      */
     bool excludePrimaryServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
+
+    /**
+     * <p>Exclude a peer service token from the message. This matches the
+     * token name and whether or not it is bound to the master token or to a
+     * user ID token. It does not require the token to be bound to the exact
+     * same master token or user ID token that will be used in the message.</p>
+     *
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #excludePeerServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return true if the service token was found and therefore removed.
+     */
+    bool excludePeerServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
     
     /**
      * <p>Exclude a peer service token from the message matching all specified
@@ -303,11 +337,29 @@ public:
      * @return true if the peer service token was found and therefore removed.
      */
     bool excludePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
+
+    /**
+     * <p>Mark a primary service token for deletion, if it exists. This matches
+     * the token name and whether or not it is bound to the master token or to
+     * a user ID token. It does not require the token to be bound to the exact
+     * same master token or user ID token that will be used in the message.</p>
+     *
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #deletePrimaryServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return true if the service token exists and was marked for deletion.
+     */
+    bool deletePrimaryServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
     
     /**
      * <p>Mark a primary service token for deletion, if it exists, matching all
      * specified parameters. A false value for the master token bound or user
-     * ID token bound parameters restricts exclusion to tokens that are not
+     * ID token bound parameters restricts deletion to tokens that are not
      * bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 
@@ -323,9 +375,27 @@ public:
     bool deletePrimaryServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
     
     /**
+     * <p>Mark a peer service token for deletion, if it exists. This matches
+     * the token name and whether or not it is bound to the master token or to
+     * a user ID token. It does not require the token to be bound to the exact
+     * same master token or user ID token that will be used in the message.</p>
+     *
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     *
+     * <p>This function is equivalent to calling
+     * {@link #deletePeerServiceToken(String, boolean, boolean)}.</p>
+     *
+     * @param serviceToken the service token.
+     * @return true if the service token exists and was marked for deletion.
+     */
+    bool deletePeerServiceToken(std::shared_ptr<tokens::ServiceToken> serviceToken);
+
+    /**
      * <p>Mark a peer service token for deletion, if it exists, matching all
      * specified parameters. A false value for the master token bound or user
-     * ID token bound parameters restricts exclusion to tokens that are not
+     * ID token bound parameters restricts deletion to tokens that are not
      * bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 

--- a/core/src/main/cpp/msg/MessageServiceTokenBuilder.h
+++ b/core/src/main/cpp/msg/MessageServiceTokenBuilder.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -272,51 +272,74 @@ public:
     bool addUserBoundPeerServiceToken(const std::string& name, std::shared_ptr<ByteArray> data, bool encrypt, MslConstants::CompressionAlgorithm compressionAlgo);
     
     /**
-     * <p>Exclude a primary service token from the message.</p>
+     * <p>Exclude a primary service token from the message matching all
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the service token was found and therefore removed.
      */
-    bool excludePrimaryServiceToken(const std::string& name);
+    bool excludePrimaryServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
     
     /**
-     * <p>Exclude a peer service token from the message.</p>
+     * <p>Exclude a peer service token from the message matching all specified
+     * parameters. A false value for the master token bound or user ID token
+     * bound parameters restricts exclusion to tokens that are not bound to a
+     * master token or not bound to a user ID token respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the peer service token was found and therefore removed.
      */
-    bool excludePeerServiceToken(const std::string& name);
+    bool excludePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
     
     /**
-     * <p>Mark a primary service token for deletion, if it exists.</p>
+     * <p>Mark a primary service token for deletion, if it exists, matching all
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the service token exists and was marked for deletion.
      */
-    bool deletePrimaryServiceToken(const std::string& name);
+    bool deletePrimaryServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
     
     /**
-     * <p>Mark a peer service token for deletion, if it exists.</p>
+     * <p>Mark a peer service token for deletion, if it exists, matching all
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the peer service token exists and was marked for
      *         deletion.
      */
-    bool deletePeerServiceToken(const std::string& name);
+    bool deletePeerServiceToken(const std::string& name, const bool masterTokenBound, const bool userIdTokenBound);
 
 private:
     /** MSL context. */

--- a/core/src/main/cpp/util/MslStore.h
+++ b/core/src/main/cpp/util/MslStore.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,20 +169,20 @@ public:
     virtual std::set<std::shared_ptr<tokens::ServiceToken>> getServiceTokens(std::shared_ptr<tokens::MasterToken> masterToken, std::shared_ptr<tokens::UserIdToken> userIdToken) = 0;
 
     /**
-     * <p>Remove all service tokens matching all the specified parameters.</p>
-     *
-     * <p>If a name is provided, only tokens with that name are removed. If a
-     * master token is provided, only tokens bound to that master token are
-     * removed. If a user ID token is provided, only tokens bound to that user
-     * ID token are removed.</p>
+     * <p>Remove all service tokens matching all the specified parameters. A
+     * null value for the master token or user ID token restricts removal to
+     * tokens that are not bound to a master token or not bound to a user ID
+     * token respectively.</p>
      *
      * <p>For example, if a name and master token is provided, only tokens with
-     * that name and bound to that master token are removed.</p>
+     * that name, bound to that master token, and not bound to a user ID token
+     * are removed.</p>
      *
      * <p>If no parameters are provided, no tokens are removed.</p>
      *
      * @param name service token name. May be null.
-     * @param masterToken master token. May be null.
+     * @param masterToken master token. May be null unless a user ID token is
+     *        also provided.
      * @param userIdToken user ID token. May be null.
      * @throws MslException if the user ID token is not bound to the master
      *         token.

--- a/core/src/main/cpp/util/MslStore.h
+++ b/core/src/main/cpp/util/MslStore.h
@@ -176,13 +176,13 @@ public:
      *
      * <p>For example, if a name and master token is provided, only tokens with
      * that name, bound to that master token, and not bound to a user ID token
-     * are removed.</p>
+     * are removed. If only a user ID token is provided, all tokens bound to
+     * that user ID token are removed.</p>
      *
      * <p>If no parameters are provided, no tokens are removed.</p>
      *
      * @param name service token name. May be null.
-     * @param masterToken master token. May be null unless a user ID token is
-     *        also provided.
+     * @param masterToken master token. May be null.
      * @param userIdToken user ID token. May be null.
      * @throws MslException if the user ID token is not bound to the master
      *         token.

--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -635,6 +635,26 @@ public class MessageBuilder {
         addServiceToken(serviceToken);
         return this;
     }
+    
+    /**
+     * <p>Exclude a service token from the message. This matches the token name
+     * and whether or not it is bound to the master token or to a user ID
+     * token. It does not require the token to be bound to the exact same
+     * master token or user ID token that will be used in the message.</p>
+     * 
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #excludeServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return this.
+     * @see #excludeServiceToken(String, boolean, boolean)
+     */
+    public MessageBuilder excludeServiceToken(final ServiceToken serviceToken) {
+        return excludeServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
 
     /**
      * <p>Exclude a service token from the message matching all the specified
@@ -642,12 +662,21 @@ public class MessageBuilder {
      * bound parameters restricts exclusion to tokens that are not bound to a
      * master token or not bound to a user ID token respectively.</p>
      * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be excluded
+     * from the message. If a name is provided but both other parameters are
+     * false, then only an unbound service token with the same name will be
+     * excluded.</p>
+     * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return this.
      */
     public MessageBuilder excludeServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
@@ -663,20 +692,46 @@ public class MessageBuilder {
         }
         return this;
     }
+    
+    /**
+     * <p>Mark a service token for deletion.</p>
+     * 
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #deleteServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return this.
+     */
+    public MessageBuilder deleteServiceToken(final ServiceToken serviceToken) {
+        return deleteServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
 
     /**
      * <p>Mark a service token for deletion. A false value for the master token
-     * bound or user ID token bound parameters restricts exclusion to tokens
+     * bound or user ID token bound parameters restricts deletion to tokens
      * that are not bound to a master token or not bound to a user ID token
      * respectively.</p>
+     * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be marked
+     * for deletion. If a name is provided but both other parameters are false,
+     * then only an unbound service token with the same name will be marked for
+     * deletion.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to delete a master token bound service token.
-     * @param userIdTokenBound true to delete a user ID token bound service token.
+     * @param masterTokenBound true to delete a master token bound service
+     *        token.
+     * @param userIdTokenBound true to delete a user ID token bound service
+     *        token.
      * @return this.
      */
     public MessageBuilder deleteServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
@@ -830,6 +885,25 @@ public class MessageBuilder {
         addPeerServiceToken(serviceToken);
         return this;
     }
+    
+    /**
+     * <p>Exclude a peer service token from the message. This matches the token
+     * name and whether or not it is bound to the master token or to a user ID
+     * token. It does not require the token to be bound to the exact same
+     * master token or user ID token that will be used in the message.</p>
+     * 
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #excludePeerServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return this.
+     */
+    public MessageBuilder excludePeerServiceToken(final ServiceToken serviceToken) {
+        return excludePeerServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
 
     /**
      * <p>Exclude a peer service token from the message matching all the
@@ -838,12 +912,21 @@ public class MessageBuilder {
      * bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be excluded
+     * from the message. If a name is provided but both other parameters are
+     * false, then only an unbound service token with the same name will be
+     * excluded.</p>
+     * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return this.
      */
     public MessageBuilder excludePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
@@ -859,20 +942,46 @@ public class MessageBuilder {
         }
         return this;
     }
+    
+    /**
+     * <p>Mark a peer service token for deletion.</p>
+     * 
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #deletePeerServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return this.
+     */
+    public MessageBuilder deletePeerServiceToken(final ServiceToken serviceToken) {
+        return deletePeerServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
 
     /**
      * <p>Mark a peer service token for deletion. A false value for the master
-     * token bound or user ID token bound parameters restricts exclusion to
+     * token bound or user ID token bound parameters restricts deletion to
      * tokens that are not bound to a master token or not bound to a user ID
      * token respectively.</p>
+     * 
+     * <p>For example, if a name is provided and the master token bound
+     * parameter is true while the user ID token bound parameter is false, then
+     * the master token bound service token with the same name will be marked
+     * for deletion. If a name is provided but both other parameters are false,
+     * then only an unbound service token with the same name will be marked for
+     * deletion.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to delete a master token bound service token.
-     * @param userIdTokenBound true to delete a user ID token bound service token.
+     * @param masterTokenBound true to delete a master token bound service
+     *        token.
+     * @param userIdTokenBound true to delete a user ID token bound service
+     *        token.
      * @return this.
      */
     public MessageBuilder deletePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {

--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -729,7 +729,7 @@ public class MessageBuilder {
      * 
      * @param name service token name.
      * @param masterTokenBound true to delete a master token bound service
-     *        token.
+     *        token. Must be true if {@code userIdTokenBound} is true.
      * @param userIdTokenBound true to delete a user ID token bound service
      *        token.
      * @return this.
@@ -924,7 +924,7 @@ public class MessageBuilder {
      * 
      * @param name service token name.
      * @param masterTokenBound true to exclude a master token bound service
-     *        token.
+     *        token. Must be true if {@code userIdTokenBound} is true.
      * @param userIdTokenBound true to exclude a user ID token bound service
      *        token.
      * @return this.
@@ -979,7 +979,7 @@ public class MessageBuilder {
      * 
      * @param name service token name.
      * @param masterTokenBound true to delete a master token bound service
-     *        token.
+     *        token. Must be true if {@code userIdTokenBound} is true.
      * @param userIdTokenBound true to delete a user ID token bound service
      *        token.
      * @return this.

--- a/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package com.netflix.msl.msg;
 
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.Iterator;
 import java.util.Set;
 
 import com.netflix.msl.MslConstants;
@@ -173,11 +171,18 @@ public class MessageBuilder {
         // Set the initial service tokens based on the MSL store and provided
         // service tokens.
         final Set<ServiceToken> tokens = ctx.getMslStore().getServiceTokens(serviceMasterToken, userIdToken);
-        for (final ServiceToken token : tokens)
-            this.serviceTokens.put(token.getName(), token);
+        this.serviceTokens.addAll(tokens);
         if (serviceTokens != null) {
-            for (final ServiceToken token : serviceTokens)
-                this.serviceTokens.put(token.getName(), token);
+            for (final ServiceToken token : serviceTokens) {
+                // Make sure the service token is properly bound.
+                if (token.isMasterTokenBound() && !token.isBoundTo(serviceMasterToken))
+                    throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + token + "; mt " + serviceMasterToken).setMasterToken(serviceMasterToken);
+                if (token.isUserIdTokenBound() && !token.isBoundTo(userIdToken))
+                    throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + token + "; uit " + userIdToken).setMasterToken(serviceMasterToken).setUserIdToken(userIdToken);
+                
+                // Add the service token.
+                this.serviceTokens.add(token);
+            }
         }
         
         // Set the peer-to-peer data.
@@ -196,11 +201,18 @@ public class MessageBuilder {
             // Set the initial peer service tokens based on the MSL store and
             // provided peer service tokens.
             final Set<ServiceToken> peerTokens = ctx.getMslStore().getServiceTokens(peerServiceMasterToken, peerUserIdToken);
-            for (final ServiceToken peerToken : peerTokens)
-                this.peerServiceTokens.put(peerToken.getName(), peerToken);
+            this.peerServiceTokens.addAll(peerTokens);
             if (peerServiceTokens != null) {
-                for (final ServiceToken peerToken : peerServiceTokens)
-                    this.peerServiceTokens.put(peerToken.getName(), peerToken);
+                for (final ServiceToken peerToken : peerServiceTokens) {
+                    // Make sure the service token is properly bound.
+                    if (peerToken.isMasterTokenBound() && !peerToken.isBoundTo(peerMasterToken))
+                        throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + peerToken + "; mt " + peerMasterToken).setMasterToken(peerMasterToken);
+                    if (peerToken.isUserIdTokenBound() && !peerToken.isBoundTo(peerUserIdToken))
+                        throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + peerToken + "; uit " + peerUserIdToken).setMasterToken(peerMasterToken).setUserIdToken(peerUserIdToken);
+
+                    // Add the peer service token.
+                    this.peerServiceTokens.add(peerToken);
+                }
             }
         }
     }
@@ -291,7 +303,6 @@ public class MessageBuilder {
      */
     public MessageHeader getHeader() throws MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslMessageException, MslException {
         final KeyResponseData response = (keyExchangeData != null) ? keyExchangeData.keyResponseData : null;
-        final Set<ServiceToken> tokens = new HashSet<ServiceToken>(serviceTokens.values());
         final Long nonReplayableId;
         if (nonReplayable) {
             if (masterToken == null)
@@ -300,9 +311,8 @@ public class MessageBuilder {
         } else {
             nonReplayableId = null;
         }
-        final HeaderData headerData = new HeaderData(messageId, nonReplayableId, renewable, handshake, capabilities, keyRequestData, response, userAuthData, userIdToken, tokens);
-        final Set<ServiceToken> peerTokens = new HashSet<ServiceToken>(peerServiceTokens.values());
-        final HeaderPeerData peerData = new HeaderPeerData(peerMasterToken, peerUserIdToken, peerTokens);
+        final HeaderData headerData = new HeaderData(messageId, nonReplayableId, renewable, handshake, capabilities, keyRequestData, response, userAuthData, userIdToken, serviceTokens);
+        final HeaderPeerData peerData = new HeaderPeerData(peerMasterToken, peerUserIdToken, peerServiceTokens);
 
         return createMessageHeader(ctx, ctx.getEntityAuthenticationData(null), masterToken, headerData, peerData);
     }
@@ -445,12 +455,13 @@ public class MessageBuilder {
         }
 
         // Remove any service tokens that will no longer be bound.
-        final Collection<ServiceToken> tokens = serviceTokens.values();
-        for (final ServiceToken token : tokens) {
-            if (token.isUserIdTokenBound() && !token.isBoundTo(userIdToken) ||
-                token.isMasterTokenBound() && !token.isBoundTo(masterToken))
+        final Iterator<ServiceToken> tokens = serviceTokens.iterator();
+        while (tokens.hasNext()) {
+            final ServiceToken token = tokens.next();
+            if ((token.isUserIdTokenBound() && !token.isBoundTo(userIdToken)) ||
+                (token.isMasterTokenBound() && !token.isBoundTo(masterToken)))
             {
-                serviceTokens.remove(token.getName());
+                tokens.remove();
             }
         }
         
@@ -458,8 +469,10 @@ public class MessageBuilder {
         // set as they may be newer. The application will have a chance to
         // manage the service tokens before the message is constructed and
         // sent.
-        for (final ServiceToken token : storedTokens)
-            serviceTokens.put(token.getName(), token);
+        for (final ServiceToken token : storedTokens) {
+            excludeServiceToken(token.getName(), token.isMasterTokenBound(), token.isUserIdTokenBound());
+            serviceTokens.add(token);
+        }
 
         // Set the new authentication tokens.
         this.masterToken = masterToken;
@@ -558,7 +571,8 @@ public class MessageBuilder {
 
     /**
      * <p>Add a service token to the message. This will overwrite any service
-     * token with the same name.</p>
+     * token with the same name that is also bound to the master token or user
+     * ID token in the same way as the new service token.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -585,14 +599,18 @@ public class MessageBuilder {
         if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(userIdToken))
             throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + serviceToken + "; uit " + userIdToken).setMasterToken(serviceMasterToken).setUserIdToken(userIdToken);
         
+        // Remove any existing service token with the same name and bound state.
+        excludeServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+        
         // Add the service token.
-        serviceTokens.put(serviceToken.getName(), serviceToken);
+        serviceTokens.add(serviceToken);
         return this;
     }
 
     /**
      * <p>Add a service token to the message if a service token with the same
-     * name does not already exist.</p>
+     * name that is also bound to the master token or user ID token in the same
+     * way as the new service token does not already exist.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -604,45 +622,67 @@ public class MessageBuilder {
      *         built.
      */
     public MessageBuilder addServiceTokenIfAbsent(final ServiceToken serviceToken) throws MslMessageException {
-        if (!serviceTokens.containsKey(serviceToken.getName()))
-            addServiceToken(serviceToken);
+        final Iterator<ServiceToken> tokens = serviceTokens.iterator();
+        while (tokens.hasNext()) {
+            final ServiceToken token = tokens.next();
+            if (token.getName().equals(serviceToken.getName()) &&
+                token.isMasterTokenBound() == serviceToken.isMasterTokenBound() &&
+                token.isUserIdTokenBound() == serviceToken.isUserIdTokenBound())
+            {
+                return this;
+            }
+        }
+        addServiceToken(serviceToken);
         return this;
     }
 
     /**
-     * <p>Exclude a service token from the message.</p>
+     * <p>Exclude a service token from the message matching all the specified
+     * parameters. A false value for the master token bound or user ID token
+     * bound parameters restricts exclusion to tokens that are not bound to a
+     * master token or not bound to a user ID token respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return this.
      */
-    public MessageBuilder excludeServiceToken(final String name) {
-        serviceTokens.remove(name);
+    public MessageBuilder excludeServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
+        final Iterator<ServiceToken> tokens = serviceTokens.iterator();
+        while (tokens.hasNext()) {
+            final ServiceToken token = tokens.next();
+            if (token.getName().equals(name) &&
+                token.isMasterTokenBound() == masterTokenBound &&
+                token.isUserIdTokenBound() == userIdTokenBound)
+            {
+                tokens.remove();
+            }
+        }
         return this;
     }
 
     /**
-     * <p>Mark a service token for deletion, if it exists. Otherwise this
-     * method does nothing.</p>
+     * <p>Mark a service token for deletion. A false value for the master token
+     * bound or user ID token bound parameters restricts exclusion to tokens
+     * that are not bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to delete a master token bound service token.
+     * @param userIdTokenBound true to delete a user ID token bound service token.
      * @return this.
      */
-    public MessageBuilder deleteServiceToken(final String name) {
-        // Do nothing if the original token does not exist.
-        final ServiceToken originalToken = serviceTokens.get(name);
-        if (originalToken == null)
-            return this;
-        
+    public MessageBuilder deleteServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
         // Rebuild the original token with empty service data.
-        final MasterToken masterToken = originalToken.isMasterTokenBound() ? this.masterToken : null;
-        final UserIdToken userIdToken = originalToken.isUserIdTokenBound() ? this.userIdToken : null;
+        final MasterToken masterToken = masterTokenBound ? this.masterToken : null;
+        final UserIdToken userIdToken = userIdTokenBound ? this.userIdToken : null;
         try {
             final ServiceToken token = new ServiceToken(ctx, name, EMPTY_DATA, masterToken, userIdToken, false, null, new NullCryptoContext());
             return addServiceToken(token);
@@ -656,7 +696,7 @@ public class MessageBuilder {
      *         the built message.
      */
     public Set<ServiceToken> getServiceTokens() {
-        return Collections.unmodifiableSet(new HashSet<ServiceToken>(serviceTokens.values()));
+        return Collections.unmodifiableSet(serviceTokens);
     }
 
     /**
@@ -705,23 +745,21 @@ public class MessageBuilder {
         }
 
         // Remove any peer service tokens that will no longer be bound.
-        final Collection<ServiceToken> tokens = peerServiceTokens.values();
-        for (final ServiceToken token : tokens) {
-            if (token.isUserIdTokenBound() && !token.isBoundTo(userIdToken)) {
-                peerServiceTokens.remove(token.getName());
-                continue;
-            }
-            if (token.isMasterTokenBound() && !token.isBoundTo(masterToken)) {
-                peerServiceTokens.remove(token.getName());
-                continue;
+        final Iterator<ServiceToken> tokens = peerServiceTokens.iterator();
+        while (tokens.hasNext()) {
+            final ServiceToken token = tokens.next();
+            if ((token.isUserIdTokenBound() && !token.isBoundTo(userIdToken)) ||
+                (token.isMasterTokenBound() && !token.isBoundTo(masterToken)))
+            {
+                tokens.remove();
             }
         }
         
         // Add any peer service tokens based on the MSL store if they are not
         // already set (as a set one may be newer than the stored one).
         for (final ServiceToken token : storedTokens) {
-            if (!peerServiceTokens.containsKey(token.getName()))
-                peerServiceTokens.put(token.getName(), token);
+            excludePeerServiceToken(token.getName(), token.isMasterTokenBound(), token.isUserIdTokenBound());
+            peerServiceTokens.add(token);
         }
         
         // Set the new peer authentication tokens.
@@ -731,7 +769,8 @@ public class MessageBuilder {
 
     /**
      * <p>Add a peer service token to the message. This will overwrite any peer
-     * service token with the same name.</p>
+     * service token with the same name that is also bound to a peer master
+     * token or peer user ID token in the same way as the new service token.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -743,21 +782,30 @@ public class MessageBuilder {
      *         being built.
      */
     public MessageBuilder addPeerServiceToken(final ServiceToken serviceToken) throws MslMessageException {
+        // If we are not in peer-to-peer mode then peer service tokens cannot
+        // be set.
         if (!ctx.isPeerToPeer())
             throw new MslInternalException("Cannot set peer service tokens when not in peer-to-peer mode.");
+
+        // Make sure the service token is properly bound.
         if (serviceToken.isMasterTokenBound() && !serviceToken.isBoundTo(peerMasterToken))
             throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + serviceToken + "; mt " + peerMasterToken).setMasterToken(peerMasterToken);
         if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(peerUserIdToken))
             throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + serviceToken + "; uit " + peerUserIdToken).setMasterToken(peerMasterToken).setUserIdToken(peerUserIdToken);
+
+        // Remove any existing service token with the same name and bound state.
+        excludePeerServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
         
         // Add the peer service token.
-        peerServiceTokens.put(serviceToken.getName(), serviceToken);
+        peerServiceTokens.add(serviceToken);
         return this;
     }
 
     /**
      * <p>Add a peer service token to the message if a peer service token with
-     * the same name does not already exist.</p>
+     * the same name that is also bound to the peer master token or peer user
+     * ID token in the same way as the new service token does not already
+     * exist.</p>
      * 
      * <p>Adding a service token with empty data indicates the recipient should
      * delete the service token.</p>
@@ -769,45 +817,68 @@ public class MessageBuilder {
      *         being built.
      */
     public MessageBuilder addPeerServiceTokenIfAbsent(final ServiceToken serviceToken) throws MslMessageException {
-        if (!peerServiceTokens.containsKey(serviceToken.getName()))
-            addPeerServiceToken(serviceToken);
+        final Iterator<ServiceToken> tokens = peerServiceTokens.iterator();
+        while (tokens.hasNext()) {
+            final ServiceToken token = tokens.next();
+            if (token.getName().equals(serviceToken.getName()) &&
+                token.isMasterTokenBound() == serviceToken.isMasterTokenBound() &&
+                token.isUserIdTokenBound() == serviceToken.isUserIdTokenBound())
+            {
+                return this;
+            }
+        }
+        addPeerServiceToken(serviceToken);
         return this;
     }
 
     /**
-     * <p>Exclude a peer service token from the message.</p>
+     * <p>Exclude a peer service token from the message matching all the
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return this.
      */
-    public MessageBuilder excludePeerServiceToken(final String name) {
-        peerServiceTokens.remove(name);
+    public MessageBuilder excludePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
+        final Iterator<ServiceToken> tokens = peerServiceTokens.iterator();
+        while (tokens.hasNext()) {
+            final ServiceToken token = tokens.next();
+            if (token.getName().equals(name) &&
+                token.isMasterTokenBound() == masterTokenBound &&
+                token.isUserIdTokenBound() == userIdTokenBound)
+            {
+                tokens.remove();
+            }
+        }
         return this;
     }
 
     /**
-     * <p>Mark a peer service token for deletion, if it exists. Otherwise this
-     * method does nothing.</p>
+     * <p>Mark a peer service token for deletion. A false value for the master
+     * token bound or user ID token bound parameters restricts exclusion to
+     * tokens that are not bound to a master token or not bound to a user ID
+     * token respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to delete a master token bound service token.
+     * @param userIdTokenBound true to delete a user ID token bound service token.
      * @return this.
      */
-    public MessageBuilder deletePeerServiceToken(final String name) {
-        // Do nothing if the original token does not exist.
-        final ServiceToken originalToken = peerServiceTokens.get(name);
-        if (originalToken == null)
-            return this;
-
+    public MessageBuilder deletePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
         // Rebuild the original token with empty service data.
-        final MasterToken peerMasterToken = originalToken.isMasterTokenBound() ? this.peerMasterToken : null;
-        final UserIdToken peerUserIdToken = originalToken.isUserIdTokenBound() ? this.peerUserIdToken : null;
+        final MasterToken peerMasterToken = masterTokenBound ? this.peerMasterToken : null;
+        final UserIdToken peerUserIdToken = userIdTokenBound ? this.peerUserIdToken : null;
         try {
             final ServiceToken token = new ServiceToken(ctx, name, EMPTY_DATA, peerMasterToken, peerUserIdToken, false, null, new NullCryptoContext());
             return addPeerServiceToken(token);
@@ -821,7 +892,7 @@ public class MessageBuilder {
      *         included in the built message.
      */
     public Set<ServiceToken> getPeerServiceTokens() {
-        return Collections.unmodifiableSet(new HashSet<ServiceToken>(peerServiceTokens.values()));
+        return Collections.unmodifiableSet(peerServiceTokens);
     }
 
     /** MSL context. */
@@ -846,13 +917,13 @@ public class MessageBuilder {
     protected UserAuthenticationData userAuthData = null;
     /** Header data user ID token. */
     protected UserIdToken userIdToken = null;
-    /** Header data service tokens keyed off token name. */
-    protected final Map<String,ServiceToken> serviceTokens = new HashMap<String,ServiceToken>();
+    /** Header data service tokens. */
+    protected final Set<ServiceToken> serviceTokens = new HashSet<ServiceToken>();
 
     /** Header peer data master token. */
     protected MasterToken peerMasterToken = null;
     /** Header peer data user ID token. */
     protected UserIdToken peerUserIdToken = null;
-    /** Header peer data service tokens keyed off token name. */
-    protected final Map<String,ServiceToken> peerServiceTokens = new HashMap<String,ServiceToken>();
+    /** Header peer data service tokens. */
+    protected final Set<ServiceToken> peerServiceTokens = new HashSet<ServiceToken>();
 }

--- a/core/src/main/java/com/netflix/msl/msg/MessageServiceTokenBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageServiceTokenBuilder.java
@@ -437,6 +437,25 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
+     * <p>Exclude a primary service token from the message. This matches the
+     * token name and whether or not it is bound to a master token or to a user
+     * ID token. It does not require the token to be bound to the exact same
+     * master token or user ID token that will be used in the message.</p>
+     * 
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #excludePrimaryServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return true if the service token was found and therefore removed.
+     */
+    public boolean excludePrimaryServiceToken(final ServiceToken serviceToken) {
+        return excludePrimaryServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
+    
+    /**
      * <p>Exclude a primary service token from the message matching all
      * specified parameters. A false value for the master token bound or user
      * ID token bound parameters restricts exclusion to tokens that are not
@@ -465,6 +484,25 @@ public class MessageServiceTokenBuilder {
         
         // Not found.
         return false;
+    }
+    
+    /**
+     * <p>Exclude a peer service token from the message. This matches the
+     * token name and whether or not it is bound to a master token or to a user
+     * ID token. It does not require the token to be bound to the exact same
+     * master token or user ID token that will be used in the message.</p>
+     * 
+     * <p>The service token will not be sent in the built message. This is not
+     * the same as requesting the remote entity delete a service token.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #excludePeerServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return true if the service token was found and therefore removed.
+     */
+    public boolean excludePeerServiceToken(final ServiceToken serviceToken) {
+        return excludePeerServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
     }
     
     /**
@@ -498,9 +536,29 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
+     * <p>Mark a primary service token for deletion, if it exists. This matches
+     * the token name and whether or not it is bound to a master token or to a
+     * user ID token. It does not require the token to be bound to the exact
+     * same master token or user ID token that will be used in the message.</p>
+     * 
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #deletePrimaryServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return true if the service token exists and was marked for deletion.
+     */
+    public boolean deletePrimaryServiceToken(final ServiceToken serviceToken) {
+        return deletePrimaryServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
+    
+    /**
      * <p>Mark a primary service token for deletion, if it exists, matching all
      * specified parameters. A false value for the master token bound or user
-     * ID token bound parameters restricts exclusion to tokens that are not
+     * ID token bound parameters restricts deletion to tokens that are not
      * bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 
@@ -530,9 +588,29 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
+     * <p>Mark a peer service token for deletion, if it exists. This matches
+     * the token name and whether or not it is bound to a master token or to a
+     * user ID token. It does not require the token to be bound to the exact
+     * same master token or user ID token that will be used in the message.</p>
+     * 
+     * <p>The service token will be sent in the built message with an empty
+     * value. This is not the same as requesting that a service token be
+     * excluded from the message.</p>
+     * 
+     * <p>This function is equivalent to calling
+     * {@link #deletePeerServiceToken(String, boolean, boolean)}.</p>
+     * 
+     * @param serviceToken the service token.
+     * @return true if the service token exists and was marked for deletion.
+     */
+    public boolean deletePeerServiceToken(final ServiceToken serviceToken) {
+        return deletePeerServiceToken(serviceToken.getName(), serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+    }
+    
+    /**
      * <p>Mark a peer service token for deletion, if it exists, matching all
      * specified parameters. A false value for the master token bound or user
-     * ID token bound parameters restricts exclusion to tokens that are not
+     * ID token bound parameters restricts deletion to tokens that are not
      * bound to a master token or not bound to a user ID token
      * respectively.</p>
      * 

--- a/core/src/main/java/com/netflix/msl/msg/MessageServiceTokenBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageServiceTokenBuilder.java
@@ -466,8 +466,10 @@ public class MessageServiceTokenBuilder {
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the service token was found and therefore removed.
      */
     public boolean excludePrimaryServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
@@ -515,8 +517,10 @@ public class MessageServiceTokenBuilder {
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the peer service token was found and therefore removed.
      */
     public boolean excludePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
@@ -567,8 +571,10 @@ public class MessageServiceTokenBuilder {
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the service token exists and was marked for deletion.
      */
     public boolean deletePrimaryServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
@@ -619,8 +625,10 @@ public class MessageServiceTokenBuilder {
      * excluded from the message.</p>
      * 
      * @param name service token name.
-     * @param masterTokenBound true to exclude a master token bound service token.
-     * @param userIdTokenBound true to exclude a user ID token bound service token.
+     * @param masterTokenBound true to exclude a master token bound service
+     *        token. Must be true if {@code userIdTokenBound} is true.
+     * @param userIdTokenBound true to exclude a user ID token bound service
+     *        token.
      * @return true if the peer service token exists and was marked for
      *         deletion.
      */

--- a/core/src/main/java/com/netflix/msl/msg/MessageServiceTokenBuilder.java
+++ b/core/src/main/java/com/netflix/msl/msg/MessageServiceTokenBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -437,19 +437,28 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
-     * <p>Exclude a primary service token from the message.</p>
+     * <p>Exclude a primary service token from the message matching all
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the service token was found and therefore removed.
      */
-    public boolean excludePrimaryServiceToken(final String name) {
+    public boolean excludePrimaryServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
         // Exclude the service token if found.
         for (final ServiceToken serviceToken : builder.getServiceTokens()) {
-            if (serviceToken.getName().equals(name)) {
-                builder.excludeServiceToken(name);
+            if (serviceToken.getName().equals(name) &&
+                serviceToken.isMasterTokenBound() == masterTokenBound &&
+                serviceToken.isUserIdTokenBound() == userIdTokenBound)
+            {
+                builder.excludeServiceToken(name, masterTokenBound, userIdTokenBound);
                 return true;
             }
         }
@@ -459,19 +468,27 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
-     * <p>Exclude a peer service token from the message.</p>
+     * <p>Exclude a peer service token from the message matching all specified
+     * parameters. A false value for the master token bound or user ID token
+     * bound parameters restricts exclusion to tokens that are not bound to a
+     * master token or not bound to a user ID token respectively.</p>
      * 
      * <p>The service token will not be sent in the built message. This is not
      * the same as requesting the remote entity delete a service token.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the peer service token was found and therefore removed.
      */
-    public boolean excludePeerServiceToken(final String name) {
+    public boolean excludePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
         // Exclude the service token if found.
         for (final ServiceToken serviceToken : builder.getPeerServiceTokens()) {
-            if (serviceToken.getName().equals(name)) {
-                builder.excludePeerServiceToken(name);
+            if (serviceToken.getName().equals(name) &&
+                serviceToken.isMasterTokenBound() == masterTokenBound &&
+                serviceToken.isUserIdTokenBound() == userIdTokenBound)
+            {
+                builder.excludePeerServiceToken(name, masterTokenBound, userIdTokenBound);
                 return true;
             }
         }
@@ -481,20 +498,29 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
-     * <p>Mark a primary service token for deletion, if it exists.</p>
+     * <p>Mark a primary service token for deletion, if it exists, matching all
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the service token exists and was marked for deletion.
      */
-    public boolean deletePrimaryServiceToken(final String name) {
+    public boolean deletePrimaryServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
         // Mark the service token for deletion if found.
         for (final ServiceToken serviceToken : builder.getServiceTokens()) {
-            if (serviceToken.getName().equals(name)) {
-                builder.deleteServiceToken(name);
+            if (serviceToken.getName().equals(name) &&
+                serviceToken.isMasterTokenBound() == masterTokenBound &&
+                serviceToken.isUserIdTokenBound() == userIdTokenBound)
+            {
+                builder.deleteServiceToken(name, masterTokenBound, userIdTokenBound);
                 return true;
             }
         }
@@ -504,21 +530,30 @@ public class MessageServiceTokenBuilder {
     }
     
     /**
-     * <p>Mark a peer service token for deletion, if it exists.</p>
+     * <p>Mark a peer service token for deletion, if it exists, matching all
+     * specified parameters. A false value for the master token bound or user
+     * ID token bound parameters restricts exclusion to tokens that are not
+     * bound to a master token or not bound to a user ID token
+     * respectively.</p>
      * 
      * <p>The service token will be sent in the built message with an empty
      * value. This is not the same as requesting that a service token be
      * excluded from the message.</p>
      * 
      * @param name service token name.
+     * @param masterTokenBound true to exclude a master token bound service token.
+     * @param userIdTokenBound true to exclude a user ID token bound service token.
      * @return true if the peer service token exists and was marked for
      *         deletion.
      */
-    public boolean deletePeerServiceToken(final String name) {
+    public boolean deletePeerServiceToken(final String name, final boolean masterTokenBound, final boolean userIdTokenBound) {
         // Mark the service token for deletion if found.
         for (final ServiceToken serviceToken : builder.getPeerServiceTokens()) {
-            if (serviceToken.getName().equals(name)) {
-                builder.deletePeerServiceToken(name);
+            if (serviceToken.getName().equals(name) &&
+                serviceToken.isMasterTokenBound() == masterTokenBound &&
+                serviceToken.isUserIdTokenBound() == userIdTokenBound)
+            {
+                builder.deletePeerServiceToken(name, masterTokenBound, userIdTokenBound);
                 return true;
             }
         }

--- a/core/src/main/java/com/netflix/msl/util/MslStore.java
+++ b/core/src/main/java/com/netflix/msl/util/MslStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,20 +160,20 @@ public interface MslStore {
     public Set<ServiceToken> getServiceTokens(final MasterToken masterToken, final UserIdToken userIdToken) throws MslException;
 
     /**
-     * <p>Remove all service tokens matching all the specified parameters.</p>
-     * 
-     * <p>If a name is provided, only tokens with that name are removed. If a
-     * master token is provided, only tokens bound to that master token are
-     * removed. If a user ID token is provided, only tokens bound to that user
-     * ID token are removed.</p>
+     * <p>Remove all service tokens matching all the specified parameters. A
+     * null value for the master token or user ID token restricts removal to
+     * tokens that are not bound to a master token or not bound to a user ID
+     * token respectively.</p>
      * 
      * <p>For example, if a name and master token is provided, only tokens with
-     * that name and bound to that master token are removed.</p>
+     * that name, bound to that master token, and not bound to a user ID token
+     * are removed.</p>
      * 
      * <p>If no parameters are provided, no tokens are removed.</p>
      * 
      * @param name service token name. May be null.
-     * @param masterToken master token. May be null.
+     * @param masterToken master token. May be null unless a user ID token is
+     *        also provided.
      * @param userIdToken user ID token. May be null.
      * @throws MslException if the user ID token is not bound to the master
      *         token.

--- a/core/src/main/java/com/netflix/msl/util/MslStore.java
+++ b/core/src/main/java/com/netflix/msl/util/MslStore.java
@@ -167,13 +167,13 @@ public interface MslStore {
      * 
      * <p>For example, if a name and master token is provided, only tokens with
      * that name, bound to that master token, and not bound to a user ID token
-     * are removed.</p>
+     * are removed. If only a user ID token is provided, all tokens bound to
+     * that user ID token are removed.</p>
      * 
      * <p>If no parameters are provided, no tokens are removed.</p>
      * 
      * @param name service token name. May be null.
-     * @param masterToken master token. May be null unless a user ID token is
-     *        also provided.
+     * @param masterToken master token. May be null.
      * @param userIdToken user ID token. May be null.
      * @throws MslException if the user ID token is not bound to the master
      *         token.

--- a/core/src/main/java/com/netflix/msl/util/SimpleMslStore.java
+++ b/core/src/main/java/com/netflix/msl/util/SimpleMslStore.java
@@ -385,7 +385,7 @@ public class SimpleMslStore implements MslStore {
         // If a user ID token was provided remove all tokens bound to the user
         // ID token. If a name was also provided then limit removal to tokens
         // with the specified name.
-        if (masterToken != null && userIdToken != null) {
+        if (userIdToken != null) {
             final Set<ServiceToken> tokenSet = uitServiceTokens.get(userIdToken.getSerialNumber());
             if (tokenSet != null) {
                 final Iterator<ServiceToken> tokens = tokenSet.iterator();

--- a/core/src/main/java/com/netflix/msl/util/SimpleMslStore.java
+++ b/core/src/main/java/com/netflix/msl/util/SimpleMslStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 package com.netflix.msl.util;
 
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -108,18 +109,27 @@ public class SimpleMslStore implements MslStore {
      */
     @Override
     public synchronized void removeCryptoContext(final MasterToken masterToken) {
-        if (cryptoContexts.remove(masterToken) != null) {
-            // Remove bound user ID tokens, service tokens, and the non-
-            // replayable ID if we no longer have a master token with the same
-            // serial number.
+        // We must perform the removal operations in reverse-dependency order.
+        // This ensures the store is in the correct state, allowing all logical
+        // and safety checks to pass.
+        //
+        // First any bound user ID tokens are removed (which first removes any
+        // service tokens bound to those user ID tokens), then bound service
+        // tokens, and finally the non-replayable ID and crypto context and
+        // master token pair.
+        if (cryptoContexts.containsKey(masterToken)) {
+            // Look for a second master token with the same serial number. If
+            // there is one, then just remove this master token and its crypto
+            // context but do not remove any bound user ID tokens, service
+            // tokens, or the non-replayable ID as those are still associated
+            // with the master token that remains.
             final long serialNumber = masterToken.getSerialNumber();
             for (final MasterToken token : cryptoContexts.keySet()) {
-                if (token.getSerialNumber() == serialNumber)
+                if (!token.equals(masterToken) && token.getSerialNumber() == serialNumber) {
+                    cryptoContexts.remove(masterToken);
                     return;
+                }
             }
-            
-            // Remove the non-replayable ID.
-            nonReplayableIds.remove(serialNumber);
             
             // Remove bound user ID tokens and service tokens.
             for (final UserIdToken userIdToken : userIdTokens.values()) {
@@ -133,6 +143,12 @@ public class SimpleMslStore implements MslStore {
                 // token.
                 throw new MslInternalException("Unexpected exception while removing master token bound service tokens.", e);
             }
+            
+            // Remove the non-replayable ID.
+            nonReplayableIds.remove(serialNumber);
+            
+            // Finally remove the crypto context.
+            cryptoContexts.remove(masterToken);
         }
     }
     
@@ -191,8 +207,6 @@ public class SimpleMslStore implements MslStore {
         // ID token, but it doesn't hurt to try anyway and clean things up.
         for (final Entry<String,UserIdToken> entry : userIdTokens.entrySet()) {
             if (entry.getValue().equals(userIdToken)) {
-                final String userId = entry.getKey();
-                userIdTokens.remove(userId);
                 try {
                     removeServiceTokens(null, masterToken, userIdToken);
                 } catch (final MslException e) {
@@ -200,6 +214,8 @@ public class SimpleMslStore implements MslStore {
                     // that the user ID token is bound to the master token.
                     throw new MslInternalException("Unexpected exception while removing user ID token bound service tokens.", e);
                 }
+                final String userId = entry.getKey();
+                userIdTokens.remove(userId);
                 break;
             }
         }
@@ -210,16 +226,9 @@ public class SimpleMslStore implements MslStore {
      */
     @Override
     public void clearUserIdTokens() {
-        for (final UserIdToken userIdToken : userIdTokens.values()) {
-            try {
-                removeServiceTokens(null, null, userIdToken);
-            } catch (final MslException e) {
-                // This should not happen since we are only providing a user ID
-                // token.
-                throw new MslInternalException("Unexpected exception while removing user ID token bound service tokens.", e);
-            }
-        }
-        userIdTokens.clear();
+        final List<UserIdToken> tokens = new ArrayList<UserIdToken>(userIdTokens.values());
+        for (final UserIdToken token : tokens)
+            removeUserIdToken(token);
     }
     
     /* (non-Javadoc)
@@ -342,51 +351,14 @@ public class SimpleMslStore implements MslStore {
             throw new MslException(MslError.USERIDTOKEN_MASTERTOKEN_MISMATCH, "uit mtserialnumber " + userIdToken.getMasterTokenSerialNumber() + "; mt " + masterToken.getSerialNumber());
         }
         
-        // If only a name was provided remove all tokens with that name.
+        // If only a name was provided remove all unbound tokens with that
+        // name.
         if (name != null && masterToken == null && userIdToken == null) {
             // Remove all unbound tokens with the specified name.
             final Iterator<ServiceToken> unboundTokens = unboundServiceTokens.iterator();
             while (unboundTokens.hasNext()) {
                 if (unboundTokens.next().getName().equals(name))
                     unboundTokens.remove();
-            }
-            
-            // Remove all master bound tokens with the specified name.
-            final Collection<Entry<Long, Set<ServiceToken>>> mtTokenEntries = mtServiceTokens.entrySet();
-            for (final Entry<Long, Set<ServiceToken>> entry : mtTokenEntries) {
-                final Long serialNumber = entry.getKey();
-                final Set<ServiceToken> tokenSet = entry.getValue();
-                final Iterator<ServiceToken> tokens = tokenSet.iterator();
-                while (tokens.hasNext()) {
-                    final ServiceToken token = tokens.next();
-                    
-                    // Skip if the name was provided and it does not match.
-                    if (!token.getName().equals(name))
-                        continue;
-                    
-                    // Remove the token.
-                    tokens.remove();
-                }
-                mtServiceTokens.put(serialNumber, tokenSet);
-            }
-        
-            // Remove all user ID tokens with the specified name.
-            final Collection<Entry<Long, Set<ServiceToken>>> uitTokenEntries = uitServiceTokens.entrySet();
-            for (final Entry<Long, Set<ServiceToken>> entry : uitTokenEntries) {
-                final Long serialNumber = entry.getKey();
-                final Set<ServiceToken> tokenSet = entry.getValue();
-                final Iterator<ServiceToken> tokens = tokenSet.iterator();
-                while (tokens.hasNext()) {
-                    final ServiceToken token = tokens.next();
-                    
-                    // Skip if the name was provided and it does not match.
-                    if (!token.getName().equals(name))
-                        continue;
-                    
-                    // Remove the token.
-                    tokens.remove();
-                }
-                uitServiceTokens.put(serialNumber, tokenSet);
             }
         }
         
@@ -408,36 +380,12 @@ public class SimpleMslStore implements MslStore {
                     tokens.remove();
                 }
             }
-            
-            // Remove all user ID tokens (with the specified name if any).
-            final Collection<Entry<Long, Set<ServiceToken>>> entries = uitServiceTokens.entrySet();
-            for (final Entry<Long, Set<ServiceToken>> entry : entries) {
-                final Long serialNumber = entry.getKey();
-                final Set<ServiceToken> uitTokenSet = entry.getValue();
-                final Iterator<ServiceToken> tokens = uitTokenSet.iterator();
-                while (tokens.hasNext()) {
-                    final ServiceToken token = tokens.next();
-                    
-                    // Skip if the name was provided and it does not match.
-                    if (name != null && !token.getName().equals(name))
-                        continue;
-                    
-                    // Skip if the token is not bound to the master token.
-                    if (!token.isBoundTo(masterToken))
-                        continue;
-                    
-                    // Remove the token.
-                    tokens.remove();
-                }
-                uitServiceTokens.put(serialNumber, uitTokenSet);
-            }
         }
         
         // If a user ID token was provided remove all tokens bound to the user
         // ID token. If a name was also provided then limit removal to tokens
-        // with the specified name. If a master token was also provided then
-        // limit removal to tokens bound to the master token.
-        if (userIdToken != null) {
+        // with the specified name.
+        if (masterToken != null && userIdToken != null) {
             final Set<ServiceToken> tokenSet = uitServiceTokens.get(userIdToken.getSerialNumber());
             if (tokenSet != null) {
                 final Iterator<ServiceToken> tokens = tokenSet.iterator();
@@ -446,11 +394,6 @@ public class SimpleMslStore implements MslStore {
                     
                     // Skip if the name was provided and it does not match.
                     if (name != null && !token.getName().equals(name))
-                        continue;
-                    
-                    // Skip if the master token was provided and the token is
-                    // not bound to it.
-                    if (masterToken != null && !token.isBoundTo(masterToken))
                         continue;
                     
                     // Remove the token.

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -717,20 +717,71 @@
         },
 
         /**
-         * <p>Exclude a service token from the message matching all the specified
-         * parameters. A false value for the master token bound or user ID token
-         * bound parameters restricts exclusion to tokens that are not bound to a
-         * master token or not bound to a user ID token respectively.</p>
-         *
-         * <p>The service token will not be sent in the built message. This is not
-         * the same as requesting the remote entity delete a service token.</p>
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * <p>This function is equivalent to calling the second form with the
+         * service token's properties.</p>
+         * 
+         * @param {ServiceToken} serviceToken the service token.
+         * @return {MessageBuilder} this.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
+         * 
+         * <p>For example, if a name is provided and the master token bound
+         * parameter is true while the user ID token bound parameter is false, then
+         * the master token bound service token with the same name will be excluded
+         * from the message. If a name is provided but both other parameters are
+         * false, then only an unbound service token with the same name will be
+         * excluded.</p>
          *
          * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
-         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service
+         *        token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
+         *        token.
          * @return {MessageBuilder} this.
+         * 
+         * <hr>
+         * 
+         * <p>In either case the service token will not be sent in the built
+         * message. This is not the same as requesting the remote entity delete
+         * a service token.</p>
          */
-        excludeServiceToken: function excludeServiceToken(name, masterTokenBound, userIdTokenBound) {
+        excludeServiceToken: function excludeServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound;
+            
+            // Handle the first form.
+            if (arguments.length == 1) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+            }
+            
+            // Handle the second form.
+            else if (arguments.length = 3) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             for (var i = this._serviceTokens.length - 1; i >= 0; --i) {
                 var token = this._serviceTokens[i];
                 if (token.name == name &&
@@ -744,23 +795,78 @@
         },
 
         /**
-         * <p>Mark a service token for deletion. A false value for the master token
-         * bound or user ID token bound parameters restricts exclusion to tokens
-         * that are not bound to a master token or not bound to a user ID token
-         * respectively.</p>
-         *
-         * <p>The service token will be sent in the built message with an empty
-         * value. This is not the same as requesting that a service token be
-         * excluded from the message.</p>
-         *
-         * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to delete a master token bound service token.
-         * @param {boolean} userIdTokenBound true to delete a user ID token bound service token.
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * <p>This function is equivalent to calling the second form with the
+         * service token's properties.</p>
+         * 
+         * @param {ServiceToken} serviceToken the service token.
          * @param {{result: function(MessageBuilder), error: function(Error)}}
          *        callback the callback that will receive this message builder
          *        upon completion or any thrown exceptions.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
+         * 
+         * <p>For example, if a name is provided and the master token bound
+         * parameter is true while the user ID token bound parameter is false, then
+         * the master token bound service token with the same name will be excluded
+         * from the message. If a name is provided but both other parameters are
+         * false, then only an unbound service token with the same name will be
+         * excluded.</p>
+         *
+         * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to delete a master token bound service
+         *        token.
+         * @param {boolean} userIdTokenBound true to delete a user ID token bound service
+         *        token.
+         * @param {{result: function(MessageBuilder), error: function(Error)}}
+         *        callback the callback that will receive this message builder
+         *        upon completion or any thrown exceptions.
+         * 
+         * <hr>
+         *
+         * <p>In either case the service token will be marked for deletion and
+         * sent in the built message with an empty value. This is not the same as
+         * requesting that a service token be excluded from the message.</p>
          */
-        deleteServiceToken: function deleteServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
+        deleteServiceToken: function deleteServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound,
+                callback;
+            
+            // Handle the first form.
+            if (arguments.length == 2) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+                callback = arguments[1];
+            }
+
+            // Handle the second form.
+            else if (arguments.length = 4) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+                callback = arguments[3];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             var self = this;
             AsyncExecutor(callback, function() {
                 // Rebuild the original token with empty service data.
@@ -924,21 +1030,71 @@
         },
 
         /**
-         * <p>Exclude a peer service token from the message matching all the
-         * specified parameters. A false value for the master token bound or user
-         * ID token bound parameters restricts exclusion to tokens that are not
-         * bound to a master token or not bound to a user ID token
-         * respectively.</p>
-         *
-         * <p>The service token will not be sent in the built message. This is not
-         * the same as requesting the remote entity delete a service token.</p>
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * <p>This function is equivalent to calling the second form with the
+         * service token's properties.</p>
+         * 
+         * @param {ServiceToken} serviceToken the service token.
+         * @return {MessageBuilder} this.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
+         * 
+         * <p>For example, if a name is provided and the master token bound
+         * parameter is true while the user ID token bound parameter is false, then
+         * the master token bound service token with the same name will be excluded
+         * from the message. If a name is provided but both other parameters are
+         * false, then only an unbound service token with the same name will be
+         * excluded.</p>
          *
          * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
-         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service
+         *        token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
+         *        token.
          * @return {MessageBuilder} this.
+         * 
+         * <hr>
+         * 
+         * <p>In either case the service token will not be sent in the built
+         * message. This is not the same as requesting the remote entity delete
+         * a service token.</p>
          */
-        excludePeerServiceToken: function excludePeerServiceToken(name, masterTokenBound, userIdTokenBound) {
+        excludePeerServiceToken: function excludePeerServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound;
+        
+            // Handle the first form.
+            if (arguments.length == 1) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+            }
+
+            // Handle the second form.
+            else if (arguments.length = 3) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             for (var i = this._peerServiceTokens.length - 1; i >= 0; --i) {
                 var token = this._peerServiceTokens[i];
                 if (token.name == name &&
@@ -952,23 +1108,78 @@
         },
 
         /**
-         * <p>Mark a peer service token for deletion. A false value for the master
-         * token bound or user ID token bound parameters restricts exclusion to
-         * tokens that are not bound to a master token or not bound to a user ID
-         * token respectively.</p>
-         *
-         * <p>The service token will be sent in the built message with an empty
-         * value. This is not the same as requesting that a service token be
-         * excluded from the message.</p>
-         *
-         * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to delete a master token bound service token.
-         * @param {boolean} userIdTokenBound true to delete a user ID token bound service token.
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * <p>This function is equivalent to calling the second form with the
+         * service token's properties.</p>
+         * 
+         * @param {ServiceToken} serviceToken the service token.
          * @param {{result: function(MessageBuilder), error: function(Error)}}
          *        callback the callback that will receive this message builder
          *        upon completion or any thrown exceptions.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
+         * 
+         * <p>For example, if a name is provided and the master token bound
+         * parameter is true while the user ID token bound parameter is false, then
+         * the master token bound service token with the same name will be excluded
+         * from the message. If a name is provided but both other parameters are
+         * false, then only an unbound service token with the same name will be
+         * excluded.</p>
+         *
+         * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to delete a master token bound service
+         *        token.
+         * @param {boolean} userIdTokenBound true to delete a user ID token bound service
+         *        token.
+         * @param {{result: function(MessageBuilder), error: function(Error)}}
+         *        callback the callback that will receive this message builder
+         *        upon completion or any thrown exceptions.
+         * 
+         * <hr>
+         *
+         * <p>In either case the service token will be marked for deletion and
+         * sent in the built message with an empty value. This is not the same as
+         * requesting that a service token be excluded from the message.</p>
          */
-        deletePeerServiceToken: function deletePeerServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
+        deletePeerServiceToken: function deletePeerServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound,
+                callback;
+            
+            // Handle the first form.
+            if (arguments.length == 2) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+                callback = arguments[1];
+            }
+    
+            // Handle the second form.
+            else if (arguments.length = 4) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+                callback = arguments[3];
+            }
+    
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             var self = this;
             AsyncExecutor(callback, function() {
                 // Rebuild the original token with empty service data.

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -748,7 +748,7 @@
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to exclude a master token bound service
-         *        token.
+         *        token. Must be true if {@code userIdTokenBound} is true.
          * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
          *        token.
          * @return {MessageBuilder} this.
@@ -828,7 +828,7 @@
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to delete a master token bound service
-         *        token.
+         *        token. Must be true if {@code userIdTokenBound} is true.
          * @param {boolean} userIdTokenBound true to delete a user ID token bound service
          *        token.
          * @param {{result: function(MessageBuilder), error: function(Error)}}
@@ -1061,7 +1061,7 @@
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to exclude a master token bound service
-         *        token.
+         *        token. Must be true if {@code userIdTokenBound} is true.
          * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
          *        token.
          * @return {MessageBuilder} this.
@@ -1141,7 +1141,7 @@
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to delete a master token bound service
-         *        token.
+         *        token. Must be true if {@code userIdTokenBound} is true.
          * @param {boolean} userIdTokenBound true to delete a user ID token bound service
          *        token.
          * @param {{result: function(MessageBuilder), error: function(Error)}}

--- a/core/src/main/javascript/msg/MessageBuilder.js
+++ b/core/src/main/javascript/msg/MessageBuilder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,21 +157,26 @@
 
             // Set the initial service tokens based on the MSL store and provided
             // service tokens.
-            var _serviceTokens = {};
+            var _serviceTokens = [];
             var tokens = ctx.getMslStore().getServiceTokens(serviceMasterToken, userIdToken);
-            tokens.forEach(function(token) {
-                _serviceTokens[token.name] = token;
-            }, this);
+            _serviceTokens.push.apply(_serviceTokens, tokens);
             if (serviceTokens) {
                 serviceTokens.forEach(function(token) {
-                    _serviceTokens[token.name] = token;
+                    // Make sure the service token is properly bound.
+                    if (token.isMasterTokenBound() && !token.isBoundTo(serviceMasterToken))
+                        throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + token + "; mt " + serviceMasterToken).setMasterToken(serviceMasterToken);
+                    if (token.isUserIdTokenBound() && !token.isBoundTo(userIdToken))
+                        throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + token + "; uit " + userIdToken).setMasterToken(serviceMasterToken).setUserIdToken(userIdToken);
+
+                    // Add the service token.
+                    _serviceTokens.push(token);
                 }, this);
             }
 
             // Set the peer-to-peer data.
             var _peerMasterToken;
             var _peerUserIdToken;
-            var _peerServiceTokens = {};
+            var _peerServiceTokens = [];
             if (ctx.isPeerToPeer()) {
                 _peerMasterToken = peerMasterToken;
                 _peerUserIdToken = peerUserIdToken;
@@ -187,12 +192,17 @@
                 // Set the initial peer service tokens based on the MSL store and
                 // provided peer service tokens.
                 var peerTokens = ctx.getMslStore().getServiceTokens(peerServiceMasterToken, peerUserIdToken);
-                peerTokens.forEach(function(peerToken) {
-                    _peerServiceTokens[peerToken.name] = peerToken;
-                }, this);
+                _peerServiceTokens.push.apply(_peerServiceTokens, peerTokens);
                 if (peerServiceTokens) {
                     peerServiceTokens.forEach(function(peerToken) {
-                        _peerServiceTokens[peerToken.name] = peerToken;
+                        // Make sure the service token is properly bound.
+                        if (peerToken.isMasterTokenBound() && !peerToken.isBoundTo(peerMasterToken))
+                            throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + peerToken + "; mt " + peerMasterToken).setMasterToken(peerMasterToken);
+                        if (peerToken.isUserIdTokenBound() && !peerToken.isBoundTo(peerUserIdToken))
+                            throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + peerToken + "; uit " + peerUserIdToken).setMasterToken(peerMasterToken).setUserIdToken(peerUserIdToken);
+
+                        // Add the peer service token.
+                        _peerServiceTokens.push(peerToken);
                     }, this);
                 }
             }
@@ -244,14 +254,14 @@
                 _userAuthData: { value: _userAuthData, writable: true, enumerable: false, configurable: false },
                 /** @type {UserIdToken} */
                 _userIdToken: { value: _userIdToken, writable: true, enumerable: false, configurable: false },
-                /** @type {Object.<name,ServiceToken>} */
+                /** @type {Array<ServiceToken>} */
                 _serviceTokens: { value: _serviceTokens, writable: false, enumerable: false, configurable: false },
 
                 /** @type {MasterToken} */
                 _peerMasterToken: { value: _peerMasterToken, writable: true, enumerable: false, configurable: false },
                 /** @type {UserIdToken} */
                 _peerUserIdToken: { value: _peerUserIdToken, writable: true, enumerable: false, configurable: false },
-                /** @type {Object.<name,ServiceToken>} */
+                /** @type {Array<ServiceToken>} */
                 _peerServiceTokens: { value: _peerServiceTokens, writable: false, enumerable: false, configurable: false },
             };
             Object.defineProperties(this, props);
@@ -361,9 +371,6 @@
             var self = this;
             AsyncExecutor(callback, function() {
                 var response = (this._keyExchangeData) ? this._keyExchangeData.keyResponseData : null;
-                var tokens = [];
-                for (var name in this._serviceTokens)
-                    tokens.push(this._serviceTokens[name]);
                 var keyRequests = [];
                 for (var key in this._keyRequestData)
                     keyRequests.push(this._keyRequestData[key]);
@@ -375,11 +382,8 @@
                 } else {
                     nonReplayableId = null;
                 }
-                var headerData = new MessageHeader.HeaderData(this._messageId, nonReplayableId, this._renewable, this._handshake, this._capabilities, keyRequests, response, this._userAuthData, this._userIdToken, tokens);
-                var peerTokens = [];
-                for (var peerName in this._peerServiceTokens)
-                    peerTokens.push(this._peerServiceTokens[peerName]);
-                var peerData = new MessageHeader.HeaderPeerData(this._peerMasterToken, this._peerUserIdToken, peerTokens);
+                var headerData = new MessageHeader.HeaderData(this._messageId, nonReplayableId, this._renewable, this._handshake, this._capabilities, keyRequests, response, this._userAuthData, this._userIdToken, this._serviceTokens);
+                var peerData = new MessageHeader.HeaderPeerData(this._peerMasterToken, this._peerUserIdToken, this._peerServiceTokens);
                 this.createMessageHeader(this._ctx, this._entityAuthData, this._masterToken, headerData, peerData, callback);
             }, self);
         },
@@ -519,28 +523,29 @@
             }
 
             // Remove any service tokens that will no longer be bound.
-            var tokens = [];
-            for (var name in this._serviceTokens)
-                tokens.push(this._serviceTokens[name]);
-            tokens.forEach(function(token) {
-                if (token.isUserIdTokenBound() && !token.isBoundTo(userIdToken) ||
-                    token.isMasterTokenBound() && !token.isBoundTo(masterToken))
+            for (var i = this._serviceTokens.length - 1; i >= 0; --i) {
+                var token = this._serviceTokens[i];
+                if ((token.isUserIdTokenBound() && !token.isBoundTo(userIdToken)) ||
+                    (token.isMasterTokenBound() && !token.isBoundTo(masterToken)))
                 {
-                    delete this._serviceTokens[token.name];
+                    this._serviceTokens.splice(i, 1);
                 }
-            }, this);
+            }
 
             // Add any service tokens based on the MSL store replacing ones already
             // set as they may be newer. The application will have a chance to
             // manage the service tokens before the message is constructed and
             // sent.
             storedTokens.forEach(function(token) {
-                this._serviceTokens[token.name] = token;
+                this.excludeServiceToken(token.name, token.isMasterTokenBound(), token.isUserIdTokenBound());
+                this._serviceTokens.push(token);
             }, this);
 
             // Set the new authentication tokens.
             this._masterToken = masterToken;
             this._userIdToken = userIdToken;
+            if (!this._userIdToken)
+                this._userAuthData = null;
         },
 
         /**
@@ -647,7 +652,8 @@
 
         /**
          * <p>Add a service token to the message. This will overwrite any service
-         * token with the same name.</p>
+         * token with the same name that is also bound to the master token or user
+         * ID token in the same way as the new service token.</p>
          *
          * <p>Adding a service token with empty data indicates the recipient should
          * delete the service token.</p>
@@ -674,14 +680,18 @@
             if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(this._userIdToken))
                 throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + serviceToken + "; uit " + this._userIdToken).setMasterToken(serviceMasterToken).setUserIdToken(this._userIdToken);
 
+            // Remove any existing service token with the same name and bound state.
+            this.excludeServiceToken(serviceToken.name, serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+            
             // Add the service token.
-            this._serviceTokens[serviceToken.name] = serviceToken;
+            this._serviceTokens.push(serviceToken);
             return this;
         },
 
         /**
          * <p>Add a service token to the message if a service token with the same
-         * name does not already exist.</p>
+         * name that is also bound to the master token or user ID token in the same
+         * way as the new service token does not already exist.</p>
          *
          * <p>Adding a service token with empty data indicates the recipient should
          * delete the service token.</p>
@@ -693,49 +703,69 @@
          *         built.
          */
         addServiceTokenIfAbsent: function addServiceTokenIfAbsent(serviceToken) {
-            if (!this._serviceTokens[serviceToken.name])
-                this.addServiceToken(serviceToken);
+            for (var i = this._serviceTokens.length - 1; i >= 0; --i) {
+                var token = this._serviceTokens[i];
+                if (token.name == serviceToken.name &&
+                    token.isMasterTokenBound() == serviceToken.isMasterTokenBound() &&
+                    token.isUserIdTokenBound() == serviceToken.isUserIdTokenBound())
+                {
+                    return this;
+                }
+            }
+            this.addServiceToken(serviceToken);
             return this;
         },
 
         /**
-         * <p>Exclude a service token from the message.</p>
+         * <p>Exclude a service token from the message matching all the specified
+         * parameters. A false value for the master token bound or user ID token
+         * bound parameters restricts exclusion to tokens that are not bound to a
+         * master token or not bound to a user ID token respectively.</p>
          *
          * <p>The service token will not be sent in the built message. This is not
          * the same as requesting the remote entity delete a service token.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @return {MessageBuilder} this.
          */
-        excludeServiceToken: function excludeServiceToken(name) {
-            delete this._serviceTokens[name];
+        excludeServiceToken: function excludeServiceToken(name, masterTokenBound, userIdTokenBound) {
+            for (var i = this._serviceTokens.length - 1; i >= 0; --i) {
+                var token = this._serviceTokens[i];
+                if (token.name == name &&
+                    token.isMasterTokenBound() == masterTokenBound &&
+                    token.isUserIdTokenBound() == userIdTokenBound)
+                {
+                    this._serviceTokens.splice(i, 1);
+                }
+            }
             return this;
         },
 
         /**
-         * <p>Mark a service token for deletion, if it exists. Otherwise this
-         * method does nothing.</p>
+         * <p>Mark a service token for deletion. A false value for the master token
+         * bound or user ID token bound parameters restricts exclusion to tokens
+         * that are not bound to a master token or not bound to a user ID token
+         * respectively.</p>
          *
          * <p>The service token will be sent in the built message with an empty
          * value. This is not the same as requesting that a service token be
          * excluded from the message.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to delete a master token bound service token.
+         * @param {boolean} userIdTokenBound true to delete a user ID token bound service token.
          * @param {{result: function(MessageBuilder), error: function(Error)}}
          *        callback the callback that will receive this message builder
          *        upon completion or any thrown exceptions.
          */
-        deleteServiceToken: function deleteServiceToken(name, callback) {
+        deleteServiceToken: function deleteServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
             var self = this;
             AsyncExecutor(callback, function() {
-                // Do nothing if the original token does not exist.
-                var originalToken = this._serviceTokens[name];
-                if (!originalToken)
-                    return this;
-
                 // Rebuild the original token with empty service data.
-                var masterToken = originalToken.isMasterTokenBound() ? this._masterToken : null;
-                var userIdToken = originalToken.isUserIdTokenBound() ? this._userIdToken : null;
+                var masterToken = masterTokenBound ? this._masterToken : null;
+                var userIdToken = userIdTokenBound ? this._userIdToken : null;
                 ServiceToken.create(this._ctx, name, EMPTY_DATA, masterToken, userIdToken, false, null, new NullCryptoContext(), {
                     result: function(token) {
                         AsyncExecutor(callback, function() {
@@ -757,8 +787,7 @@
          */
         getServiceTokens: function getServiceTokens() {
             var tokens = [];
-            for (var name in this._serviceTokens)
-                tokens.push(this._serviceTokens[name]);
+            tokens.push.apply(tokens, this._serviceTokens);
             return tokens;
         },
 
@@ -786,7 +815,6 @@
          *
          * @param {MasterToken} masterToken peer master token to set. May be null.
          * @param {UserIdToken} userIdToken peer user ID token to set. May be null.
-         * @return {MessageBuilder} this.
          * @throws MslMessageException if the peer user ID token is not bound to
          *         the peer master token.
          */
@@ -811,36 +839,31 @@
             }
 
             // Remove any peer service tokens that will no longer be bound.
-            var names = Object.keys(this._peerServiceTokens);
-            names.forEach(function(name) {
-                var token = this._peerServiceTokens[name];
-                if (token.isUserIdTokenBound() && !token.isBoundTo(userIdToken)) {
-                    delete this._peerServiceTokens[name];
-                    return;
+            for (var i = this._peerServiceTokens.length - 1; i >= 0; --i) {
+                var token = this._peerServiceTokens[i];
+                if ((token.isUserIdTokenBound() && !token.isBoundTo(userIdToken)) ||
+                    (token.isMasterTokenBound() && !token.isBoundTo(masterToken)))
+                {
+                    this._peerServiceTokens.slice(i, 1);
                 }
-                if (token.isMasterTokenBound() && !token.isBoundTo(masterToken)) {
-                    delete this._peerServiceTokens[name];
-                    return;
-                }
-            }, this);
+            }
 
             // Add any peer service tokens based on the MSL store if they are not
             // already set (as a set one may be newer than the stored one).
             storedTokens.forEach(function(token) {
-                var name = token.name;
-                if (!this._peerServiceTokens[name])
-                    this._peerServiceTokens[name] = token;
+                this.excludePeerServiceToken(token.name, token.isMasterTokenBound(), token.isUserIdTokenBound());
+                this._peerServiceTokens.push(token);
             }, this);
 
             // Set the new peer authentication tokens.
             this._peerUserIdToken = userIdToken;
             this._peerMasterToken = masterToken;
-            return this;
         },
 
         /**
          * <p>Add a peer service token to the message. This will overwrite any peer
-         * service token with the same name.</p>
+         * service token with the same name that is also bound to a peer master
+         * token or peer user ID token in the same way as the new service token.</p>
          *
          * <p>Adding a service token with empty data indicates the recipient should
          * delete the service token.</p>
@@ -852,21 +875,30 @@
          *         being built.
          */
         addPeerServiceToken: function addPeerServiceToken(serviceToken) {
+            // If we are not in peer-to-peer mode then peer service tokens cannot
+            // be set.
             if (!this._ctx.isPeerToPeer())
                 throw new MslInternalException("Cannot set peer service tokens when not in peer-to-peer mode.");
+
+            // Make sure the service token is properly bound.
             if (serviceToken.isMasterTokenBound() && !serviceToken.isBoundTo(this._peerMasterToken))
                 throw new MslMessageException(MslError.SERVICETOKEN_MASTERTOKEN_MISMATCH, "st " + serviceToken + "; mt " + this._peerMasterToken).setMasterToken(this._peerMasterToken);
             if (serviceToken.isUserIdTokenBound() && !serviceToken.isBoundTo(this._peerUserIdToken))
                 throw new MslMessageException(MslError.SERVICETOKEN_USERIDTOKEN_MISMATCH, "st " + serviceToken + "; uit " + this._peerUserIdToken).setMasterToken(this._peerMasterToken).setUserIdToken(this._peerUserIdToken);
 
+            // Remove any existing service token with the same name and bound state.
+            this.excludePeerServiceToken(serviceToken.name, serviceToken.isMasterTokenBound(), serviceToken.isUserIdTokenBound());
+            
             // Add the peer service token.
-            this._peerServiceTokens[serviceToken.name] = serviceToken;
+            this._peerServiceTokens.push(serviceToken);
             return this;
         },
 
         /**
          * <p>Add a peer service token to the message if a peer service token with
-         * the same name does not already exist.</p>
+         * the same name that is also bound to the peer master token or peer user
+         * ID token in the same way as the new service token does not already
+         * exist.</p>
          *
          * <p>Adding a service token with empty data indicates the recipient should
          * delete the service token.</p>
@@ -878,49 +910,70 @@
          *         being built.
          */
         addPeerServiceTokenIfAbsent: function addPeerServiceTokenIfAbsent(serviceToken) {
-            if (!this._peerServiceTokens[serviceToken.name])
-                this.addPeerServiceToken(serviceToken);
+            for (var i = this._peerServiceTokens.length - 1; i >= 0; --i) {
+                var token = this._peerServiceTokens[i];
+                if (token.name == serviceToken.name &&
+                    token.isMasterTokenBound() == serviceToken.isMasterTokenBound() &&
+                    token.isUserIdTokenBound() == serviceToken.isUserIdTokenBound())
+                {
+                    return this;
+                }
+            }
+            this.addPeerServiceToken(serviceToken);
             return this;
         },
 
         /**
-         * <p>Exclude a peer service token from the message.</p>
+         * <p>Exclude a peer service token from the message matching all the
+         * specified parameters. A false value for the master token bound or user
+         * ID token bound parameters restricts exclusion to tokens that are not
+         * bound to a master token or not bound to a user ID token
+         * respectively.</p>
          *
          * <p>The service token will not be sent in the built message. This is not
          * the same as requesting the remote entity delete a service token.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @return {MessageBuilder} this.
          */
-        excludePeerServiceToken: function excludePeerServiceToken(name) {
-            delete this._peerServiceTokens[name];
+        excludePeerServiceToken: function excludePeerServiceToken(name, masterTokenBound, userIdTokenBound) {
+            for (var i = this._peerServiceTokens.length - 1; i >= 0; --i) {
+                var token = this._peerServiceTokens[i];
+                if (token.name == name &&
+                    token.isMasterTokenBound() == masterTokenBound &&
+                    token.isUserIdTokenBound() == userIdTokenBound)
+                {
+                    this._peerServiceTokens.splice(i, 1);
+                }
+            }
             return this;
         },
 
         /**
-         * <p>Mark a peer service token for deletion, if it exists. Otherwise this
-         * method does nothing.</p>
+         * <p>Mark a peer service token for deletion. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user ID
+         * token respectively.</p>
          *
          * <p>The service token will be sent in the built message with an empty
          * value. This is not the same as requesting that a service token be
          * excluded from the message.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to delete a master token bound service token.
+         * @param {boolean} userIdTokenBound true to delete a user ID token bound service token.
          * @param {{result: function(MessageBuilder), error: function(Error)}}
          *        callback the callback that will receive this message builder
          *        upon completion or any thrown exceptions.
          */
-        deletePeerServiceToken: function deletePeerServiceToken(name, callback) {
+        deletePeerServiceToken: function deletePeerServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
             var self = this;
             AsyncExecutor(callback, function() {
-                // Do nothing if the original token does not exist.
-                var originalToken = this._peerServiceTokens[name];
-                if (!originalToken)
-                    return this;
-
                 // Rebuild the original token with empty service data.
-                var peerMasterToken = originalToken.isMasterTokenBound() ? this._peerMasterToken : null;
-                var peerUserIdToken = originalToken.isUserIdTokenBound() ? this._peerUserIdToken : null;
+                var peerMasterToken = masterTokenBound ? this._peerMasterToken : null;
+                var peerUserIdToken = userIdTokenBound ? this._peerUserIdToken : null;
                 ServiceToken.create(this._ctx, name, EMPTY_DATA, peerMasterToken, peerUserIdToken, false, null, new NullCryptoContext(), {
                     result: function(token) {
                         AsyncExecutor(callback, function() {
@@ -942,8 +995,7 @@
          */
         getPeerServiceTokens: function getPeerServiceTokens() {
             var tokens = [];
-            for (var name in this._peerServiceTokens)
-                tokens.push(this._peerServiceTokens[name]);
+            tokens.push.apply(tokens, this._peerServiceTokens);
             return tokens;
         },
     });

--- a/core/src/main/javascript/msg/MessageHeader.js
+++ b/core/src/main/javascript/msg/MessageHeader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@
 	var SessionCryptoContext = require('../crypto/SessionCryptoContext.js');
 	var MslEntityAuthException = require('../MslEntityAuthException.js');
 	var MslEncodable = require('../io/MslEncodable.js');
+	var MslEncoderUtils = require('../io/MslEncoderUtils.js');
 	var AsyncExecutor = require('../util/AsyncExecutor.js');
 	var MslConstants = require('../MslConstants.js');
 	var MslInternalException = require('../MslInternalException.js');

--- a/core/src/main/javascript/msg/MessageServiceTokenBuilder.js
+++ b/core/src/main/javascript/msg/MessageServiceTokenBuilder.js
@@ -539,8 +539,10 @@
          * ID token respectively.</p>
          * 
          * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
-         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service
+         *        token. Must be true if {@code userIdTokenBound} is true.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
+         *        token.
          * @return {boolean} true if the service token was found and therefore removed.
          * 
          * <hr>
@@ -613,8 +615,10 @@
          * ID token respectively.</p>
          *
          * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
-         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service
+         *        token. Must be true if {@code userIdTokenBound} is true.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
+         *        token.
          * @return {boolean} true if the peer service token was found and therefore removed.
          * 
          * <h2>
@@ -686,8 +690,10 @@
          * ID token respectively.</p>
          *
          * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
-         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service
+         *        token. Must be true if {@code userIdTokenBound} is true.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
+         *        token.
          * @param {{result: function(boolean), error: function(Error)}} callback
          *        the callback will receive true if the service token exists
          *        and was marked for deletion, or any thrown exceptions.
@@ -769,8 +775,10 @@
          * ID token respectively.</p>
          *
          * @param {string} name service token name.
-         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
-         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service
+         *        token. Must be true if {@code userIdTokenBound} is true.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service
+         *        token.
          * @param {{result: function(boolean), error: function(Error)}} callback
          *        the callback will receive true if the peer service token
          *        exists and was marked for deletion, or any thrown exceptions.

--- a/core/src/main/javascript/msg/MessageServiceTokenBuilder.js
+++ b/core/src/main/javascript/msg/MessageServiceTokenBuilder.js
@@ -516,21 +516,62 @@
         },
 
         /**
-         * <p>Exclude a primary service token from the message matching all
-         * specified parameters. A false value for the master token bound or user
-         * ID token bound parameters restricts exclusion to tokens that are not
-         * bound to a master token or not bound to a user ID token
-         * respectively.</p>
-         *
-         * <p>The service token will not be sent in the built message. This is not
-         * the same as requesting the remote entity delete a service token.</p>
-         *
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * <p>This function is equivalent to calling the second form with the
+         * service token's properties.</p>
+         * 
+         * @param {ServiceToken} serviceToken the service token.
+         * @return {boolean} true if the service token was found and therefore removed.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
+         * 
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to exclude a master token bound service token.
          * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @return {boolean} true if the service token was found and therefore removed.
+         * 
+         * <hr>
+         *
+         * <p>In either case the service token will not be sent in the built
+         * message. This is not the same as requesting the remote entity delete
+         * a service token.</p>
          */
-        excludePrimaryServiceToken: function excludePrimaryServiceToken(name, masterTokenBound, userIdTokenBound) {
+        excludePrimaryServiceToken: function excludePrimaryServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound;
+            
+            // Handle the first form.
+            if (arguments.length == 1) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+            }
+            
+            // Handle the second form.
+            else if (arguments.length = 3) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             // Exclude the service token if found.
             var serviceTokens = this.builder.getServiceTokens();
             for (var i = 0; i < serviceTokens.length; ++i) {
@@ -549,20 +590,62 @@
         },
 
         /**
-         * <p>Exclude a peer service token from the message matching all specified
-         * parameters. A false value for the master token bound or user ID token
-         * bound parameters restricts exclusion to tokens that are not bound to a
-         * master token or not bound to a user ID token respectively.</p>
-         *
-         * <p>The service token will not be sent in the built message. This is not
-         * the same as requesting the remote entity delete a service token.</p>
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * <p>This function is equivalent to calling the second form with the
+         * service token's properties.</p>
+         * 
+         * @param {ServiceToken} serviceToken the service token.
+         * @return {boolean} true if the peer service token was found and therefore removed.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts exclusion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to exclude a master token bound service token.
          * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @return {boolean} true if the peer service token was found and therefore removed.
+         * 
+         * <h2>
+         * 
+         * <p>In either case the service token will not be sent in the built
+         * message. This is not the same as requesting the remote entity delete
+         * a service token.</p>
          */
-        excludePeerServiceToken: function excludePeerServiceToken(name, masterTokenBound, userIdTokenBound) {
+        excludePeerServiceToken: function excludePeerServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound;
+
+            // Handle the first form.
+            if (arguments.length == 1) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+            }
+
+            // Handle the second form.
+            else if (arguments.length = 3) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+
             // Exclude the service token if found.
             var peerServiceTokens = this.builder.getPeerServiceTokens();
             for (var i = 0; i < peerServiceTokens.length; ++i) {
@@ -581,15 +664,26 @@
         },
 
         /**
-         * <p>Mark a primary service token for deletion, if it exists, matching all
-         * specified parameters. A false value for the master token bound or user
-         * ID token bound parameters restricts exclusion to tokens that are not
-         * bound to a master token or not bound to a user ID token
-         * respectively.</p>
-         *
-         * <p>The service token will be sent in the built message with an empty
-         * value. This is not the same as requesting that a service token be
-         * excluded from the message.</p>
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * @param {ServiceToken> serviceToken the service token.
+         * @param {{result: function(boolean), error: function(Error)}} callback
+         *        the callback will receive true if the service token exists
+         *        and was marked for deletion, or any thrown exceptions.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts deletion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to exclude a master token bound service token.
@@ -597,8 +691,39 @@
          * @param {{result: function(boolean), error: function(Error)}} callback
          *        the callback will receive true if the service token exists
          *        and was marked for deletion, or any thrown exceptions.
+         * 
+         * <hr>
+         *
+         * <p>In either case the service token will marked for deletion and be
+         * sent in the built message with an empty value. This is not the same
+         * as requesting that a service token be excluded from the message.</p>
          */
-        deletePrimaryServiceToken: function deletePrimaryServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
+        deletePrimaryServiceToken: function deletePrimaryServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound,
+                callback;
+            
+            // Handle the first form.
+            if (arguments.length == 2) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+                callback = arguments[1];
+            }
+            
+            // Handle the second form.
+            else if (arguments.length == 4) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+                callback = arguments[3];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             AsyncExecutor(callback, function() {
                 // Mark the service token for deletion if found.
                 var serviceTokens = this.builder.getServiceTokens();
@@ -622,15 +747,26 @@
         },
 
         /**
-         * <p>Mark a peer service token for deletion, if it exists, matching all
-         * specified parameters. A false value for the master token bound or user
-         * ID token bound parameters restricts exclusion to tokens that are not
-         * bound to a master token or not bound to a user ID token
-         * respectively.</p>
-         *
-         * <p>The service token will be sent in the built message with an empty
-         * value. This is not the same as requesting that a service token be
-         * excluded from the message.</p>
+         * <p>This method has two acceptable parameter lists.</p>
+         * 
+         * <p>The first form accepts a service token and uses the token name
+         * and whether or not it is bound to a master token or to a user ID
+         * token. It does not require the token to be bound to the exact same
+         * master token or user ID token that will be used in the message.</p>
+         * 
+         * @param {ServiceToken> serviceToken the service token.
+         * @param {{result: function(boolean), error: function(Error)}} callback
+         *        the callback will receive true if the peer service token
+         *        exists and was marked for deletion, or any thrown exceptions.
+         * 
+         * <hr>
+         * 
+         * <p>The second form accepts a service token name and parameters
+         * indicating if the token must be bound to a master token and if the
+         * token must be bound to a user ID token. A false value for the master
+         * token bound or user ID token bound parameters restricts deletion to
+         * tokens that are not bound to a master token or not bound to a user
+         * ID token respectively.</p>
          *
          * @param {string} name service token name.
          * @param {boolean} masterTokenBound true to exclude a master token bound service token.
@@ -638,8 +774,39 @@
          * @param {{result: function(boolean), error: function(Error)}} callback
          *        the callback will receive true if the peer service token
          *        exists and was marked for deletion, or any thrown exceptions.
+         * 
+         * <hr>
+         *
+         * <p>In either case the service token will marked for deletion and be
+         * sent in the built message with an empty value. This is not the same
+         * as requesting that a service token be excluded from the message.</p>
          */
-        deletePeerServiceToken: function deletePeerServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
+        deletePeerServiceToken: function deletePeerServiceToken(/* variable arguments */) {
+            var name,
+                masterTokenBound,
+                userIdTokenBound,
+                callback;
+            
+            // Handle the first form.
+            if (arguments.length == 2) {
+                var serviceToken = arguments[0];
+                name = serviceToken.name;
+                masterTokenBound = serviceToken.isMasterTokenBound();
+                userIdTokenBound = serviceToken.isUserIdTokenBound();
+                callback = arguments[1];
+            }
+            
+            // Handle the second form.
+            else if (arguments.length == 4) {
+                name = arguments[0];
+                masterTokenBound = arguments[1];
+                userIdTokenBound = arguments[2];
+                callback = arguments[3];
+            }
+
+            // Malformed arguments are not explicitly handled, just as with any
+            // other function.
+            
             AsyncExecutor(callback, function() {
                 // Mark the service token for deletion if found.
                 var peerServiceTokens = this.builder.getPeerServiceTokens();

--- a/core/src/main/javascript/msg/MessageServiceTokenBuilder.js
+++ b/core/src/main/javascript/msg/MessageServiceTokenBuilder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -516,21 +516,30 @@
         },
 
         /**
-         * <p>Exclude a primary service token from the message.</p>
+         * <p>Exclude a primary service token from the message matching all
+         * specified parameters. A false value for the master token bound or user
+         * ID token bound parameters restricts exclusion to tokens that are not
+         * bound to a master token or not bound to a user ID token
+         * respectively.</p>
          *
          * <p>The service token will not be sent in the built message. This is not
          * the same as requesting the remote entity delete a service token.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @return {boolean} true if the service token was found and therefore removed.
          */
-        excludePrimaryServiceToken: function excludePrimaryServiceToken(name) {
+        excludePrimaryServiceToken: function excludePrimaryServiceToken(name, masterTokenBound, userIdTokenBound) {
             // Exclude the service token if found.
             var serviceTokens = this.builder.getServiceTokens();
             for (var i = 0; i < serviceTokens.length; ++i) {
                 var serviceToken = serviceTokens[i];
-                if (serviceToken.name == name) {
-                    this.builder.excludeServiceToken(name);
+                if (serviceToken.name == name &&
+                    serviceToken.isMasterTokenBound() == masterTokenBound &&
+                    serviceToken.isUserIdTokenBound() == userIdTokenBound)
+                {
+                    this.builder.excludeServiceToken(name, masterTokenBound, userIdTokenBound);
                     return true;
                 }
             }
@@ -540,21 +549,29 @@
         },
 
         /**
-         * <p>Exclude a peer service token from the message.</p>
+         * <p>Exclude a peer service token from the message matching all specified
+         * parameters. A false value for the master token bound or user ID token
+         * bound parameters restricts exclusion to tokens that are not bound to a
+         * master token or not bound to a user ID token respectively.</p>
          *
          * <p>The service token will not be sent in the built message. This is not
          * the same as requesting the remote entity delete a service token.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @return {boolean} true if the peer service token was found and therefore removed.
          */
-        excludePeerServiceToken: function excludePeerServiceToken(name) {
+        excludePeerServiceToken: function excludePeerServiceToken(name, masterTokenBound, userIdTokenBound) {
             // Exclude the service token if found.
             var peerServiceTokens = this.builder.getPeerServiceTokens();
             for (var i = 0; i < peerServiceTokens.length; ++i) {
                 var serviceToken = peerServiceTokens[i];
-                if (serviceToken.name == name) {
-                    this.builder.excludePeerServiceToken(name);
+                if (serviceToken.name == name &&
+                    serviceToken.isMasterTokenBound() == masterTokenBound &&
+                    serviceToken.isUserIdTokenBound() == userIdTokenBound)
+                {
+                    this.builder.excludePeerServiceToken(name, masterTokenBound, userIdTokenBound);
                     return true;
                 }
             }
@@ -564,25 +581,34 @@
         },
 
         /**
-         * <p>Mark a primary service token for deletion, if it exists.</p>
+         * <p>Mark a primary service token for deletion, if it exists, matching all
+         * specified parameters. A false value for the master token bound or user
+         * ID token bound parameters restricts exclusion to tokens that are not
+         * bound to a master token or not bound to a user ID token
+         * respectively.</p>
          *
          * <p>The service token will be sent in the built message with an empty
          * value. This is not the same as requesting that a service token be
          * excluded from the message.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @param {{result: function(boolean), error: function(Error)}} callback
          *        the callback will receive true if the service token exists
          *        and was marked for deletion, or any thrown exceptions.
          */
-        deletePrimaryServiceToken: function deletePrimaryServiceToken(name, callback) {
+        deletePrimaryServiceToken: function deletePrimaryServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
             AsyncExecutor(callback, function() {
                 // Mark the service token for deletion if found.
                 var serviceTokens = this.builder.getServiceTokens();
                 for (var i = 0; i < serviceTokens.length; ++i) {
                     var serviceToken = serviceTokens[i];
-                    if (serviceToken.name == name) {
-                        this.builder.deleteServiceToken(name, {
+                    if (serviceToken.name == name &&
+                        serviceToken.isMasterTokenBound() == masterTokenBound &&
+                        serviceToken.isUserIdTokenBound() == userIdTokenBound)
+                    {
+                        this.builder.deleteServiceToken(name, masterTokenBound, userIdTokenBound, {
                             result: function() { callback.result(true); },
                             error: callback.error,
                         });
@@ -596,25 +622,34 @@
         },
 
         /**
-         * <p>Mark a peer service token for deletion, if it exists.</p>
+         * <p>Mark a peer service token for deletion, if it exists, matching all
+         * specified parameters. A false value for the master token bound or user
+         * ID token bound parameters restricts exclusion to tokens that are not
+         * bound to a master token or not bound to a user ID token
+         * respectively.</p>
          *
          * <p>The service token will be sent in the built message with an empty
          * value. This is not the same as requesting that a service token be
          * excluded from the message.</p>
          *
          * @param {string} name service token name.
+         * @param {boolean} masterTokenBound true to exclude a master token bound service token.
+         * @param {boolean} userIdTokenBound true to exclude a user ID token bound service token.
          * @param {{result: function(boolean), error: function(Error)}} callback
          *        the callback will receive true if the peer service token
          *        exists and was marked for deletion, or any thrown exceptions.
          */
-        deletePeerServiceToken: function deletePeerServiceToken(name, callback) {
+        deletePeerServiceToken: function deletePeerServiceToken(name, masterTokenBound, userIdTokenBound, callback) {
             AsyncExecutor(callback, function() {
                 // Mark the service token for deletion if found.
                 var peerServiceTokens = this.builder.getPeerServiceTokens();
                 for (var i = 0; i < peerServiceTokens.length; ++i) {
                     var serviceToken = peerServiceTokens[i];
-                    if (serviceToken.name == name) {
-                        this.builder.deletePeerServiceToken(name, {
+                    if (serviceToken.name == name &&
+                        serviceToken.isMasterTokenBound() == masterTokenBound &&
+                        serviceToken.isUserIdTokenBound() == userIdTokenBound)
+                    {
+                        this.builder.deletePeerServiceToken(name, masterTokenBound, userIdTokenBound, {
                             result: function() { callback.result(true); },
                             error: callback.error,
                         });

--- a/core/src/main/javascript/package.json
+++ b/core/src/main/javascript/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "jshint": "^2.9.6",
-    "jsrsasign": "^7.2.2"
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15"
   }
 }

--- a/core/src/main/javascript/util/MslStore.js
+++ b/core/src/main/javascript/util/MslStore.js
@@ -164,13 +164,13 @@
 	     * 
 	     * <p>For example, if a name and master token is provided, only tokens with
 	     * that name, bound to that master token, and not bound to a user ID token
-	     * are removed.</p>
+	     * are removed. If only a user ID token is provided, all tokens bound to
+	     * that user ID token are removed.</p>
 	     * 
 	     * <p>If no parameters are provided, no tokens are removed.</p>
 	     *
 	     * @param {String} name service token name. May be null.
-	     * @param {MasterToken} masterToken master token. May be null unless a user ID token is
-	     *        also provided.
+	     * @param {MasterToken} masterToken master token. May be null.
 	     * @param {UserIdToken} userIdToken user ID token. May be null.
 	     * @throws MslException if the user ID token is not bound to the master
 	     *         token.

--- a/core/src/main/javascript/util/MslStore.js
+++ b/core/src/main/javascript/util/MslStore.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,20 +157,20 @@
 	    getServiceTokens: function(masterToken, userIdToken) {},
 	
 	    /**
-	     * <p>Remove all service tokens matching all the specified parameters.</p>
-	     * 
-	     * <p>If a name is provided, only tokens with that name are removed. If a
-	     * master token is provided, only tokens bound to that master token are
-	     * removed. If a user ID token is provided, only tokens bound to that user
-	     * ID token are removed.</p>
+	     * <p>Remove all service tokens matching all the specified parameters. A
+	     * null value for the master token or user ID token restricts removal to
+	     * tokens that are not bound to a master token or not bound to a user ID
+	     * token respectively.</p>
 	     * 
 	     * <p>For example, if a name and master token is provided, only tokens with
-	     * that name and bound to that master token are removed.</p>
+	     * that name, bound to that master token, and not bound to a user ID token
+	     * are removed.</p>
 	     * 
 	     * <p>If no parameters are provided, no tokens are removed.</p>
 	     *
 	     * @param {String} name service token name. May be null.
-	     * @param {MasterToken} masterToken master token. May be null.
+	     * @param {MasterToken} masterToken master token. May be null unless a user ID token is
+	     *        also provided.
 	     * @param {UserIdToken} userIdToken user ID token. May be null.
 	     * @throws MslException if the user ID token is not bound to the master
 	     *         token.

--- a/core/src/main/javascript/util/SimpleMslStore.js
+++ b/core/src/main/javascript/util/SimpleMslStore.js
@@ -424,7 +424,7 @@
             // If a user ID token was provided remove all tokens bound to the user
             // ID token. If a name was also provided then limit removal to tokens
             // with the specified name.
-            if (masterToken && userIdToken) {
+            if (userIdToken) {
                 uitTokenSet = this.uitServiceTokens[userIdToken.serialNumber];
                 if (uitTokenSet) {
                     uitBoundKeys = Object.keys(uitTokenSet);

--- a/examples/simple/src/main/javascript/client/package.json
+++ b/examples/simple/src/main/javascript/client/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "clarinet": "^0.11.0",
-    "jsrsasign": "^7.2.2",
-    "jshint": "^2.9.5"
+    "jsrsasign": "^8.0.15",
+    "jshint": "^2.11.1"
   }
 }

--- a/integ-tests/src/test/javascript/package.json
+++ b/integ-tests/src/test/javascript/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "ec-key": "0.0.2",
     "elliptic": "^6.4.0",
-    "jshint": "^2.9.5",
-    "jsrsasign": "^7.2.2",
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15",
     "ursa": "^0.9.4"
   }
 }

--- a/tests/.cproject
+++ b/tests/.cproject
@@ -1,109 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
 	<storageModule moduleId="org.eclipse.cdt.core.settings">
-		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568" moduleId="org.eclipse.cdt.core.settings" name="Debug">
-				<externalSettings/>
-				<extensions>
-					<extension id="org.eclipse.cdt.core.MachO64" point="org.eclipse.cdt.core.BinaryParser"/>
-					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
-					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-				</extensions>
-			</storageModule>
-			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568" name="Debug" parent="cdt.managedbuild.config.gnu.cross.exe.debug.129194568">
-					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.1844414414" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.43558529" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder buildPath="${workspace_loc:/msl-tests}/Debug" id="cdt.managedbuild.target.gnu.builder.macosx.base.756034131" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.1459502394" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool command="/usr/local/bin/g++-7" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1654787322" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
-								<option id="macosx.cpp.link.option.libs.1283465021" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="msl-core"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="crypto"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="pthread"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="curl"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="z"/>
-								</option>
-								<option id="macosx.cpp.link.option.paths.1082102412" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/lib"/>
-								</option>
-								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1103657322" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
-									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
-									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
-								</inputType>
-							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.598028434" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<option id="gnu.both.asm.option.include.paths.1616660223" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
-								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.738645599" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
-							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1675106369" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="/usr/local/bin/g++-7" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1378869369" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
-								<option id="gnu.cpp.compiler.option.include.paths.592003339" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
-								</option>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.1527158162" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
-									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
-									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
-								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.1103614805" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.1667277426" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.2095685891" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.other.443726258" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="-ggdb" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.other.other.677095831" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -Wpointer-arith -fno-omit-frame-pointer -Wformat -Werror=format-security -Werror=array-bounds -fstack-protector" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.warnings.nowarn.89648713" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.1663856523" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.1585264921" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1002399806" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.toerrors.488175136" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.wconversion.480305465" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1835043685" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
-							</tool>
-							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.697820670" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
-								<option id="gnu.c.compiler.option.include.paths.1641897067" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
-								</option>
-								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.973976006" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.908737305" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.258140130" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.672006609" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
-							</tool>
-						</toolChain>
-					</folderInfo>
-					<sourceEntries>
-						<entry excluding="lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/main/cpp"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/test/cpp"/>
-					</sourceEntries>
-				</configuration>
-			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings">
-				<externalSettings containerId="msl-core;cdt.managedbuild.config.gnu.cross.so.debug.1261219416" factoryId="org.eclipse.cdt.core.cfg.export.settings.sipplier">
-					<externalSetting>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Debug"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
-					</externalSetting>
-				</externalSettings>
-			</storageModule>
-		</cconfiguration>
-		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622" moduleId="org.eclipse.cdt.core.settings" name="Release">
+		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245" moduleId="org.eclipse.cdt.core.settings" name="Debug">
 				<externalSettings>
 					<externalSetting>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-tests"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-tests/Release"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Debug"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-tests/Debug"/>
+						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="msl-tests" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -117,96 +23,197 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622" name="Release" parent="cdt.managedbuild.config.gnu.cross.exe.release.1802512622">
-					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.888281384" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.1489325537" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder buildPath="${workspace_loc:/msl-tests}/Release" id="cdt.managedbuild.target.gnu.builder.macosx.base.897652761" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.81692079" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool command="/usr/local/bin/g++-7" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.97252435" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
-								<option id="macosx.cpp.link.option.libs.1535008202" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="msl-core"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="crypto"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="pthread"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="curl"/>
-									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="z"/>
-								</option>
-								<option id="macosx.cpp.link.option.paths.1230734662" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245" name="Debug" parent="cdt.managedbuild.config.gnu.cross.exe.debug" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245." name="/" resourcePath="">
+						<toolChain errorParsers="" id="cdt.managedbuild.toolchain.gnu.macosx.base.1383669104" name="MacOSX GCC" nonInternalBuilderId="cdt.managedbuild.builder.gnu.cross" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.439436129" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
+							<builder buildPath="${workspace_loc:/msl-core}/Debug" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.builder.gnu.cross.2004559693" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.575684029" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1855195074" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
+								<option id="macosx.cpp.link.option.paths.1681729596" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/lib"/>
 								</option>
-								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.715455431" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
+								<option id="macosx.cpp.link.option.libs.285968913" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="msl-core"/>
+									<listOptionValue builtIn="false" value="crypto"/>
+									<listOptionValue builtIn="false" value="pthread"/>
+									<listOptionValue builtIn="false" value="curl"/>
+									<listOptionValue builtIn="false" value="z"/>
+								</option>
+								<option id="macosx.cpp.link.option.flags.782700268" name="Linker flags" superClass="macosx.cpp.link.option.flags" useByScannerDiscovery="false" value="" valueType="string"/>
+								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.417577252" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
 								</inputType>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.721091445" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<option id="gnu.both.asm.option.include.paths.658336774" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.1968779818" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
+								<option id="gnu.both.asm.option.include.paths.1633564861" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1037113984" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1573204453" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.968914762" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.254011418" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
-								<option id="gnu.cpp.compiler.option.include.paths.1714447920" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+							<tool command="ar" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="" id="cdt.managedbuild.tool.gnu.archiver.macosx.base.102444448" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.2071770013" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+								<option id="gnu.cpp.compiler.option.include.paths.682364181" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/test/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.349980858" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option id="gnu.cpp.compiler.option.preprocessor.def.1840885606" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
 									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
 									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.1464316337" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.1381019639" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.1946127744" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.other.other.557774850" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -Wpointer-arith -fno-omit-frame-pointer -Wformat -Werror=format-security -Werror=array-bounds -fstack-protector" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.warnings.nowarn.1322496368" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.1693802620" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.1355655934" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1482268893" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.toerrors.406101342" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.wconversion.593618530" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.debugging.other.1896894688" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="-ggdb" valueType="string"/>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.2000522692" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+								<option id="gnu.cpp.compiler.option.optimization.level.1952647787" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.1618084455" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.485256826" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.759579935" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1428963431" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
-								<option id="gnu.c.compiler.option.include.paths.608128227" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
+							<tool command="/usr/local/bin/gcc-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1176226158" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+								<option id="gnu.c.compiler.option.include.paths.15704130" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.791310028" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.1389056860" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.1286033302" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.898258631" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.106542641" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+								</option>
+								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.1817484847" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.2096512286" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.1667377217" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.include.files.1712504020" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false" valueType="includeFiles"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1867512074" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/main/cpp"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/test/cpp"/>
+						<entry excluding="main/javascript/|main/java/|test/java/|test/javascript/|main/cpp/lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings">
-				<externalSettings containerId="msl-core;cdt.managedbuild.config.gnu.cross.so.release.1284340631" factoryId="org.eclipse.cdt.core.cfg.export.settings.sipplier">
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659" moduleId="org.eclipse.cdt.core.settings" name="Release">
+				<externalSettings>
 					<externalSetting>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Release"/>
 						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.MachO64" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
 			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659" name="Release" parent="cdt.managedbuild.config.gnu.cross.exe.release" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659." name="/" resourcePath="">
+						<toolChain errorParsers="" id="cdt.managedbuild.toolchain.gnu.macosx.base.440047286" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.486771602" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
+							<builder buildPath="${workspace_loc:/msl-core}/Release" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.target.gnu.builder.macosx.base.1142674050" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
+							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.780739361" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1179594792" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
+								<option id="macosx.cpp.link.option.paths.758442765" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Release}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/lib"/>
+								</option>
+								<option id="macosx.cpp.link.option.libs.1516641663" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="msl-core"/>
+									<listOptionValue builtIn="false" value="crypto"/>
+									<listOptionValue builtIn="false" value="pthread"/>
+									<listOptionValue builtIn="false" value="curl"/>
+									<listOptionValue builtIn="false" value="z"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.567751112" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.2131443798" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
+								<option id="gnu.both.asm.option.include.paths.1536637206" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.828932783" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+							<tool errorParsers="" id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1422978416" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.585589160" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+								<option id="gnu.cpp.compiler.option.include.paths.594456184" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/test/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.578659221" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.optimization.level.2091881550" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.1012424629" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.1725855378" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.1996849848" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.1589424196" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.1212295418" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.125317467" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1928762903" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool command="/usr/local/bin/gcc-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1953264969" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+								<option id="gnu.c.compiler.option.include.paths.1658347758" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
+								</option>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.1420430963" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+								</option>
+								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.544636181" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.most" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.1184770750" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.741070673" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.148001690" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.1509173346" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.809298230" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.1144677001" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1982198313" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="main/java/|main/javascript/|test/java/|test/javascript/|main/cpp/lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
-		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619" moduleId="org.eclipse.cdt.core.settings" name="Debug Library">
+		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245.1840533421">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245.1840533421" moduleId="org.eclipse.cdt.core.settings" name="Debug Library">
 				<externalSettings>
 					<externalSetting>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-tests"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Debug"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-tests/Debug"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-tests/Debug Library"/>
+						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="msl-tests" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -216,89 +223,97 @@
 					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619" name="Debug Library" parent="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619">
-					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.debug.129194568.195588619." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.1262943948" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.1634598396" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder buildPath="${workspace_loc:/msl-tests}/Debug Library" id="cdt.managedbuild.target.gnu.builder.macosx.base.1379083283" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.1443322594" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.566618787" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
-								<option id="macosx.cpp.link.option.paths.852422524" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" valueType="libPaths">
+				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245.1840533421" name="Debug Library" parent="cdt.managedbuild.config.gnu.cross.exe.debug" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245.1840533421." name="/" resourcePath="">
+						<toolChain errorParsers="" id="cdt.managedbuild.toolchain.gnu.macosx.base.964847400" name="MacOSX GCC" nonInternalBuilderId="cdt.managedbuild.builder.gnu.cross" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.720342043" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
+							<builder buildPath="${workspace_loc:/msl-core}/Debug" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.builder.gnu.cross.1508261110" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.1469025672" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1715380614" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
+								<option id="macosx.cpp.link.option.paths.498366571" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/lib"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/lib"/>
 								</option>
+								<option id="macosx.cpp.link.option.libs.1994861781" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="msl-core"/>
+									<listOptionValue builtIn="false" value="crypto"/>
+									<listOptionValue builtIn="false" value="pthread"/>
+									<listOptionValue builtIn="false" value="curl"/>
+									<listOptionValue builtIn="false" value="z"/>
+								</option>
+								<option id="macosx.cpp.link.option.flags.1215135738" name="Linker flags" superClass="macosx.cpp.link.option.flags" useByScannerDiscovery="false" value="" valueType="string"/>
+								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1288798156" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.1521214507" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<option id="gnu.both.asm.option.include.paths.1726613433" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.318948763" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
+								<option id="gnu.both.asm.option.include.paths.241689408" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1049126314" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1691795943" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1137820216" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="/usr/local/bin/g++-7" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.271260144" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
-								<option id="gnu.cpp.compiler.option.include.paths.561756412" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+							<tool command="ar" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="" id="cdt.managedbuild.tool.gnu.archiver.macosx.base.13534862" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1007417641" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+								<option id="gnu.cpp.compiler.option.include.paths.227312718" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/test/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.1845721471" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option id="gnu.cpp.compiler.option.preprocessor.def.1318351227" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
 									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
 									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.2016904486" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.566973550" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.213386192" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.other.156200063" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="-ggdb" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.other.other.512724141" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -Wpointer-arith -fno-omit-frame-pointer -Wformat -Werror=format-security -Werror=array-bounds -fstack-protector" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.warnings.nowarn.1620090137" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.387861188" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.1935606686" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.extrawarn.749421700" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.toerrors.2137906632" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.wconversion.879985015" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.359003652" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+								<option id="gnu.cpp.compiler.option.optimization.level.230951799" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.110762430" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2014962614" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.568809394" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.859845840" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
-								<option id="gnu.c.compiler.option.include.paths.2045100379" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
+							<tool command="/usr/local/bin/gcc-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1157727092" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+								<option id="gnu.c.compiler.option.include.paths.1512931436" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.374641711" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.414275714" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.1459799100" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.870066761" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.2015111388" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+								</option>
+								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.972414182" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.1092741101" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.390999286" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.include.files.763753475" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false" valueType="includeFiles"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1377040253" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/main/cpp"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/test/cpp"/>
+						<entry excluding="main/javascript/|main/java/|test/java/|test/javascript/|main/cpp/lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings">
-				<externalSettings containerId="msl-core;cdt.managedbuild.config.gnu.cross.so.debug.1261219416" factoryId="org.eclipse.cdt.core.cfg.export.settings.sipplier">
-					<externalSetting>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Debug"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
-					</externalSetting>
-				</externalSettings>
-			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
-		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633" moduleId="org.eclipse.cdt.core.settings" name="Release Library">
+		<cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659.1631556074">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659.1631556074" moduleId="org.eclipse.cdt.core.settings" name="Release Library">
 				<externalSettings>
 					<externalSetting>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-tests"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-tests/Release"/>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Release"/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-tests/Release Library"/>
+						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
 						<entry flags="RESOLVED" kind="libraryFile" name="msl-tests" srcPrefixMapping="" srcRootPath=""/>
 					</externalSetting>
 				</externalSettings>
@@ -308,88 +323,99 @@
 					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
 					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633" name="Release Library" parent="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633">
-					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633." name="/" resourcePath="">
-						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.1312854591" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
-							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.342838623" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder buildPath="${workspace_loc:/msl-tests}/Release Library" id="cdt.managedbuild.target.gnu.builder.macosx.base.1051254845" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.1199707719" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
-							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1234075371" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
-								<option id="macosx.cpp.link.option.paths.917301000" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" valueType="libPaths">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Debug}&quot;"/>
-									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2m/lib"/>
+				<configuration artifactExtension="a" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.staticLib" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.staticLib,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659.1631556074" name="Release Library" parent="cdt.managedbuild.config.gnu.cross.exe.release" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+					<folderInfo id="cdt.managedbuild.config.gnu.cross.exe.release.1827123659.1631556074." name="/" resourcePath="">
+						<toolChain errorParsers="" id="cdt.managedbuild.toolchain.gnu.macosx.base.1416028791" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.1965408503" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
+							<builder buildPath="${workspace_loc:/msl-core}/Release" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.target.gnu.builder.macosx.base.202160597" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
+							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.938269619" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GLDErrorParser" id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.2057658646" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
+								<option id="macosx.cpp.link.option.paths.2045002420" name="Library search path (-L)" superClass="macosx.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/Release}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/lib"/>
 								</option>
+								<option id="macosx.cpp.link.option.libs.2002735515" name="Libraries (-l)" superClass="macosx.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="msl-core"/>
+									<listOptionValue builtIn="false" value="crypto"/>
+									<listOptionValue builtIn="false" value="pthread"/>
+									<listOptionValue builtIn="false" value="curl"/>
+									<listOptionValue builtIn="false" value="z"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1170833000" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.assembler.macosx.base.789704543" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
-								<option id="gnu.both.asm.option.include.paths.966551943" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+							<tool command="as" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="cdt.managedbuild.tool.gnu.assembler.macosx.base.869504423" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.macosx.base">
+								<option id="gnu.both.asm.option.include.paths.735911559" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
 								</option>
-								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.84373148" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1755499163" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
 							</tool>
-							<tool id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1443167072" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
-							<tool command="/usr/local/bin/g++-6" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1424187117" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
-								<option id="gnu.cpp.compiler.option.include.paths.465623166" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/test/cpp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-tests/src/main/cpp/lib}&quot;"/>
+							<tool errorParsers="" id="cdt.managedbuild.tool.gnu.archiver.macosx.base.1565612037" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.macosx.base"/>
+							<tool command="/usr/local/bin/g++-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.1895901765" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base">
+								<option id="gnu.cpp.compiler.option.include.paths.1579134071" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/test/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.1520566858" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option id="gnu.cpp.compiler.option.preprocessor.def.138376761" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
 									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
 									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.1079411537" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.1662453942" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.dialect.std.538855632" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.other.other.868327135" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -Wpointer-arith -fno-omit-frame-pointer -Wformat -Werror=format-security -Werror=array-bounds -fstack-protector" valueType="string"/>
-								<option id="gnu.cpp.compiler.option.warnings.nowarn.1123466182" name="Inhibit all warnings (-w)" superClass="gnu.cpp.compiler.option.warnings.nowarn" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.1699814782" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.pedantic.90827613" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.extrawarn.275314228" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.toerrors.631650753" name="Warnings as errors (-Werror)" superClass="gnu.cpp.compiler.option.warnings.toerrors" useByScannerDiscovery="false" value="false" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.warnings.wconversion.647833774" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="gnu.cpp.compiler.option.debugging.other.1083324839" name="Other debugging flags" superClass="gnu.cpp.compiler.option.debugging.other" useByScannerDiscovery="false" value="-ggdb" valueType="string"/>
-								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1518815171" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+								<option id="gnu.cpp.compiler.option.optimization.level.1296113236" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.535461786" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.1185256079" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.171887201" name="Pedantic (-pedantic)" superClass="gnu.cpp.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.extrawarn.835992187" name="Extra warnings (-Wextra)" superClass="gnu.cpp.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.pedantic.error.599051531" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.cpp.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.compiler.option.warnings.wconversion.760826629" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.cpp.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.29820215" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
-							<tool command="/usr/local/bin/gcc-7" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1158370398" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
-								<option id="gnu.c.compiler.option.include.paths.1586792133" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core}&quot;"/>
+							<tool command="/usr/local/bin/gcc-9" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1475086582" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.macosx.base">
+								<option id="gnu.c.compiler.option.include.paths.713396327" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/msl-core/src/main/cpp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/main/cpp/lib}&quot;"/>
+									<listOptionValue builtIn="false" value="/usr/local/Cellar/openssl/1.0.2o_1/include"/>
 								</option>
-								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.776024367" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.507778031" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.dialect.std.1765881189" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>
-								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1796434685" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+								<option id="gnu.c.compiler.option.preprocessor.def.symbols.1547253792" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="GTEST_DONT_DEFINE_FAIL=1"/>
+									<listOptionValue builtIn="false" value="RAPIDJSON_HAS_STDSTRING=1"/>
+									<listOptionValue builtIn="false" value="_FORTIFY_SOURCE=2"/>
+								</option>
+								<option defaultValue="gnu.c.optimization.level.most" id="gnu.c.compiler.option.optimization.level.433143268" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.most" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.1112626322" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.dialect.std.2082186632" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.warnings.wconversion.635230877" name="Implicit conversion warnings (-Wconversion)" superClass="gnu.c.compiler.option.warnings.wconversion" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.extrawarn.1428224421" name="Extra warnings (-Wextra)" superClass="gnu.c.compiler.option.warnings.extrawarn" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.error.1277170688" name="Pedantic warnings as errors (-pedantic-errors)" superClass="gnu.c.compiler.option.warnings.pedantic.error" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.c.compiler.option.warnings.pedantic.1771497838" name="Pedantic (-pedantic)" superClass="gnu.c.compiler.option.warnings.pedantic" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.23750848" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/main/cpp"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src/test/cpp"/>
+						<entry excluding="main/java/|main/javascript/|test/java/|test/javascript/|main/cpp/lib/gmock/src/" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
-			<storageModule moduleId="org.eclipse.cdt.core.externalSettings">
-				<externalSettings containerId="msl-core;cdt.managedbuild.config.gnu.cross.so.release.1284340631" factoryId="org.eclipse.cdt.core.cfg.export.settings.sipplier">
-					<externalSetting>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="includePath" name="/msl-core"/>
-						<entry flags="VALUE_WORKSPACE_PATH" kind="libraryPath" name="/msl-core/Release"/>
-						<entry flags="RESOLVED" kind="libraryFile" name="msl-core" srcPrefixMapping="" srcRootPath=""/>
-					</externalSetting>
-				</externalSettings>
-			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="msl-tests.cdt.managedbuild.target.gnu.cross.exe.1953246307" name="Executable"/>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
-	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 	<storageModule moduleId="refreshScope" versionNumber="2">
 		<configuration configurationName="Release Library">
 			<resource resourceType="PROJECT" workspacePath="/msl-tests"/>
@@ -404,6 +430,7 @@
 			<resource resourceType="PROJECT" workspacePath="/msl-tests"/>
 		</configuration>
 	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 	<storageModule moduleId="scannerConfiguration">
 		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.c.compiler.1271217917;cdt.managedbuild.tool.gnu.c.compiler.input.1047369648">
@@ -416,6 +443,12 @@
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.129194568;cdt.managedbuild.config.gnu.cross.exe.debug.129194568.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1646818905;cdt.managedbuild.tool.gnu.cpp.compiler.input.1208905405">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245;cdt.managedbuild.config.gnu.cross.exe.debug.1343669245.;cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.2071770013;cdt.managedbuild.tool.gnu.cpp.compiler.input.759579935">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.1343669245;cdt.managedbuild.config.gnu.cross.exe.debug.1343669245.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1176226158;cdt.managedbuild.tool.gnu.c.compiler.input.1867512074">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633.;cdt.managedbuild.tool.gnu.cross.c.compiler.1630305389;cdt.managedbuild.tool.gnu.c.compiler.input.2064414777">
@@ -458,6 +491,12 @@
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633;cdt.managedbuild.config.gnu.cross.exe.release.1802512622.138891633.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1158370398;cdt.managedbuild.tool.gnu.c.compiler.input.1796434685">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1827123659;cdt.managedbuild.config.gnu.cross.exe.release.1827123659.;cdt.managedbuild.tool.gnu.cpp.compiler.macosx.base.585589160;cdt.managedbuild.tool.gnu.cpp.compiler.input.1928762903">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.release.1827123659;cdt.managedbuild.config.gnu.cross.exe.release.1827123659.;cdt.managedbuild.tool.gnu.c.compiler.macosx.base.1953264969;cdt.managedbuild.tool.gnu.c.compiler.input.1982198313">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 	</storageModule>

--- a/tests/src/main/cpp/util/MslTestUtils.cpp
+++ b/tests/src/main/cpp/util/MslTestUtils.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -273,9 +273,12 @@ set<shared_ptr<ServiceToken>> getMasterBoundServiceTokens(shared_ptr<MslContext>
 	shared_ptr<ICryptoContext> cryptoContext = make_shared<NullCryptoContext>();
 	set<shared_ptr<ServiceToken>> tokens;
 	for (int count = random->nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+        stringstream ss;
+        ss << SERVICE_TOKEN_NAME << random->nextInt();
+        const string name = ss.str();
 		shared_ptr<ByteArray> data = make_shared<ByteArray>(8);
 		random->nextBytes(*data);
-		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, "masterbound" + to_string(count), data, masterToken, shared_ptr<UserIdToken>(), false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
+		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, name, data, masterToken, shared_ptr<UserIdToken>(), false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
 		tokens.insert(token);
 	}
 	return tokens;
@@ -288,9 +291,12 @@ set<shared_ptr<ServiceToken>> getUserBoundServiceTokens(shared_ptr<MslContext> c
 	shared_ptr<ICryptoContext> cryptoContext = make_shared<NullCryptoContext>();
 	set<shared_ptr<ServiceToken>> tokens;
 	for (int count = random->nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+        stringstream ss;
+        ss << SERVICE_TOKEN_NAME << random->nextInt();
+        const string name = ss.str();
 		shared_ptr<ByteArray> data = make_shared<ByteArray>(8);
 		random->nextBytes(*data);
-		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, "masterbound" + to_string(count), data, masterToken, userIdToken, false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
+		shared_ptr<ServiceToken> token = make_shared<ServiceToken>(ctx, name, data, masterToken, userIdToken, false, MslConstants::CompressionAlgorithm::NOCOMPRESSION, cryptoContext);
 		tokens.insert(token);
 	}
 	return tokens;

--- a/tests/src/main/java/com/netflix/msl/util/MslTestUtils.java
+++ b/tests/src/main/java/com/netflix/msl/util/MslTestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,9 +238,10 @@ public class MslTestUtils {
         final ICryptoContext cryptoContext = new NullCryptoContext();
         final Set<ServiceToken> tokens = new HashSet<ServiceToken>();
         for (int count = random.nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+            final String name = SERVICE_TOKEN_NAME + random.nextInt();
             final byte[] data = new byte[8];
             random.nextBytes(data);
-            final ServiceToken token = new ServiceToken(ctx, "masterbound" + count, data, masterToken, null, false, null, cryptoContext);
+            final ServiceToken token = new ServiceToken(ctx, name, data, masterToken, null, false, null, cryptoContext);
             tokens.add(token);
         }
         return tokens;
@@ -262,9 +263,10 @@ public class MslTestUtils {
         final ICryptoContext cryptoContext = new NullCryptoContext();
         final Set<ServiceToken> tokens = new HashSet<ServiceToken>();
         for (int count = random.nextInt(NUM_SERVICE_TOKENS); count >= 0; --count) {
+            final String name = SERVICE_TOKEN_NAME + random.nextInt();
             final byte[] data = new byte[8];
             random.nextBytes(data);
-            final ServiceToken token = new ServiceToken(ctx, "userbound" + count, data, masterToken, userIdToken, false, null, cryptoContext);
+            final ServiceToken token = new ServiceToken(ctx, name, data, masterToken, userIdToken, false, null, cryptoContext);
             tokens.add(token);
         }
         return tokens;

--- a/tests/src/main/javascript/package.json
+++ b/tests/src/main/javascript/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "ec-key": "0.0.2",
     "elliptic": "^6.4.1",
-    "jshint": "^2.9.6",
-    "jsrsasign": "^7.2.2",
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15",
     "ursa": "^0.9.4"
   }
 }

--- a/tests/src/main/javascript/util/MslTestUtils.js
+++ b/tests/src/main/javascript/util/MslTestUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -374,10 +374,11 @@
 	    			callback.result(tokens);
 	    			return;
 	    		}
-	    		
+
+                var name = SERVICE_TOKEN_NAME + random.nextInt();
 	    		var data = new Uint8Array(8);
 	            random.nextBytes(data);
-	            ServiceToken.create(ctx, "masterbound" + count, data, masterToken, null, false, null, cryptoContext, {
+	            ServiceToken.create(ctx, name, data, masterToken, null, false, null, cryptoContext, {
 	            	result: function(token) {
 	            		tokens.push(token);
 	            		--count;
@@ -414,10 +415,11 @@
 	    			callback.result(tokens);
 	    			return;
 	    		}
-	    		
+
+                var name = SERVICE_TOKEN_NAME + random.nextInt();
 	    		var data = new Uint8Array(8);
 	            random.nextBytes(data);
-	            ServiceToken.create(ctx, "userbound" + count, data, masterToken, userIdToken, false, null, cryptoContext, {
+	            ServiceToken.create(ctx, name, data, masterToken, userIdToken, false, null, cryptoContext, {
 	            	result: function(token) {
 	            		tokens.push(token);
 	            		--count;

--- a/tests/src/test/cpp/crypto/JsonWebKeyTest.cpp
+++ b/tests/src/test/cpp/crypto/JsonWebKeyTest.cpp
@@ -28,6 +28,7 @@
 #include <MslEncodingException.h>
 #include <openssl/x509.h>
 #include <openssl/bn.h>
+#include <openssl/opensslv.h>
 #include <memory>
 #include <set>
 #include <string>
@@ -137,15 +138,27 @@ public:
     }
     shared_ptr<ByteArray> getPublicExponent() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BigNumToByteArray(rsa.get()->e);
+#else
+        return BigNumToByteArray(RSA_get0_e(rsa.get()));
+#endif
     }
     shared_ptr<ByteArray> getPrivateExponent() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BigNumToByteArray(rsa.get()->d);
+#else
+        return BigNumToByteArray(RSA_get0_d(rsa.get()));
+#endif
     }
     shared_ptr<ByteArray> getModulus() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BigNumToByteArray(rsa.get()->n);
+#else
+        return BigNumToByteArray(RSA_get0_n(rsa.get()));
+#endif
     }
 private:
     ScopedDisposer<RSA, void, RSA_free> rsa;
@@ -213,14 +226,22 @@ shared_ptr<ByteArray> getModulus(shared_ptr<PublicKey> key)
 {
     ScopedDisposer<RSA, void, RSA_free> rsa(getRsaKeyFromSpki(key));
     assert(rsa);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return BigNumToByteArray(rsa.get()->n);
+#else
+    return BigNumToByteArray(RSA_get0_n(rsa.get()));
+#endif
 }
 
 shared_ptr<ByteArray> getPublicExponent(shared_ptr<PublicKey> key)
 {
     ScopedDisposer<RSA, void, RSA_free> rsa(getRsaKeyFromSpki(key));
     assert(rsa);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return BigNumToByteArray(rsa.get()->e);
+#else
+    return BigNumToByteArray(RSA_get0_e(rsa.get()));
+#endif
 }
 
 EVP_PKEY * getEvpPkeyFromPkcs8(shared_ptr<PrivateKey> key)
@@ -256,7 +277,11 @@ shared_ptr<ByteArray> getModulus(shared_ptr<PrivateKey> key)
     const RSA * const rsa = EVP_PKEY_get1_RSA(pkey.get());
     assert(rsa);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return BigNumToByteArray(rsa->n);
+#else
+    return BigNumToByteArray(RSA_get0_n(rsa));
+#endif
 }
 
 shared_ptr<ByteArray> getPublicExponent(shared_ptr<PrivateKey> key)
@@ -268,7 +293,11 @@ shared_ptr<ByteArray> getPublicExponent(shared_ptr<PrivateKey> key)
     const RSA * const rsa = EVP_PKEY_get1_RSA(pkey.get());
     assert(rsa);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return BigNumToByteArray(rsa->e);
+#else
+    return BigNumToByteArray(RSA_get0_e(rsa));
+#endif
 }
 
 shared_ptr<ByteArray> getPrivateExponent(shared_ptr<PrivateKey> key)
@@ -280,7 +309,11 @@ shared_ptr<ByteArray> getPrivateExponent(shared_ptr<PrivateKey> key)
     const RSA * const rsa = EVP_PKEY_get1_RSA(pkey.get());
     assert(rsa);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     return BigNumToByteArray(rsa->d);
+#else
+    return BigNumToByteArray(RSA_get0_d(rsa));
+#endif
 }
 
 } // namespace anonymous

--- a/tests/src/test/cpp/crypto/RsaEvpKeyTest.cpp
+++ b/tests/src/test/cpp/crypto/RsaEvpKeyTest.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <vector>
 #include <openssl/x509.h>
+#include <openssl/opensslv.h>
 
 using namespace std;
 using namespace netflix::msl;
@@ -101,9 +102,15 @@ public:
     {
         if (!rsa.get())
             throw MslInternalException("RsaKey not initialized");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         pubMod = extractBignum(rsa.get()->n);
         pubExp = extractBignum(rsa.get()->e);
         privExp = extractBignum(rsa.get()->d);
+#else
+        pubMod = extractBignum(RSA_get0_n(rsa.get()));
+        pubExp = extractBignum(RSA_get0_e(rsa.get()));
+        privExp = extractBignum(RSA_get0_d(rsa.get()));
+#endif
     }
 private:
     ScopedDisposer<RSA, void, RSA_free> rsa;

--- a/tests/src/test/cpp/msg/MessageServiceTokenBuilderTest.cpp
+++ b/tests/src/test/cpp/msg/MessageServiceTokenBuilderTest.cpp
@@ -608,6 +608,14 @@ TEST_F(MessageServiceTokenBuilderTest, excludeUnboundPrimaryServiceToken)
     EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, false, false));
     EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
     EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, excludeMasterBoundPrimaryServiceToken)
@@ -630,6 +638,16 @@ TEST_F(MessageServiceTokenBuilderTest, excludeMasterBoundPrimaryServiceToken)
     EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, false));
     EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
     EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+
+
 }
 
 TEST_F(MessageServiceTokenBuilderTest, excludeUserBoundPrimaryServiceToken)
@@ -650,6 +668,14 @@ TEST_F(MessageServiceTokenBuilderTest, excludeUserBoundPrimaryServiceToken)
     EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
 
     EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(serviceToken));
     EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
     EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
 }
@@ -700,6 +726,11 @@ TEST_F(MessageServiceTokenBuilderTest, deleteUnboundPrimaryServiceToken)
 	EXPECT_FALSE(msgServiceToken->isEncrypted());
 	EXPECT_FALSE(msgServiceToken->isMasterTokenBound());
 	EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(serviceToken));
+    EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteMasterBoundPrimaryServiceToken)
@@ -730,6 +761,11 @@ TEST_F(MessageServiceTokenBuilderTest, deleteMasterBoundPrimaryServiceToken)
     EXPECT_FALSE(msgServiceToken->isEncrypted());
     EXPECT_TRUE(msgServiceToken->isBoundTo(MASTER_TOKEN));
     EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(serviceToken));
+    EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteUserBoundPrimaryServiceToken)
@@ -760,6 +796,11 @@ TEST_F(MessageServiceTokenBuilderTest, deleteUserBoundPrimaryServiceToken)
     EXPECT_FALSE(msgServiceToken->isEncrypted());
     EXPECT_TRUE(msgServiceToken->isBoundTo(MASTER_TOKEN));
     EXPECT_TRUE(msgServiceToken->isBoundTo(USER_ID_TOKEN));
+
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(serviceToken));
+    EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteUnknownPrimaryServiceToken)
@@ -961,6 +1002,14 @@ TEST_F(MessageServiceTokenBuilderTest, excludeUnboundPeerServiceToken)
     EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, false, false));
     EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
     EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, excludeMasterBoundPeerServiceToken)
@@ -984,6 +1033,14 @@ TEST_F(MessageServiceTokenBuilderTest, excludeMasterBoundPeerServiceToken)
     EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, false));
     EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
     EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, excludeUserBoundPeerServiceToken)
@@ -1005,6 +1062,14 @@ TEST_F(MessageServiceTokenBuilderTest, excludeUserBoundPeerServiceToken)
     EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
 
     EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(serviceToken));
     EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
     EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
 }
@@ -1057,6 +1122,11 @@ TEST_F(MessageServiceTokenBuilderTest, deleteUnboundPeerServiceToken)
 	EXPECT_FALSE(msgServiceToken->isEncrypted());
 	EXPECT_FALSE(msgServiceToken->isMasterTokenBound());
 	EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+
+	EXPECT_TRUE(tokenBuilder->addPeerServiceToken(serviceToken));
+	EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(serviceToken));
+	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+	EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteMasterBoundPeerServiceToken)
@@ -1088,6 +1158,11 @@ TEST_F(MessageServiceTokenBuilderTest, deleteMasterBoundPeerServiceToken)
     EXPECT_FALSE(msgServiceToken->isEncrypted());
     EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_MASTER_TOKEN));
     EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(serviceToken));
+    EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteUserBoundPeerServiceToken)
@@ -1119,6 +1194,11 @@ TEST_F(MessageServiceTokenBuilderTest, deleteUserBoundPeerServiceToken)
     EXPECT_FALSE(msgServiceToken->isEncrypted());
     EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_MASTER_TOKEN));
     EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_USER_ID_TOKEN));
+
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(serviceToken));
+    EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(serviceToken));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteUnknownPeerServiceToken)

--- a/tests/src/test/cpp/msg/MessageServiceTokenBuilderTest.cpp
+++ b/tests/src/test/cpp/msg/MessageServiceTokenBuilderTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,6 +276,37 @@ TEST_F(MessageServiceTokenBuilderTest, addPrimaryServiceToken)
 	EXPECT_EQ(serviceToken, builderServiceToken);
 }
 
+TEST_F(MessageServiceTokenBuilderTest, addNamedPrimaryServiceTokens)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_TRUE(tokenBuilder->getPrimaryServiceTokens().empty());
+
+    shared_ptr<ServiceToken> unboundServiceTokenA = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(unboundServiceTokenA));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+
+    shared_ptr<ServiceToken> unboundServiceTokenB = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(unboundServiceTokenB));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+
+    shared_ptr<ServiceToken> masterBoundServiceTokenA = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(masterBoundServiceTokenA));
+    EXPECT_EQ(static_cast<size_t>(2), tokenBuilder->getPrimaryServiceTokens().size());
+
+    shared_ptr<ServiceToken> masterBoundServiceTokenB = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(masterBoundServiceTokenB));
+    EXPECT_EQ(static_cast<size_t>(2), tokenBuilder->getPrimaryServiceTokens().size());
+
+    shared_ptr<ServiceToken> userBoundServiceTokenA = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(userBoundServiceTokenA));
+    EXPECT_EQ(static_cast<size_t>(3), tokenBuilder->getPrimaryServiceTokens().size());
+
+    shared_ptr<ServiceToken> userBoundServiceTokenB = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPrimaryServiceToken(userBoundServiceTokenB));
+    EXPECT_EQ(static_cast<size_t>(3), tokenBuilder->getPrimaryServiceTokens().size());
+}
+
 TEST_F(MessageServiceTokenBuilderTest, mismatchedMasterTokenAddPrimaryServiceToken)
 {
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
@@ -331,6 +362,38 @@ TEST_F(MessageServiceTokenBuilderTest, addPeerServiceToken)
 	EXPECT_EQ(static_cast<size_t>(1), serviceTokens.size());
 	shared_ptr<ServiceToken> builderServiceToken = *serviceTokens.begin();
 	EXPECT_EQ(serviceToken, builderServiceToken);
+}
+
+TEST_F(MessageServiceTokenBuilderTest, addNamedPeerServiceTokens)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_TRUE(tokenBuilder->getPeerServiceTokens().empty());
+
+    shared_ptr<ServiceToken> unboundServiceTokenA = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(unboundServiceTokenA));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+
+    shared_ptr<ServiceToken> unboundServiceTokenB = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(unboundServiceTokenB));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+
+    shared_ptr<ServiceToken> masterBoundServiceTokenA = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(masterBoundServiceTokenA));
+    EXPECT_EQ(static_cast<size_t>(2), tokenBuilder->getPeerServiceTokens().size());
+
+    shared_ptr<ServiceToken> masterBoundServiceTokenB = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, NULL_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(masterBoundServiceTokenB));
+    EXPECT_EQ(static_cast<size_t>(2), tokenBuilder->getPeerServiceTokens().size());
+
+    shared_ptr<ServiceToken> userBoundServiceTokenA = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(userBoundServiceTokenA));
+    EXPECT_EQ(static_cast<size_t>(3), tokenBuilder->getPeerServiceTokens().size());
+
+    shared_ptr<ServiceToken> userBoundServiceTokenB = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, CompressionAlgorithm::NOCOMPRESSION, make_shared<NullCryptoContext>());
+    EXPECT_TRUE(tokenBuilder->addPeerServiceToken(userBoundServiceTokenB));
+    EXPECT_EQ(static_cast<size_t>(3), tokenBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, mismatchedMasterTokenAddPeerServiceToken)
@@ -525,18 +588,70 @@ TEST_F(MessageServiceTokenBuilderTest, noCryptoContextAddUserBoundPrimaryService
 	EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
 }
 
-TEST_F(MessageServiceTokenBuilderTest, excludePrimaryServiceToken)
+TEST_F(MessageServiceTokenBuilderTest, excludeUnboundPrimaryServiceToken)
 {
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
-	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
 	msgBuilder->addServiceToken(serviceToken);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+	EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
 
-	EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME));
-	EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+	EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, false));
+	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
 
-	EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, excludeMasterBoundPrimaryServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, excludeUserBoundPrimaryServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, false));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, excludeUnknownPrimaryServiceToken)
@@ -544,26 +659,38 @@ TEST_F(MessageServiceTokenBuilderTest, excludeUnknownPrimaryServiceToken)
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 
-	EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME));
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPrimaryServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
 }
 
-TEST_F(MessageServiceTokenBuilderTest, deletePrimaryServiceToken)
+TEST_F(MessageServiceTokenBuilderTest, deleteUnboundPrimaryServiceToken)
 {
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
-	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
 	msgBuilder->addServiceToken(serviceToken);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
 
-	EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, false));
+    EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, false, false));
 	set<shared_ptr<ServiceToken>> builderServiceTokens = tokenBuilder->getPrimaryServiceTokens();
 	EXPECT_EQ(static_cast<size_t>(1), builderServiceTokens.size());
 	shared_ptr<ServiceToken> builderServiceToken = *builderServiceTokens.begin();
 	EXPECT_EQ(TOKEN_NAME, builderServiceToken->getName());
 	EXPECT_EQ(static_cast<size_t>(0), builderServiceToken->getData()->size());
 	EXPECT_FALSE(builderServiceToken->isEncrypted());
-	EXPECT_TRUE(builderServiceToken->isBoundTo(MASTER_TOKEN));
-	EXPECT_TRUE(builderServiceToken->isBoundTo(USER_ID_TOKEN));
+	EXPECT_FALSE(builderServiceToken->isMasterTokenBound());
+	EXPECT_FALSE(builderServiceToken->isUserIdTokenBound());
 
 	set<shared_ptr<ServiceToken>> msgServiceTokens = msgBuilder->getServiceTokens();
 	EXPECT_EQ(static_cast<size_t>(1), msgServiceTokens.size());
@@ -571,8 +698,68 @@ TEST_F(MessageServiceTokenBuilderTest, deletePrimaryServiceToken)
 	EXPECT_EQ(TOKEN_NAME, msgServiceToken->getName());
 	EXPECT_EQ(static_cast<size_t>(0), msgServiceToken->getData()->size());
 	EXPECT_FALSE(msgServiceToken->isEncrypted());
-	EXPECT_TRUE(msgServiceToken->isBoundTo(MASTER_TOKEN));
-	EXPECT_TRUE(msgServiceToken->isBoundTo(USER_ID_TOKEN));
+	EXPECT_FALSE(msgServiceToken->isMasterTokenBound());
+	EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, deleteMasterBoundPrimaryServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, false, false));
+    EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, true));
+    EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, false));
+    set<shared_ptr<ServiceToken>> builderServiceTokens = tokenBuilder->getPrimaryServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), builderServiceTokens.size());
+    shared_ptr<ServiceToken> builderServiceToken = *builderServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, builderServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), builderServiceToken->getData()->size());
+    EXPECT_FALSE(builderServiceToken->isEncrypted());
+    EXPECT_TRUE(builderServiceToken->isBoundTo(MASTER_TOKEN));
+    EXPECT_FALSE(builderServiceToken->isUserIdTokenBound());
+
+    set<shared_ptr<ServiceToken>> msgServiceTokens = msgBuilder->getServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), msgServiceTokens.size());
+    shared_ptr<ServiceToken> msgServiceToken = *msgServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, msgServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), msgServiceToken->getData()->size());
+    EXPECT_FALSE(msgServiceToken->isEncrypted());
+    EXPECT_TRUE(msgServiceToken->isBoundTo(MASTER_TOKEN));
+    EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, deleteUserBoundPrimaryServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPrimaryServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, false, false));
+    EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, false));
+    EXPECT_TRUE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, true));
+    set<shared_ptr<ServiceToken>> builderServiceTokens = tokenBuilder->getPrimaryServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), builderServiceTokens.size());
+    shared_ptr<ServiceToken> builderServiceToken = *builderServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, builderServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), builderServiceToken->getData()->size());
+    EXPECT_FALSE(builderServiceToken->isEncrypted());
+    EXPECT_TRUE(builderServiceToken->isBoundTo(MASTER_TOKEN));
+    EXPECT_TRUE(builderServiceToken->isBoundTo(USER_ID_TOKEN));
+
+    set<shared_ptr<ServiceToken>> msgServiceTokens = msgBuilder->getServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), msgServiceTokens.size());
+    shared_ptr<ServiceToken> msgServiceToken = *msgServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, msgServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), msgServiceToken->getData()->size());
+    EXPECT_FALSE(msgServiceToken->isEncrypted());
+    EXPECT_TRUE(msgServiceToken->isBoundTo(MASTER_TOKEN));
+    EXPECT_TRUE(msgServiceToken->isBoundTo(USER_ID_TOKEN));
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteUnknownPrimaryServiceToken)
@@ -580,7 +767,9 @@ TEST_F(MessageServiceTokenBuilderTest, deleteUnknownPrimaryServiceToken)
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 
-	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, false, false));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, false));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, true));
 }
 
 TEST_F(MessageServiceTokenBuilderTest, addUnboundPeerServiceToken)
@@ -751,19 +940,73 @@ TEST_F(MessageServiceTokenBuilderTest, trustedNetAddUserBoundPeerServiceToken)
 	EXPECT_FALSE(tokenBuilder->addUserBoundPeerServiceToken(TOKEN_NAME, DATA, ENCRYPT, COMPRESSION_ALGO));
 }
 
-TEST_F(MessageServiceTokenBuilderTest, excludePeerServiceToken)
+TEST_F(MessageServiceTokenBuilderTest, excludeUnboundPeerServiceToken)
 {
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
 	msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
-	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
 	msgBuilder->addPeerServiceToken(serviceToken);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+	EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
 
-	EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME));
-	EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+	EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, false));
+	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
 
-	EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getServiceTokens().size());
+    EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, excludeMasterBoundPeerServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addPeerServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, excludeUserBoundPeerServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addPeerServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, false));
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(1), msgBuilder->getPeerServiceTokens().size());
+
+    EXPECT_TRUE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
 }
 
 TEST_F(MessageServiceTokenBuilderTest, excludeUnknownPeerServiceToken)
@@ -772,27 +1015,39 @@ TEST_F(MessageServiceTokenBuilderTest, excludeUnknownPeerServiceToken)
 	msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 
-	EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME));
+	EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, false, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+
+	EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, false));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
+
+	EXPECT_FALSE(tokenBuilder->excludePeerServiceToken(TOKEN_NAME, true, true));
+    EXPECT_EQ(static_cast<size_t>(0), tokenBuilder->getPeerServiceTokens().size());
+    EXPECT_EQ(static_cast<size_t>(0), msgBuilder->getPeerServiceTokens().size());
 }
 
-TEST_F(MessageServiceTokenBuilderTest, deletePeerServiceToken)
+TEST_F(MessageServiceTokenBuilderTest, deleteUnboundPeerServiceToken)
 {
 	shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
 	msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
-	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+	shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
 	msgBuilder->addPeerServiceToken(serviceToken);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 	EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
 
-	EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME));
+	EXPECT_FALSE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, true, false));
+	EXPECT_FALSE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, true, true));
+	EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, false, false));
 	set<shared_ptr<ServiceToken>> builderServiceTokens = tokenBuilder->getPeerServiceTokens();
 	EXPECT_EQ(static_cast<size_t>(1), builderServiceTokens.size());
 	shared_ptr<ServiceToken> builderServiceToken = *builderServiceTokens.begin();
 	EXPECT_EQ(TOKEN_NAME, builderServiceToken->getName());
 	EXPECT_EQ(static_cast<size_t>(0), builderServiceToken->getData()->size());
 	EXPECT_FALSE(builderServiceToken->isEncrypted());
-	EXPECT_TRUE(builderServiceToken->isBoundTo(PEER_MASTER_TOKEN));
-	EXPECT_TRUE(builderServiceToken->isBoundTo(PEER_USER_ID_TOKEN));
+	EXPECT_FALSE(builderServiceToken->isMasterTokenBound());
+	EXPECT_FALSE(builderServiceToken->isUserIdTokenBound());
 
 	set<shared_ptr<ServiceToken>> msgServiceTokens = msgBuilder->getPeerServiceTokens();
 	EXPECT_EQ(static_cast<size_t>(1), msgServiceTokens.size());
@@ -800,8 +1055,70 @@ TEST_F(MessageServiceTokenBuilderTest, deletePeerServiceToken)
 	EXPECT_EQ(TOKEN_NAME, msgServiceToken->getName());
 	EXPECT_EQ(static_cast<size_t>(0), msgServiceToken->getData()->size());
 	EXPECT_FALSE(msgServiceToken->isEncrypted());
-	EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_MASTER_TOKEN));
-	EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_USER_ID_TOKEN));
+	EXPECT_FALSE(msgServiceToken->isMasterTokenBound());
+	EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, deleteMasterBoundPeerServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, NULL_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addPeerServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, false, false));
+    EXPECT_FALSE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, true, true));
+    EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, true, false));
+    set<shared_ptr<ServiceToken>> builderServiceTokens = tokenBuilder->getPeerServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), builderServiceTokens.size());
+    shared_ptr<ServiceToken> builderServiceToken = *builderServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, builderServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), builderServiceToken->getData()->size());
+    EXPECT_FALSE(builderServiceToken->isEncrypted());
+    EXPECT_TRUE(builderServiceToken->isBoundTo(PEER_MASTER_TOKEN));
+    EXPECT_FALSE(builderServiceToken->isUserIdTokenBound());
+
+    set<shared_ptr<ServiceToken>> msgServiceTokens = msgBuilder->getPeerServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), msgServiceTokens.size());
+    shared_ptr<ServiceToken> msgServiceToken = *msgServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, msgServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), msgServiceToken->getData()->size());
+    EXPECT_FALSE(msgServiceToken->isEncrypted());
+    EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_MASTER_TOKEN));
+    EXPECT_FALSE(msgServiceToken->isUserIdTokenBound());
+}
+
+TEST_F(MessageServiceTokenBuilderTest, deleteUserBoundPeerServiceToken)
+{
+    shared_ptr<MessageBuilder> msgBuilder = messageFactory->createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+    msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+    shared_ptr<ServiceToken> serviceToken = make_shared<ServiceToken>(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, make_shared<NullCryptoContext>());
+    msgBuilder->addPeerServiceToken(serviceToken);
+    shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
+    EXPECT_EQ(static_cast<size_t>(1), tokenBuilder->getPeerServiceTokens().size());
+
+    EXPECT_FALSE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, false, false));
+    EXPECT_FALSE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, true, false));
+    EXPECT_TRUE(tokenBuilder->deletePeerServiceToken(TOKEN_NAME, true, true));
+    set<shared_ptr<ServiceToken>> builderServiceTokens = tokenBuilder->getPeerServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), builderServiceTokens.size());
+    shared_ptr<ServiceToken> builderServiceToken = *builderServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, builderServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), builderServiceToken->getData()->size());
+    EXPECT_FALSE(builderServiceToken->isEncrypted());
+    EXPECT_TRUE(builderServiceToken->isBoundTo(PEER_MASTER_TOKEN));
+    EXPECT_TRUE(builderServiceToken->isBoundTo(PEER_USER_ID_TOKEN));
+
+    set<shared_ptr<ServiceToken>> msgServiceTokens = msgBuilder->getPeerServiceTokens();
+    EXPECT_EQ(static_cast<size_t>(1), msgServiceTokens.size());
+    shared_ptr<ServiceToken> msgServiceToken = *msgServiceTokens.begin();
+    EXPECT_EQ(TOKEN_NAME, msgServiceToken->getName());
+    EXPECT_EQ(static_cast<size_t>(0), msgServiceToken->getData()->size());
+    EXPECT_FALSE(msgServiceToken->isEncrypted());
+    EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_MASTER_TOKEN));
+    EXPECT_TRUE(msgServiceToken->isBoundTo(PEER_USER_ID_TOKEN));
 }
 
 TEST_F(MessageServiceTokenBuilderTest, deleteUnknownPeerServiceToken)
@@ -810,7 +1127,9 @@ TEST_F(MessageServiceTokenBuilderTest, deleteUnknownPeerServiceToken)
 	msgBuilder->setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
 	shared_ptr<MessageServiceTokenBuilder> tokenBuilder = make_shared<MessageServiceTokenBuilder>(p2pCtx, p2pMsgCtx, msgBuilder);
 
-	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, false, false));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, false));
+	EXPECT_FALSE(tokenBuilder->deletePrimaryServiceToken(TOKEN_NAME, true, true));
 }
 
 }}} // namespace netflix::msl::msg

--- a/tests/src/test/cpp/util/SimpleMslStoreTest.cpp
+++ b/tests/src/test/cpp/util/SimpleMslStoreTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Netflix, Inc.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -711,9 +711,12 @@ TEST_F(SimpleMslStoreTest, removeMasterBoundServiceTokens)
 	set<shared_ptr<ServiceToken>> storedMasterBoundTokens = store->getServiceTokens(masterToken, NULL_USER_ID_TOKEN);
 	EXPECT_TRUE(MslTestUtils::equal(unboundTokens, storedMasterBoundTokens));
 
-	// This should only return the unbound tokens.
+	// This should only return the unbound and user-bound tokens.
+	set<shared_ptr<ServiceToken>> unboundAndUserBoundTokens;
+	unboundAndUserBoundTokens.insert(unboundTokens.begin(), unboundTokens.end());
+	unboundAndUserBoundTokens.insert(userBoundTokens.begin(), userBoundTokens.end());
 	set<shared_ptr<ServiceToken>> storedUserBoundTokens = store->getServiceTokens(masterToken, userIdToken);
-	EXPECT_TRUE(MslTestUtils::equal(unboundTokens, storedUserBoundTokens));
+	EXPECT_TRUE(MslTestUtils::equal(unboundAndUserBoundTokens, storedUserBoundTokens));
 
 	// This should only return the unbound tokens.
 	set<shared_ptr<ServiceToken>> storedUnboundTokens = store->getServiceTokens(NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN);
@@ -819,7 +822,7 @@ TEST_F(SimpleMslStoreTest, removeNamedServiceTokens)
 		if (random->nextBoolean()) continue;
 		shared_ptr<ServiceToken> token = *tokens;
 		shared_ptr<string> name = make_shared<string>(token->getName());
-		store->removeServiceTokens(name, NULL_MASTER_TOKEN, NULL_USER_ID_TOKEN);
+		store->removeServiceTokens(name, token->isMasterTokenBound() ? masterToken : NULL_MASTER_TOKEN, token->isUserIdTokenBound() ? userIdToken : NULL_USER_ID_TOKEN);
 		removedTokens.insert(token);
 	}
 

--- a/tests/src/test/cpp/util/SimpleMslStoreTest.cpp
+++ b/tests/src/test/cpp/util/SimpleMslStoreTest.cpp
@@ -738,7 +738,7 @@ TEST_F(SimpleMslStoreTest, removeUserBoundServiceTokens)
 	store->addServiceTokens(userBoundTokens);
 	store->addServiceTokens(unboundTokens);
 
-	store->removeServiceTokens(NULL_NAME, masterToken, userIdToken);
+	store->removeServiceTokens(NULL_NAME, NULL_MASTER_TOKEN, userIdToken);
 
 	// This should only return the unbound and master bound-only tokens.
 	set<shared_ptr<ServiceToken>> storedMasterBoundTokens = store->getServiceTokens(masterToken, NULL_USER_ID_TOKEN);

--- a/tests/src/test/java/com/netflix/msl/msg/MessageBuilderSuite.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageBuilderSuite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -800,6 +800,37 @@ public class MessageBuilderSuite {
         }
         
         @Test
+        public void addNamedServiceTokens() throws MslException {
+            final MessageBuilder builder = messageFactory.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
+            final byte[] data = new byte[1];
+            random.nextBytes(data);
+            
+            final ServiceToken unboundServiceTokenA = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, null, null, false, null, new NullCryptoContext());
+            builder.addServiceToken(unboundServiceTokenA);
+            assertEquals(1, builder.getServiceTokens().size());
+            
+            final ServiceToken unboundServiceTokenB = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, null, null, false, null, new NullCryptoContext());
+            builder.addServiceToken(unboundServiceTokenB);
+            assertEquals(1, builder.getServiceTokens().size());
+            
+            final ServiceToken masterBoundServiceTokenA = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, null, false, null, new NullCryptoContext());
+            builder.addServiceToken(masterBoundServiceTokenA);
+            assertEquals(2, builder.getServiceTokens().size());
+            
+            final ServiceToken masterBoundServiceTokenB = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, null, false, null, new NullCryptoContext());
+            builder.addServiceToken(masterBoundServiceTokenB);
+            assertEquals(2, builder.getServiceTokens().size());
+            
+            final ServiceToken userBoundServiceTokenA = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, USER_ID_TOKEN, false, null, new NullCryptoContext());
+            builder.addServiceToken(userBoundServiceTokenA);
+            assertEquals(3, builder.getServiceTokens().size());
+            
+            final ServiceToken userBoundServiceTokenB = new ServiceToken(trustedNetCtx, SERVICE_TOKEN_NAME, data, MASTER_TOKEN, USER_ID_TOKEN, false, null, new NullCryptoContext());
+            builder.addServiceToken(userBoundServiceTokenB);
+            assertEquals(3, builder.getServiceTokens().size());
+        }
+        
+        @Test
         public void excludeServiceToken() throws MslEncodingException, MslCryptoException, MslException {
             final MessageBuilder builder = messageFactory.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
             final Set<ServiceToken> serviceTokens = MslTestUtils.getServiceTokens(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
@@ -810,7 +841,7 @@ public class MessageBuilderSuite {
             final Iterator<ServiceToken> tokens = serviceTokens.iterator();
             while (tokens.hasNext()) {
                 final ServiceToken token = tokens.next();
-                builder.excludeServiceToken(token.getName());
+                builder.excludeServiceToken(token.getName(), token.isMasterTokenBound(), token.isUserIdTokenBound());
                 tokens.remove();
                 final MessageHeader messageHeader = builder.getHeader();
                 assertTrue(messageHeader.getServiceTokens().equals(serviceTokens));
@@ -828,7 +859,7 @@ public class MessageBuilderSuite {
             builder.addServiceToken(serviceToken);
             
             // Delete the service token.
-            builder.deleteServiceToken(SERVICE_TOKEN_NAME);
+            builder.deleteServiceToken(SERVICE_TOKEN_NAME, true, true);
             final MessageHeader messageHeader = builder.getHeader();
             final Set<ServiceToken> tokens = messageHeader.getServiceTokens();
             for (final ServiceToken token : tokens) {
@@ -843,13 +874,16 @@ public class MessageBuilderSuite {
         @Test
         public void deleteUnknownServiceToken() throws MslException {
             final MessageBuilder builder = messageFactory.createRequest(trustedNetCtx, MASTER_TOKEN, USER_ID_TOKEN);
-            builder.deleteServiceToken(SERVICE_TOKEN_NAME);
+            builder.deleteServiceToken(SERVICE_TOKEN_NAME, true, true);
             final MessageHeader messageHeader = builder.getHeader();
             final Set<ServiceToken> tokens = messageHeader.getServiceTokens();
             for (final ServiceToken token : tokens) {
-                if (token.getName().equals(SERVICE_TOKEN_NAME))
-                    fail("Deleted unknown service token.");
+                if (token.getName().equals(SERVICE_TOKEN_NAME)) {
+                    assertEquals(0, token.getData().length);
+                    return;
+                }
             }
+            fail("Deleted unknown service token not found.");
         }
         
         @Test(expected = MslInternalException.class)
@@ -925,6 +959,38 @@ public class MessageBuilderSuite {
         }
         
         @Test
+        public void addNamedPeerServiceTokens() throws MslException {
+            final MessageBuilder builder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+            builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+            final byte[] data = new byte[1];
+            random.nextBytes(data);
+            
+            final ServiceToken unboundServiceTokenA = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, data, null, null, false, null, new NullCryptoContext());
+            builder.addPeerServiceToken(unboundServiceTokenA);
+            assertEquals(1, builder.getPeerServiceTokens().size());
+            
+            final ServiceToken unboundServiceTokenB = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, data, null, null, false, null, new NullCryptoContext());
+            builder.addPeerServiceToken(unboundServiceTokenB);
+            assertEquals(1, builder.getPeerServiceTokens().size());
+            
+            final ServiceToken masterBoundServiceTokenA = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, data, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
+            builder.addPeerServiceToken(masterBoundServiceTokenA);
+            assertEquals(2, builder.getPeerServiceTokens().size());
+            
+            final ServiceToken masterBoundServiceTokenB = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, data, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
+            builder.addPeerServiceToken(masterBoundServiceTokenB);
+            assertEquals(2, builder.getPeerServiceTokens().size());
+            
+            final ServiceToken userBoundServiceTokenA = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, data, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, null, new NullCryptoContext());
+            builder.addPeerServiceToken(userBoundServiceTokenA);
+            assertEquals(3, builder.getPeerServiceTokens().size());
+            
+            final ServiceToken userBoundServiceTokenB = new ServiceToken(p2pCtx, SERVICE_TOKEN_NAME, data, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, null, new NullCryptoContext());
+            builder.addPeerServiceToken(userBoundServiceTokenB);
+            assertEquals(3, builder.getPeerServiceTokens().size());
+        }
+        
+        @Test
         public void excludePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMasterTokenException, MslEntityAuthException, MslException {
             final MessageBuilder builder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
@@ -935,7 +1001,7 @@ public class MessageBuilderSuite {
             final Iterator<ServiceToken> tokens = serviceTokens.iterator();
             while (tokens.hasNext()) {
                 final ServiceToken token = tokens.next();
-                builder.excludePeerServiceToken(token.getName());
+                builder.excludePeerServiceToken(token.getName(), token.isMasterTokenBound(), token.isUserIdTokenBound());
                 tokens.remove();
                 assertEquals(serviceTokens, builder.getPeerServiceTokens());
                 final MessageHeader messageHeader = builder.getHeader();
@@ -955,7 +1021,7 @@ public class MessageBuilderSuite {
             builder.addPeerServiceToken(serviceToken);
             
             // Delete the service token.
-            builder.deletePeerServiceToken(SERVICE_TOKEN_NAME);
+            builder.deletePeerServiceToken(SERVICE_TOKEN_NAME, true, true);
             final MessageHeader messageHeader = builder.getHeader();
             final Set<ServiceToken> tokens = messageHeader.getPeerServiceTokens();
             for (final ServiceToken token : tokens) {
@@ -971,13 +1037,16 @@ public class MessageBuilderSuite {
         public void deleteUnknownPeerServiceToken() throws MslException {
             final MessageBuilder builder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
             builder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
-            builder.deletePeerServiceToken(SERVICE_TOKEN_NAME);
+            builder.deletePeerServiceToken(SERVICE_TOKEN_NAME, true, true);
             final MessageHeader messageHeader = builder.getHeader();
             final Set<ServiceToken> tokens = messageHeader.getPeerServiceTokens();
             for (final ServiceToken token : tokens) {
-                if (token.getName().equals(SERVICE_TOKEN_NAME))
-                    fail("Deleted unknown peer service token.");
+                if (token.getName().equals(SERVICE_TOKEN_NAME)) {
+                    assertEquals(0, token.getData().length);
+                    return;
+                }
             }
+            fail("Deleted unknown peer service token not found.");
         }
         
         @Test
@@ -1225,7 +1294,7 @@ public class MessageBuilderSuite {
         @Test(expected = MslInternalException.class)
         public void negativeMessageId() throws MslEncodingException, MslEntityAuthException, MslMessageException, MslCryptoException {
             final Long messageId = -12L;
-            ErrorHeader errorHeader = messageFactory.createErrorResponse(trustedNetCtx, messageId, MSL_ERROR, USER_MESSAGE);
+            messageFactory.createErrorResponse(trustedNetCtx, messageId, MSL_ERROR, USER_MESSAGE);
         }
         
         @Test

--- a/tests/src/test/java/com/netflix/msl/msg/MessageServiceTokenBuilderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageServiceTokenBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,6 +268,37 @@ public class MessageServiceTokenBuilderTest {
     }
     
     @Test
+    public void addNamedPrimaryServiceTokens() throws MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertTrue(tokenBuilder.getPrimaryServiceTokens().isEmpty());
+        
+        final ServiceToken unboundServiceTokenA = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPrimaryServiceToken(unboundServiceTokenA));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        
+        final ServiceToken unboundServiceTokenB = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPrimaryServiceToken(unboundServiceTokenB));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        
+        final ServiceToken masterBoundServiceTokenA = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPrimaryServiceToken(masterBoundServiceTokenA));
+        assertEquals(2, tokenBuilder.getPrimaryServiceTokens().size());
+        
+        final ServiceToken masterBoundServiceTokenB = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPrimaryServiceToken(masterBoundServiceTokenB));
+        assertEquals(2, tokenBuilder.getPrimaryServiceTokens().size());
+        
+        final ServiceToken userBoundServiceTokenA = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPrimaryServiceToken(userBoundServiceTokenA));
+        assertEquals(3, tokenBuilder.getPrimaryServiceTokens().size());
+        
+        final ServiceToken userBoundServiceTokenB = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPrimaryServiceToken(userBoundServiceTokenB));
+        assertEquals(3, tokenBuilder.getPrimaryServiceTokens().size());
+    }
+    
+    @Test
     public void mismatchedMasterTokenAddPrimaryServiceToken() throws MslException {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
@@ -322,6 +353,38 @@ public class MessageServiceTokenBuilderTest {
         assertEquals(1, serviceTokens.size());
         final ServiceToken builderServiceToken = serviceTokens.toArray(new ServiceToken[0])[0];
         assertEquals(serviceToken, builderServiceToken);
+    }
+    
+    @Test
+    public void addNamedPeerServiceTokens() throws MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertTrue(tokenBuilder.getPeerServiceTokens().isEmpty());
+        
+        final ServiceToken unboundServiceTokenA = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPeerServiceToken(unboundServiceTokenA));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        
+        final ServiceToken unboundServiceTokenB = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPeerServiceToken(unboundServiceTokenB));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        
+        final ServiceToken masterBoundServiceTokenA = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPeerServiceToken(masterBoundServiceTokenA));
+        assertEquals(2, tokenBuilder.getPeerServiceTokens().size());
+        
+        final ServiceToken masterBoundServiceTokenB = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, null, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPeerServiceToken(masterBoundServiceTokenB));
+        assertEquals(2, tokenBuilder.getPeerServiceTokens().size());
+        
+        final ServiceToken userBoundServiceTokenA = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPeerServiceToken(userBoundServiceTokenA));
+        assertEquals(3, tokenBuilder.getPeerServiceTokens().size());
+        
+        final ServiceToken userBoundServiceTokenB = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, false, null, new NullCryptoContext());
+        assertTrue(tokenBuilder.addPeerServiceToken(userBoundServiceTokenB));
+        assertEquals(3, tokenBuilder.getPeerServiceTokens().size());
     }
     
     @Test
@@ -513,36 +576,160 @@ public class MessageServiceTokenBuilderTest {
     }
     
     @Test
-    public void excludePrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+    public void excludeUnboundPrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, true));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
+    }
+    
+    @Test
+    public void excludeMasterBoundPrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, true));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
+    }
+    
+    @Test
+    public void excludeUserBoundPrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addServiceToken(serviceToken);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
         
-        assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, true));
         assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
-        
         assertEquals(0, msgBuilder.getServiceTokens().size());
     }
 
     @Test
-    public void excludeUnknownPrimaryServiceToken() throws MslException {
+    public void excludeUnknownUserBoundPrimaryServiceToken() throws MslException {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
-        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, true));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
     }
     
     @Test
-    public void deletePrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+    public void deleteUnboundPrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, true));
+        assertTrue(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, false, false));
+        final Set<ServiceToken> builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
+        assertEquals(1, builderServiceTokens.size());
+        final ServiceToken builderServiceToken = builderServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, builderServiceToken.getName());
+        assertEquals(0, builderServiceToken.getData().length);
+        assertFalse(builderServiceToken.isEncrypted());
+        assertFalse(builderServiceToken.isMasterTokenBound());
+        assertFalse(builderServiceToken.isUserIdTokenBound());
+        
+        final Set<ServiceToken> msgServiceTokens = msgBuilder.getServiceTokens();
+        assertEquals(1, msgServiceTokens.size());
+        final ServiceToken msgServiceToken = msgServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, msgServiceToken.getName());
+        assertEquals(0, msgServiceToken.getData().length);
+        assertFalse(msgServiceToken.isEncrypted());
+        assertFalse(msgServiceToken.isMasterTokenBound());
+        assertFalse(msgServiceToken.isMasterTokenBound());
+    }
+    
+    @Test
+    public void deleteMasterBoundPrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, true));
+        assertTrue(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, false));
+        final Set<ServiceToken> builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
+        assertEquals(1, builderServiceTokens.size());
+        final ServiceToken builderServiceToken = builderServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, builderServiceToken.getName());
+        assertEquals(0, builderServiceToken.getData().length);
+        assertFalse(builderServiceToken.isEncrypted());
+        assertTrue(builderServiceToken.isBoundTo(MASTER_TOKEN));
+        assertFalse(builderServiceToken.isUserIdTokenBound());
+        
+        final Set<ServiceToken> msgServiceTokens = msgBuilder.getServiceTokens();
+        assertEquals(1, msgServiceTokens.size());
+        final ServiceToken msgServiceToken = msgServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, msgServiceToken.getName());
+        assertEquals(0, msgServiceToken.getData().length);
+        assertFalse(msgServiceToken.isEncrypted());
+        assertTrue(msgServiceToken.isBoundTo(MASTER_TOKEN));
+        assertFalse(msgServiceToken.isUserIdTokenBound());
+    }
+    
+    @Test
+    public void deleteUserBoundPrimaryServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, MASTER_TOKEN, USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addServiceToken(serviceToken);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
         
-        assertTrue(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertTrue(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, true));
         final Set<ServiceToken> builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
         assertEquals(1, builderServiceTokens.size());
         final ServiceToken builderServiceToken = builderServiceTokens.toArray(new ServiceToken[0])[0];
@@ -567,7 +754,9 @@ public class MessageServiceTokenBuilderTest {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
-        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, true));
     }
     
     @Test
@@ -735,18 +924,72 @@ public class MessageServiceTokenBuilderTest {
     }
     
     @Test
-    public void excludePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+    public void excludeUnboundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addPeerServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, false));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, true));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, false, false));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+    }
+    
+    @Test
+    public void excludeMasterBoundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addPeerServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, false, false));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, true));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, false));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+    }
+    
+    @Test
+    public void excludeUserBoundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
         msgBuilder.addPeerServiceToken(serviceToken);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
         
-        assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, false, false));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, false));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, true));
         assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
-        
-        assertEquals(0, msgBuilder.getServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
     }
 
     @Test
@@ -755,11 +998,83 @@ public class MessageServiceTokenBuilderTest {
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
-        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, false, false));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, false));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, true));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
     }
     
     @Test
-    public void deletePeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+    public void deleteUnboundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, null, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addPeerServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, true, false));
+        assertFalse(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, true, true));
+        assertTrue(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, false, false));
+        final Set<ServiceToken> builderServiceTokens = tokenBuilder.getPeerServiceTokens();
+        assertEquals(1, builderServiceTokens.size());
+        final ServiceToken builderServiceToken = builderServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, builderServiceToken.getName());
+        assertEquals(0, builderServiceToken.getData().length);
+        assertFalse(builderServiceToken.isEncrypted());
+        assertFalse(builderServiceToken.isMasterTokenBound());
+        assertFalse(builderServiceToken.isUserIdTokenBound());
+        
+        final Set<ServiceToken> msgServiceTokens = msgBuilder.getPeerServiceTokens();
+        assertEquals(1, msgServiceTokens.size());
+        final ServiceToken msgServiceToken = msgServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, msgServiceToken.getName());
+        assertEquals(0, msgServiceToken.getData().length);
+        assertFalse(msgServiceToken.isEncrypted());
+        assertFalse(msgServiceToken.isMasterTokenBound());
+        assertFalse(msgServiceToken.isUserIdTokenBound());
+    }
+    
+    @Test
+    public void deleteMasterBoundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
+        final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
+        msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
+        final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, null, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
+        msgBuilder.addPeerServiceToken(serviceToken);
+        final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        
+        assertFalse(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, false, false));
+        assertFalse(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, true, true));
+        assertTrue(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, true, false));
+        final Set<ServiceToken> builderServiceTokens = tokenBuilder.getPeerServiceTokens();
+        assertEquals(1, builderServiceTokens.size());
+        final ServiceToken builderServiceToken = builderServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, builderServiceToken.getName());
+        assertEquals(0, builderServiceToken.getData().length);
+        assertFalse(builderServiceToken.isEncrypted());
+        assertTrue(builderServiceToken.isBoundTo(PEER_MASTER_TOKEN));
+        assertFalse(builderServiceToken.isUserIdTokenBound());
+        
+        final Set<ServiceToken> msgServiceTokens = msgBuilder.getPeerServiceTokens();
+        assertEquals(1, msgServiceTokens.size());
+        final ServiceToken msgServiceToken = msgServiceTokens.toArray(new ServiceToken[0])[0];
+        assertEquals(TOKEN_NAME, msgServiceToken.getName());
+        assertEquals(0, msgServiceToken.getData().length);
+        assertFalse(msgServiceToken.isEncrypted());
+        assertTrue(msgServiceToken.isBoundTo(PEER_MASTER_TOKEN));
+        assertFalse(msgServiceToken.isUserIdTokenBound());
+    }
+    
+    @Test
+    public void deleteUserBoundPeerServiceToken() throws MslEncodingException, MslCryptoException, MslMessageException, MslException {
         final MessageBuilder msgBuilder = messageFactory.createRequest(p2pCtx, MASTER_TOKEN, USER_ID_TOKEN);
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final ServiceToken serviceToken = new ServiceToken(p2pCtx, TOKEN_NAME, DATA, PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN, ENCRYPT, COMPRESSION_ALGO, new NullCryptoContext());
@@ -767,7 +1082,9 @@ public class MessageServiceTokenBuilderTest {
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
         
-        assertTrue(tokenBuilder.deletePeerServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, false, false));
+        assertFalse(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, true, false));
+        assertTrue(tokenBuilder.deletePeerServiceToken(TOKEN_NAME, true, true));
         final Set<ServiceToken> builderServiceTokens = tokenBuilder.getPeerServiceTokens();
         assertEquals(1, builderServiceTokens.size());
         final ServiceToken builderServiceToken = builderServiceTokens.toArray(new ServiceToken[0])[0];
@@ -793,6 +1110,8 @@ public class MessageServiceTokenBuilderTest {
         msgBuilder.setPeerAuthTokens(PEER_MASTER_TOKEN, PEER_USER_ID_TOKEN);
         final MessageServiceTokenBuilder tokenBuilder = new MessageServiceTokenBuilder(p2pCtx, p2pMsgCtx, msgBuilder);
         
-        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, false, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, false));
+        assertFalse(tokenBuilder.deletePrimaryServiceToken(TOKEN_NAME, true, true));
     }
 }

--- a/tests/src/test/java/com/netflix/msl/msg/MessageServiceTokenBuilderTest.java
+++ b/tests/src/test/java/com/netflix/msl/msg/MessageServiceTokenBuilderTest.java
@@ -595,6 +595,14 @@ public class MessageServiceTokenBuilderTest {
         assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, false, false));
         assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
         assertEquals(0, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.addPrimaryServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePrimaryServiceToken(serviceToken));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
     }
     
     @Test
@@ -617,6 +625,14 @@ public class MessageServiceTokenBuilderTest {
         assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, false));
         assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
         assertEquals(0, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.addPrimaryServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePrimaryServiceToken(serviceToken));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
     }
     
     @Test
@@ -637,6 +653,14 @@ public class MessageServiceTokenBuilderTest {
         assertEquals(1, msgBuilder.getServiceTokens().size());
         
         assertTrue(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, true));
+        assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(0, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.addPrimaryServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePrimaryServiceToken(serviceToken));
         assertEquals(0, tokenBuilder.getPrimaryServiceTokens().size());
         assertEquals(0, msgBuilder.getServiceTokens().size());
     }
@@ -687,6 +711,11 @@ public class MessageServiceTokenBuilderTest {
         assertFalse(msgServiceToken.isEncrypted());
         assertFalse(msgServiceToken.isMasterTokenBound());
         assertFalse(msgServiceToken.isMasterTokenBound());
+        
+        assertTrue(tokenBuilder.addPrimaryServiceToken(serviceToken));
+        assertTrue(tokenBuilder.deletePrimaryServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
     }
     
     @Test
@@ -717,6 +746,11 @@ public class MessageServiceTokenBuilderTest {
         assertFalse(msgServiceToken.isEncrypted());
         assertTrue(msgServiceToken.isBoundTo(MASTER_TOKEN));
         assertFalse(msgServiceToken.isUserIdTokenBound());
+        
+        assertTrue(tokenBuilder.addPrimaryServiceToken(serviceToken));
+        assertTrue(tokenBuilder.deletePrimaryServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
     }
     
     @Test
@@ -747,6 +781,11 @@ public class MessageServiceTokenBuilderTest {
         assertFalse(msgServiceToken.isEncrypted());
         assertTrue(msgServiceToken.isBoundTo(MASTER_TOKEN));
         assertTrue(msgServiceToken.isBoundTo(USER_ID_TOKEN));
+        
+        assertTrue(tokenBuilder.addPrimaryServiceToken(serviceToken));
+        assertTrue(tokenBuilder.deletePrimaryServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPrimaryServiceTokens().size());
+        assertEquals(1, msgBuilder.getServiceTokens().size());
     }
 
     @Test
@@ -944,6 +983,14 @@ public class MessageServiceTokenBuilderTest {
         assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, false, false));
         assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
         assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.addPeerServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePeerServiceToken(serviceToken));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
     }
     
     @Test
@@ -967,6 +1014,14 @@ public class MessageServiceTokenBuilderTest {
         assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, false));
         assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
         assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.addPeerServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePeerServiceToken(serviceToken));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
     }
     
     @Test
@@ -988,6 +1043,14 @@ public class MessageServiceTokenBuilderTest {
         assertEquals(1, msgBuilder.getPeerServiceTokens().size());
         
         assertTrue(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, true));
+        assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(0, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.addPeerServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
+        
+        assertTrue(tokenBuilder.excludePeerServiceToken(serviceToken));
         assertEquals(0, tokenBuilder.getPeerServiceTokens().size());
         assertEquals(0, msgBuilder.getPeerServiceTokens().size());
     }
@@ -1040,6 +1103,11 @@ public class MessageServiceTokenBuilderTest {
         assertFalse(msgServiceToken.isEncrypted());
         assertFalse(msgServiceToken.isMasterTokenBound());
         assertFalse(msgServiceToken.isUserIdTokenBound());
+        
+        assertTrue(tokenBuilder.addPeerServiceToken(serviceToken));
+        assertTrue(tokenBuilder.deletePeerServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
     }
     
     @Test
@@ -1071,6 +1139,11 @@ public class MessageServiceTokenBuilderTest {
         assertFalse(msgServiceToken.isEncrypted());
         assertTrue(msgServiceToken.isBoundTo(PEER_MASTER_TOKEN));
         assertFalse(msgServiceToken.isUserIdTokenBound());
+        
+        assertTrue(tokenBuilder.addPeerServiceToken(serviceToken));
+        assertTrue(tokenBuilder.deletePeerServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
     }
     
     @Test
@@ -1102,6 +1175,11 @@ public class MessageServiceTokenBuilderTest {
         assertFalse(msgServiceToken.isEncrypted());
         assertTrue(msgServiceToken.isBoundTo(PEER_MASTER_TOKEN));
         assertTrue(msgServiceToken.isBoundTo(PEER_USER_ID_TOKEN));
+        
+        assertTrue(tokenBuilder.addPeerServiceToken(serviceToken));
+        assertTrue(tokenBuilder.deletePeerServiceToken(serviceToken));
+        assertEquals(1, tokenBuilder.getPeerServiceTokens().size());
+        assertEquals(1, msgBuilder.getPeerServiceTokens().size());
     }
 
     @Test

--- a/tests/src/test/java/com/netflix/msl/util/SimpleMslStoreTest.java
+++ b/tests/src/test/java/com/netflix/msl/util/SimpleMslStoreTest.java
@@ -765,7 +765,7 @@ public class SimpleMslStoreTest {
         store.addServiceTokens(userBoundTokens);
         store.addServiceTokens(unboundTokens);
         
-        store.removeServiceTokens(null, masterToken, userIdToken);
+        store.removeServiceTokens(null, null, userIdToken);
         
         // This should only return the unbound and master bound-only tokens.
         final Set<ServiceToken> storedMasterBoundTokens = store.getServiceTokens(masterToken, null);

--- a/tests/src/test/java/com/netflix/msl/util/SimpleMslStoreTest.java
+++ b/tests/src/test/java/com/netflix/msl/util/SimpleMslStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2014 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -737,9 +737,12 @@ public class SimpleMslStoreTest {
         assertNotNull(storedMasterBoundTokens);
         assertTrue(equal(unboundTokens, storedMasterBoundTokens));
         
-        // This should only return the unbound tokens.
+        // This should only return the unbound and user-bound tokens.
+        final Set<ServiceToken> unboundAndUserBoundTokens = new HashSet<ServiceToken>();
+        unboundAndUserBoundTokens.addAll(unboundTokens);
+        unboundAndUserBoundTokens.addAll(userBoundTokens);
         final Set<ServiceToken> storedUserBoundTokens = store.getServiceTokens(masterToken, userIdToken);
-        assertTrue(equal(unboundTokens, storedUserBoundTokens));
+        assertTrue(equal(unboundAndUserBoundTokens, storedUserBoundTokens));
         
         // This should only return the unbound tokens.
         final Set<ServiceToken> storedUnboundTokens = store.getServiceTokens(null, null);
@@ -847,7 +850,7 @@ public class SimpleMslStoreTest {
         final Set<ServiceToken> removedTokens = new HashSet<ServiceToken>();
         for (final ServiceToken token : allTokens) {
             if (random.nextBoolean()) continue;
-            store.removeServiceTokens(token.getName(), null, null);
+            store.removeServiceTokens(token.getName(), token.isMasterTokenBound() ? masterToken : null, token.isUserIdTokenBound() ? userIdToken : null);
             removedTokens.add(token);
         }
         

--- a/tests/src/test/javascript/msg/MessageOutputStreamTest.js
+++ b/tests/src/test/javascript/msg/MessageOutputStreamTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2018 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ describe("MessageOutputStream", function() {
     var MessageHeader = require('msl-core/msg/MessageHeader.js');
     var MslConstants = require('msl-core/MslConstants.js');
     var EntityAuthenticationScheme = require('msl-core/entityauth/EntityAuthenticationScheme.js');
+    var UnauthenticatedAuthenticationData = require('msl-core/entityauth/UnauthenticatedAuthenticationData.js');
+    var PresharedAuthenticationData = require('msl-core/entityauth/PresharedAuthenticationData.js');
+    var RsaAuthenticationData = require('msl-core/entityauth/RsaAuthenticationData.js');
     var ErrorHeader = require('msl-core/msg/ErrorHeader.js');
     var MessageOutputStream = require('msl-core/msg/MessageOutputStream.js');
     var ByteArrayInputStream = require('msl-core/io/ByteArrayInputStream.js');
@@ -44,9 +47,13 @@ describe("MessageOutputStream", function() {
     var MslError = require('msl-core/MslError.js');
     var MslIoException = require('msl-core/MslIoException.js');
     var TextEncoding = require('msl-core/util/TextEncoding.js');
+    var SymmetricWrappedExchange = require('msl-core/keyx/SymmetricWrappedExchange.js');
 
     var MslTestConstants = require('msl-tests/MslTestConstants.js');
+    var MockRsaAuthenticationFactory = require('msl-tests/entityauth/MockRsaAuthenticationFactory.js');
+    var MockPresharedAuthenticationFactory = require('msl-tests/entityauth/MockPresharedAuthenticationFactory.js');
     var MockMslContext = require('msl-tests/util/MockMslContext.js');
+    var MslTestUtils = require('msl-tests/util/MslTestUtils.js');
 
     /** MSL encoder format. */
     var ENCODER_FORMAT = MslEncoderFormat.JSON;

--- a/tests/src/test/javascript/msg/MessageServiceTokenBuilderTest.js
+++ b/tests/src/test/javascript/msg/MessageServiceTokenBuilderTest.js
@@ -1134,6 +1134,14 @@ describe("MessageServiceTokenBuilder", function() {
             expect(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, false, false)).toBeTruthy();
             expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(0);
             expect(msgBuilder.getServiceTokens().length).toEqual(0);
+            
+            expect(tokenBuilder.addPrimaryServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(1);
+            expect(msgBuilder.getServiceTokens().length).toEqual(1);
+            
+            expect(tokenBuilder.excludePrimaryServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(0);
+            expect(msgBuilder.getServiceTokens().length).toEqual(0);
 		});
 	});
 
@@ -1178,6 +1186,14 @@ describe("MessageServiceTokenBuilder", function() {
             expect(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, false)).toBeTruthy();
             expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(0);
             expect(msgBuilder.getServiceTokens().length).toEqual(0);
+            
+            expect(tokenBuilder.addPrimaryServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(1);
+            expect(msgBuilder.getServiceTokens().length).toEqual(1);
+            
+            expect(tokenBuilder.excludePrimaryServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(0);
+            expect(msgBuilder.getServiceTokens().length).toEqual(0);
         });
     });
 
@@ -1220,6 +1236,14 @@ describe("MessageServiceTokenBuilder", function() {
             expect(msgBuilder.getServiceTokens().length).toEqual(1);
             
             expect(tokenBuilder.excludePrimaryServiceToken(TOKEN_NAME, true, true)).toBeTruthy();
+            expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(0);
+            expect(msgBuilder.getServiceTokens().length).toEqual(0);
+            
+            expect(tokenBuilder.addPrimaryServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(1);
+            expect(msgBuilder.getServiceTokens().length).toEqual(1);
+            
+            expect(tokenBuilder.excludePrimaryServiceToken(serviceToken)).toBeTruthy();
             expect(tokenBuilder.getPrimaryServiceTokens().length).toEqual(0);
             expect(msgBuilder.getServiceTokens().length).toEqual(0);
         });
@@ -1310,6 +1334,7 @@ describe("MessageServiceTokenBuilder", function() {
         waitsFor(function() { return delC !== undefined; }, "delC not received", MslTestConstants.TIMEOUT);
         runs(function() { expect(delC).toBeTruthy(); });
 		
+        var delD;
 		runs(function() {
 			var builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
 			expect(builderServiceTokens.length).toEqual(1);
@@ -1328,7 +1353,22 @@ describe("MessageServiceTokenBuilder", function() {
 			expect(msgServiceToken.isEncrypted()).toBeFalsy();
 			expect(msgServiceToken.isBoundTo(MASTER_TOKEN)).toBeFalsy();
 			expect(msgServiceToken.isBoundTo(USER_ID_TOKEN)).toBeFalsy();
-		});
+			
+			expect(tokenBuilder.addPrimaryServiceToken(serviceToken)).toBeTruthy();
+			tokenBuilder.deletePrimaryServiceToken(serviceToken, {
+			    result: function(b) { delD = b; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return delD !== undefined; }, "delD not received", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            expect(delD).toBeTruthy();
+            var builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
+            expect(builderServiceTokens.length).toEqual(1);
+            var msgServiceTokens = msgBuilder.getServiceTokens();
+            expect(msgServiceTokens.length).toEqual(1);
+        });
 	});
 
     it("delete master bound primary service token", function() {
@@ -1389,6 +1429,7 @@ describe("MessageServiceTokenBuilder", function() {
         waitsFor(function() { return delC !== undefined; }, "delC not received", MslTestConstants.TIMEOUT);
         runs(function() { expect(delC).toBeTruthy(); });
         
+        var delD;
         runs(function() {
             var builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
             expect(builderServiceTokens.length).toEqual(1);
@@ -1407,6 +1448,21 @@ describe("MessageServiceTokenBuilder", function() {
             expect(msgServiceToken.isEncrypted()).toBeFalsy();
             expect(msgServiceToken.isBoundTo(MASTER_TOKEN)).toBeTruthy();
             expect(msgServiceToken.isBoundTo(USER_ID_TOKEN)).toBeFalsy();
+            
+            expect(tokenBuilder.addPrimaryServiceToken(serviceToken)).toBeTruthy();
+            tokenBuilder.deletePrimaryServiceToken(serviceToken, {
+                result: function(b) { delD = b; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return delD !== undefined; }, "delD not received", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            expect(delD).toBeTruthy();
+            var builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
+            expect(builderServiceTokens.length).toEqual(1);
+            var msgServiceTokens = msgBuilder.getServiceTokens();
+            expect(msgServiceTokens.length).toEqual(1);
         });
     });
 
@@ -1468,6 +1524,7 @@ describe("MessageServiceTokenBuilder", function() {
         waitsFor(function() { return delC !== undefined; }, "delC not received", MslTestConstants.TIMEOUT);
         runs(function() { expect(delC).toBeTruthy(); });
         
+        var delD;
         runs(function() {
             var builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
             expect(builderServiceTokens.length).toEqual(1);
@@ -1486,6 +1543,21 @@ describe("MessageServiceTokenBuilder", function() {
             expect(msgServiceToken.isEncrypted()).toBeFalsy();
             expect(msgServiceToken.isBoundTo(MASTER_TOKEN)).toBeTruthy();
             expect(msgServiceToken.isBoundTo(USER_ID_TOKEN)).toBeTruthy();
+            
+            expect(tokenBuilder.addPrimaryServiceToken(serviceToken)).toBeTruthy();
+            tokenBuilder.deletePrimaryServiceToken(serviceToken, {
+                result: function(b) { delD = b; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return delD !== undefined; }, "delD not received", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            expect(delD).toBeTruthy();
+            var builderServiceTokens = tokenBuilder.getPrimaryServiceTokens();
+            expect(builderServiceTokens.length).toEqual(1);
+            var msgServiceTokens = msgBuilder.getServiceTokens();
+            expect(msgServiceTokens.length).toEqual(1);
         });
     });
 
@@ -1924,6 +1996,14 @@ describe("MessageServiceTokenBuilder", function() {
             expect(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, false, false)).toBeTruthy();
             expect(tokenBuilder.getPeerServiceTokens().length).toEqual(0);
             expect(msgBuilder.getPeerServiceTokens().length).toEqual(0);
+            
+            expect(tokenBuilder.addPeerServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPeerServiceTokens().length).toEqual(1);
+            expect(msgBuilder.getPeerServiceTokens().length).toEqual(1);
+            
+            expect(tokenBuilder.excludePeerServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPeerServiceTokens().length).toEqual(0);
+            expect(msgBuilder.getPeerServiceTokens().length).toEqual(0);
 		});
 	});
 
@@ -1964,6 +2044,14 @@ describe("MessageServiceTokenBuilder", function() {
             expect(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, false)).toBeTruthy();
             expect(tokenBuilder.getPeerServiceTokens().length).toEqual(0);
             expect(msgBuilder.getPeerServiceTokens().length).toEqual(0);
+            
+            expect(tokenBuilder.addPeerServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPeerServiceTokens().length).toEqual(1);
+            expect(msgBuilder.getPeerServiceTokens().length).toEqual(1);
+            
+            expect(tokenBuilder.excludePeerServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPeerServiceTokens().length).toEqual(0);
+            expect(msgBuilder.getPeerServiceTokens().length).toEqual(0);
         });
     });
 
@@ -2002,6 +2090,14 @@ describe("MessageServiceTokenBuilder", function() {
             expect(msgBuilder.getPeerServiceTokens().length).toEqual(1);
             
             expect(tokenBuilder.excludePeerServiceToken(TOKEN_NAME, true, true)).toBeTruthy();
+            expect(tokenBuilder.getPeerServiceTokens().length).toEqual(0);
+            expect(msgBuilder.getPeerServiceTokens().length).toEqual(0);
+            
+            expect(tokenBuilder.addPeerServiceToken(serviceToken)).toBeTruthy();
+            expect(tokenBuilder.getPeerServiceTokens().length).toEqual(1);
+            expect(msgBuilder.getPeerServiceTokens().length).toEqual(1);
+            
+            expect(tokenBuilder.excludePeerServiceToken(serviceToken)).toBeTruthy();
             expect(tokenBuilder.getPeerServiceTokens().length).toEqual(0);
             expect(msgBuilder.getPeerServiceTokens().length).toEqual(0);
         });
@@ -2088,6 +2184,7 @@ describe("MessageServiceTokenBuilder", function() {
         waitsFor(function() { return delC !== undefined; }, "delC not received", MslTestConstants.TIMEOUT);
         runs(function() { expect(delC).toBeTruthy(); });
 		
+        var delD;
 		runs(function() {
 			var builderServiceTokens = tokenBuilder.getPeerServiceTokens();
 			expect(builderServiceTokens.length).toEqual(1);
@@ -2106,7 +2203,22 @@ describe("MessageServiceTokenBuilder", function() {
 			expect(msgServiceToken.isEncrypted()).toBeFalsy();
 			expect(msgServiceToken.isBoundTo(PEER_MASTER_TOKEN)).toBeFalsy();
 			expect(msgServiceToken.isBoundTo(PEER_USER_ID_TOKEN)).toBeFalsy();
-		});
+            
+            expect(tokenBuilder.addPeerServiceToken(serviceToken)).toBeTruthy();
+            tokenBuilder.deletePeerServiceToken(serviceToken, {
+                result: function(b) { delD = b; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return delD !== undefined; }, "delD not received", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            expect(delD).toBeTruthy();
+            var builderServiceTokens = tokenBuilder.getPeerServiceTokens();
+            expect(builderServiceTokens.length).toEqual(1);
+            var msgServiceTokens = msgBuilder.getPeerServiceTokens();
+            expect(msgServiceTokens.length).toEqual(1);
+        });
 	});
 
     it("delete master bound peer service token", function() {
@@ -2162,6 +2274,7 @@ describe("MessageServiceTokenBuilder", function() {
         waitsFor(function() { return delC !== undefined; }, "delC not received", MslTestConstants.TIMEOUT);
         runs(function() { expect(delC).toBeTruthy(); });
         
+        var delD;
         runs(function() {
             var builderServiceTokens = tokenBuilder.getPeerServiceTokens();
             expect(builderServiceTokens.length).toEqual(1);
@@ -2180,6 +2293,21 @@ describe("MessageServiceTokenBuilder", function() {
             expect(msgServiceToken.isEncrypted()).toBeFalsy();
             expect(msgServiceToken.isBoundTo(PEER_MASTER_TOKEN)).toBeTruthy();
             expect(msgServiceToken.isBoundTo(PEER_USER_ID_TOKEN)).toBeFalsy();
+            
+            expect(tokenBuilder.addPeerServiceToken(serviceToken)).toBeTruthy();
+            tokenBuilder.deletePeerServiceToken(serviceToken, {
+                result: function(b) { delD = b; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return delD !== undefined; }, "delD not received", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            expect(delD).toBeTruthy();
+            var builderServiceTokens = tokenBuilder.getPeerServiceTokens();
+            expect(builderServiceTokens.length).toEqual(1);
+            var msgServiceTokens = msgBuilder.getPeerServiceTokens();
+            expect(msgServiceTokens.length).toEqual(1);
         });
     });
 
@@ -2236,6 +2364,7 @@ describe("MessageServiceTokenBuilder", function() {
         waitsFor(function() { return delC !== undefined; }, "delC not received", MslTestConstants.TIMEOUT);
         runs(function() { expect(delC).toBeTruthy(); });
         
+        var delD;
         runs(function() {
             var builderServiceTokens = tokenBuilder.getPeerServiceTokens();
             expect(builderServiceTokens.length).toEqual(1);
@@ -2254,6 +2383,21 @@ describe("MessageServiceTokenBuilder", function() {
             expect(msgServiceToken.isEncrypted()).toBeFalsy();
             expect(msgServiceToken.isBoundTo(PEER_MASTER_TOKEN)).toBeTruthy();
             expect(msgServiceToken.isBoundTo(PEER_USER_ID_TOKEN)).toBeTruthy();
+            
+            expect(tokenBuilder.addPeerServiceToken(serviceToken)).toBeTruthy();
+            tokenBuilder.deletePeerServiceToken(serviceToken, {
+                result: function(b) { delD = b; },
+                error: function(e) { expect(function() { throw e; }).not.toThrow(); }
+            });
+        });
+        waitsFor(function() { return delD !== undefined; }, "delD not received", MslTestConstants.TIMEOUT);
+        
+        runs(function() {
+            expect(delD).toBeTruthy();
+            var builderServiceTokens = tokenBuilder.getPeerServiceTokens();
+            expect(builderServiceTokens.length).toEqual(1);
+            var msgServiceTokens = msgBuilder.getPeerServiceTokens();
+            expect(msgServiceTokens.length).toEqual(1);
         });
     });
 

--- a/tests/src/test/javascript/package.json
+++ b/tests/src/test/javascript/package.json
@@ -26,8 +26,8 @@
   "devDependencies": {
     "ec-key": "0.0.2",
     "elliptic": "^6.4.0",
-    "jshint": "^2.9.5",
-    "jsrsasign": "^7.2.2",
+    "jshint": "^2.11.1",
+    "jsrsasign": "^8.0.15",
     "ursa": "^0.9.4"
   }
 }

--- a/tests/src/test/javascript/util/SimpleMslStoreTest.js
+++ b/tests/src/test/javascript/util/SimpleMslStoreTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012-2017 Netflix, Inc.  All rights reserved.
+ * Copyright (c) 2012-2020 Netflix, Inc.  All rights reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1035,7 +1035,7 @@ describe("SimpleMslStore", function() {
         });
     });
 
-    it("remove service tokens by master token", function() {
+    it("remove master bound service tokens", function() {
         var masterToken;
         runs(function() {
             MslTestUtils.getMasterToken(ctx, 1, 1, {
@@ -1087,9 +1087,12 @@ describe("SimpleMslStore", function() {
             expect(storedMasterBoundTokens).not.toBeNull();
             expect(serviceTokensEqual(unboundTokens, storedMasterBoundTokens)).toBeTruthy();
 
-            // This should only return the unbound tokens.
+            // This should only return the unbound and user-bound tokens.
+            var unboundAndUserBoundTokens = [];
+            unboundAndUserBoundTokens.push.apply(unboundAndUserBoundTokens, unboundTokens);
+            unboundAndUserBoundTokens.push.apply(unboundAndUserBoundTokens, userBoundTokens);
             var storedUserBoundTokens = store.getServiceTokens(masterToken, userIdToken);
-            expect(serviceTokensEqual(unboundTokens, storedUserBoundTokens)).toBeTruthy();
+            expect(serviceTokensEqual(unboundAndUserBoundTokens, storedUserBoundTokens)).toBeTruthy();
 
             // This should only return the unbound tokens.
             var storedUnboundTokens = store.getServiceTokens(null, null);
@@ -1322,7 +1325,7 @@ describe("SimpleMslStore", function() {
             var removedTokens = [];
             allTokens.forEach(function(token) {
                 if (random.nextBoolean()) return;
-                store.removeServiceTokens(token.name, null, null);
+                store.removeServiceTokens(token.name, token.isMasterTokenBound() ? masterToken : null, token.isUserIdTokenBound() ? userIdToken : null);
                 removedTokens.push(token);
             }, this);
 

--- a/tests/src/test/javascript/util/SimpleMslStoreTest.js
+++ b/tests/src/test/javascript/util/SimpleMslStoreTest.js
@@ -1146,7 +1146,7 @@ describe("SimpleMslStore", function() {
             store.addServiceTokens(userBoundTokens);
             store.addServiceTokens(unboundTokens);
 
-            store.removeServiceTokens(null, masterToken, userIdToken);
+            store.removeServiceTokens(null, null, userIdToken);
 
             // This should only return the unbound and master bound-only tokens.
             var storedMasterBoundTokens = store.getServiceTokens(masterToken, null);


### PR DESCRIPTION
Fixes #315 by requiring applications to be more specific about their service token binding properties, instead of assuming all tokens will have a unique name and will never switch change binding properties. (Wiki documentation changes still pending.)

* Change `MslStore.removeServiceTokens()` to only remove tokens that explicitly match all the input parameters.
* When building a message, include tokens with the same name if their bound state differs.
* Require explicit master token-bound or user ID token-bound parameters when using the message builders to exclude or delete service tokens by name.