### PR TITLE
Update build status location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Netflix/msl.svg?branch=master)](https://travis-ci.org/Netflix/msl)
+[![Build Status](https://travis-ci.com/Netflix/msl.svg?branch=master)](https://travis-ci.com/Netflix/msl)
 
 # Message Security Layer
 


### PR DESCRIPTION
This change updates the build status badge to point to the new travis-ci.com location. The build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).