### PR TITLE
Minor efficiency improvements plus a synchronization fix in server example.

### DIFF
--- a/core/src/main/java/com/netflix/msl/io/JavaUrl.java
+++ b/core/src/main/java/com/netflix/msl/io/JavaUrl.java
@@ -40,7 +40,7 @@ public class JavaUrl implements Url {
      * methods. This is necessary to facilitate stream reuse across multiple
      * MSL messages.</p>
      */
-    public class DelayedInputStream extends FilterInputStream {
+    public static class DelayedInputStream extends FilterInputStream {
         /**
          * Create a new delayed input stream that will not attempt to
          * construct the input stream from the URL connection until it is
@@ -146,7 +146,7 @@ public class JavaUrl implements Url {
      * An implementation of the {@link Connection} interface backed by the
      * built-in Java {@link URLConnection} class.
      */
-    private class JavaConnection implements Connection {
+    private static class JavaConnection implements Connection {
         /**
          * Create a new Java connection with the backing URL connection.
          * 

--- a/core/src/main/java/com/netflix/msl/io/MslObject.java
+++ b/core/src/main/java/com/netflix/msl/io/MslObject.java
@@ -61,10 +61,11 @@ public class MslObject {
      */
     public MslObject(final Map<?,?> map) {
         if (map != null) {
-            for (final Object key : map.keySet()) {
+            for (final Map.Entry<?, ?> entry : map.entrySet()) {
+                final Object key = entry.getKey();
                 if (!(key instanceof String))
                     throw new IllegalArgumentException("Map key is not a string.");
-                final Object value = map.get(key);
+                final Object value = entry.getValue();
                 put((String)key, value);
             }
         }

--- a/examples/mslcli/client/src/main/java/mslcli/common/CmdArguments.java
+++ b/examples/mslcli/client/src/main/java/mslcli/common/CmdArguments.java
@@ -515,7 +515,7 @@ public final class CmdArguments {
      */
     private int getInteger(final String name, final int def) {
         final String s = argMap.get(name);
-        return (s != null) ? Integer.valueOf(s) : def;
+        return (s != null) ? Integer.parseInt(s) : def;
     }
 
     /**

--- a/examples/simple/src/main/java/server/userauth/SimpleTokenFactory.java
+++ b/examples/simple/src/main/java/server/userauth/SimpleTokenFactory.java
@@ -90,9 +90,8 @@ public class SimpleTokenFactory implements TokenFactory {
         
         // Accept if there is no non-replayable ID.
         final String key = masterToken.getIdentity() + ":" + masterToken.getSerialNumber();
-        final Long largestNonReplayableId = nonReplayableIds.get(key);
+        final Long largestNonReplayableId = nonReplayableIds.putIfAbsent(key, nonReplayableId);
         if (largestNonReplayableId == null) {
-            nonReplayableIds.put(key, nonReplayableId);
             return null;
         }
         


### PR DESCRIPTION
Select changes pulled from @quidryan's pull request #239.

* Change `JavaUrl` inner classes to static inner classes.
* Use `EntrySet` in `MslObject` for more efficient map iteration.
* Use `Integer.parseInt()` instead of `Integer.valueOf()` in example CLI to avoid unnecessary boxing/unboxing.
* Use `ConcurrentHashMap.putIfAbsent()` for synchronization safety in example server.